### PR TITLE
226593: Setup redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Portal Frontend for CDP
 - [Local development](#local-development)
   - [Setup](#setup)
   - [Portal APIs](#portal-apis)
+  - [Redis](#redis)
   - [Development](#development)
     - [Debugging](#debugging)
     - [Testing](#testing)
@@ -55,7 +56,20 @@ $ npm install
 
 ### Portal APIs
 
+The Portal Frontend has a number of APIs it uses to perform actions on the Platform and APIs to obtain information
+about the Platform and its tenants.
+
 - [CDP Self Service Ops](https://github.com/defra-cdp-sandpit/cdp-self-service-ops)
+- [CDP User Service Backend](https://github.com/defra-cdp-sandpit/cdp-user-service-backend)
+- [CDP Portal Backend](https://github.com/defra-cdp-sandpit/cdp-portal-backend)
+- [CDP Teams and Repositories](https://github.com/defra-cdp-sandpit/cdp-teams-and-repositories)
+
+### Redis
+
+The Portal Frontend uses [Redis](https://redis.io/) for session storage. To set up Redis locally refer to the
+documentation found
+
+- [https://redis.io/docs/getting-started/installation/](https://redis.io/docs/getting-started/installation/)
 
 ### Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@babel/runtime": "7.22.11",
         "@hapi/basic": "7.0.2",
         "@hapi/boom": "10.0.1",
+        "@hapi/catbox-redis": "7.0.2",
         "@hapi/hapi": "21.3.2",
         "@hapi/inert": "7.1.0",
         "@hapi/vision": "7.0.3",
@@ -2141,6 +2142,20 @@
         "@hapi/hoek": "^11.0.2"
       }
     },
+    "node_modules/@hapi/catbox-redis": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-redis/-/catbox-redis-7.0.2.tgz",
+      "integrity": "sha512-RY0SsnxPtMV5sjya+96a3JVonBcT+p1EXbeC4SkYiNwCNoHZ1cssU933nBjyY4DhxOEA38P3W1j8fCVRZ8nXjA==",
+      "dependencies": {
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/hoek": "^11.0.2",
+        "ioredis": "^5.0.0",
+        "joi": "^17.7.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@hapi/content": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.0.tgz",
@@ -2425,6 +2440,11 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -6663,6 +6683,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -7543,6 +7571,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -10821,6 +10857,29 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
+      "integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ip": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
@@ -13928,8 +13987,7 @@
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-      "dev": true
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
     },
     "node_modules/lodash.difference": {
       "version": "4.5.0",
@@ -13960,6 +14018,11 @@
       "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
       "integrity": "sha512-rnYUdIo6xRCJnQmbVFEwcxF144erlD+M3YcJUVesflU9paQaE8p+fJDcIQrlMYbxoANFL+AB9hZrzSBBk5PL+g==",
       "dev": true
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -17342,6 +17405,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.3.tgz",
@@ -18509,6 +18591,11 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "node_modules/standard-engine": {
       "version": "15.1.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@babel/runtime": "7.22.11",
     "@hapi/basic": "7.0.2",
     "@hapi/boom": "10.0.1",
+    "@hapi/catbox-redis": "7.0.2",
     "@hapi/hapi": "21.3.2",
     "@hapi/inert": "7.1.0",
     "@hapi/vision": "7.0.3",

--- a/src/config/app-config.js
+++ b/src/config/app-config.js
@@ -101,6 +101,18 @@ const appConfig = convict({
     sensitive: true,
     env: 'BASIC_AUTH_PASSWORD'
   },
+  cacheHost: {
+    doc: 'Redis cache host',
+    format: String,
+    default: '127.0.0.1',
+    env: 'CACHE_HOST'
+  },
+  cacheRole: {
+    doc: 'Redis cache role',
+    format: String,
+    default: 'master',
+    env: 'CACHE_ROLE'
+  },
   isProduction: {
     doc: 'If this application running in the production environment',
     format: Boolean,

--- a/src/server/common/helpers/flash-message.js
+++ b/src/server/common/helpers/flash-message.js
@@ -4,7 +4,9 @@ import { appConfig } from '~/src/config'
 const flashMessage = {
   plugin: yar,
   options: {
-    name: 'cdp-portal',
+    name: 'cdp-portal-frontend',
+    maxCookieSize: 0, // Always use server-side storage
+    cache: { cache: 'session' },
     storeBlank: false,
     errorOnCacheNotReady: true,
     cookieOptions: {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,6 +1,7 @@
 import path from 'path'
 import hapi from '@hapi/hapi'
 import qs from 'qs'
+import { Engine as CatboxRedis } from '@hapi/catbox-redis'
 import { plugin as basicAuth } from '@hapi/basic'
 
 import { router } from './router'
@@ -32,7 +33,22 @@ async function createServer() {
     },
     query: {
       parser: (query) => qs.parse(query)
-    }
+    },
+    cache: [
+      {
+        name: 'session',
+        provider: {
+          constructor: CatboxRedis,
+          options: {
+            partition: 'cdp-portal',
+            host: appConfig.get('cacheHost'),
+            port: 6379,
+            db: 0,
+            role: appConfig.get('cacheRole')
+          }
+        }
+      }
+    ]
   })
 
   // TODO this is temp auth just for the demo. Replace with proper auth before launch
@@ -43,14 +59,8 @@ async function createServer() {
     server.auth.default('simple')
   }
 
-  server.ext('onPreResponse', addFlashMessagesToContext, {
-    before: ['yar']
-  })
-
   await server.register(flashMessage)
-
   await server.register(requestLogger)
-
   await server.register(router, {
     routes: { prefix: appConfig.get('appPathPrefix') }
   })
@@ -59,6 +69,7 @@ async function createServer() {
 
   server.decorate('request', 'isXhr', isXhr)
 
+  server.ext('onPreResponse', addFlashMessagesToContext, { before: ['yar'] })
   server.ext('onPreResponse', catchAll)
 
   return server


### PR DESCRIPTION
Setup Redis to be used by `yar` for session management

This is working as expected locally:
<img width="1494" alt="Screenshot 2023-09-01 at 14 19 16" src="https://github.com/defra-cdp-sandpit/cdp-portal-frontend/assets/2305016/5cf6f3a4-b215-416d-8ecd-f876e24558d6">



Associated `cdp-app-config` PR - https://github.com/defra-cdp-sandpit/cdp-app-config/pull/68

## Of Note
I can't see `--user-id infra-dev-test` available in the options for the underlying Redis. Is this called something else?