### PR TITLE
Improve fetcher work

### DIFF
--- a/src/server/admin/teams/helpers/fetch/add-member-to-team.test.js
+++ b/src/server/admin/teams/helpers/fetch/add-member-to-team.test.js
@@ -15,7 +15,8 @@ describe('#addUserToTeam', () => {
     authedFetcher: authedFetcher({
       getUserSession: jest.fn().mockResolvedValue({}),
       logger: {
-        info: jest.fn()
+        info: jest.fn(),
+        error: jest.fn()
       }
     })
   }

--- a/src/server/admin/teams/helpers/fetch/remove-member-from-team.test.js
+++ b/src/server/admin/teams/helpers/fetch/remove-member-from-team.test.js
@@ -13,7 +13,10 @@ describe('#removeUserFromTeam', () => {
   )
   const mockRequest = {
     authedFetcher: authedFetcher({
-      getUserSession: jest.fn().mockResolvedValue({})
+      getUserSession: jest.fn().mockResolvedValue({}),
+      logger: {
+        error: jest.fn()
+      }
     })
   }
 

--- a/src/server/common/helpers/fetch/fetch-environments.test.js
+++ b/src/server/common/helpers/fetch/fetch-environments.test.js
@@ -8,7 +8,10 @@ import { fetchEnvironments } from '~/src/server/common/helpers/fetch/fetch-envir
 describe('#fetchEnvironments', () => {
   const mockRequest = {
     authedFetcher: authedFetcher({
-      getUserSession: jest.fn().mockResolvedValue({})
+      getUserSession: jest.fn().mockResolvedValue({}),
+      logger: {
+        error: jest.fn()
+      }
     })
   }
   const environmentsEndpointUrl = new URL(

--- a/src/server/common/helpers/fetch/fetcher.test.js
+++ b/src/server/common/helpers/fetch/fetcher.test.js
@@ -47,4 +47,29 @@ describe('#fetchJson', () => {
       expect(error).toHaveProperty('message', 'Gone')
     }
   })
+
+  test('With generic error, Should throw with expected message', async () => {
+    nock(librariesEndpointUrl.origin)
+      .get(librariesEndpointUrl.pathname)
+      .replyWithError({
+        message:
+          'invalid json response body at http://bad-url reason: Unexpected end of JSON input',
+        type: 'invalid-json',
+        stack:
+          'FetchError: invalid json response body at http://bad-url reason: Unexpected end of JSON input'
+      })
+
+    expect.assertions(2)
+
+    try {
+      await fetcher(librariesEndpoint)
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error)
+      expect(error).toHaveProperty(
+        'message',
+        'request to http://localhost:5094/cdp-portal-backend/libraries failed, reason: invalid json response body at' +
+          ' http://bad-url reason: Unexpected end of JSON input'
+      )
+    }
+  })
 })

--- a/src/server/common/helpers/fetch/throw-http-error.js
+++ b/src/server/common/helpers/fetch/throw-http-error.js
@@ -1,0 +1,11 @@
+import Boom from '@hapi/boom'
+
+function throwHttpError(json, response) {
+  const message = json?.message ?? response.statusText
+
+  throw Boom.boomify(new Error(message), {
+    statusCode: response?.status ?? 500
+  })
+}
+
+export { throwHttpError }

--- a/src/server/common/helpers/fetch/throw-http-error.test.js
+++ b/src/server/common/helpers/fetch/throw-http-error.test.js
@@ -1,0 +1,47 @@
+import { throwHttpError } from '~/src/server/common/helpers/fetch/throw-http-error'
+
+describe('#throwHttpError', () => {
+  const mockJson = {
+    message: 'Something terrible has happened!'
+  }
+  const mockResponse = {
+    statusText: 'Oh dear!',
+    status: 408
+  }
+
+  test('Should throw with json error message', () => {
+    expect.assertions(2)
+
+    try {
+      throwHttpError(mockJson, mockResponse)
+    } catch (error) {
+      expect(error.output.statusCode).toEqual(408)
+      expect(error).toHaveProperty(
+        'message',
+        'Something terrible has happened!'
+      )
+    }
+  })
+
+  test('Should throw with response statusText', () => {
+    expect.assertions(2)
+
+    try {
+      throwHttpError({}, mockResponse)
+    } catch (error) {
+      expect(error.output.statusCode).toEqual(408)
+      expect(error).toHaveProperty('message', 'Oh dear!')
+    }
+  })
+
+  test('Should throw with default status code', () => {
+    expect.assertions(2)
+
+    try {
+      throwHttpError({}, { statusText: 'Crikey' })
+    } catch (error) {
+      expect(error.output.statusCode).toEqual(500)
+      expect(error).toHaveProperty('message', 'Crikey')
+    }
+  })
+})


### PR DESCRIPTION
Improve the fetcher work

- Handle errors thrown when a valid JSON response is not provided via `await response.json()`

## Improved logging

<img width="1461" alt="improved-logging" src="https://github.com/DEFRA/cdp-portal-frontend/assets/2305016/ab1fdb76-2f10-452f-a264-3d2bd90e3837">

## Improved error message in UI

<img width="2131" alt="server-side-ui-error" src="https://github.com/DEFRA/cdp-portal-frontend/assets/2305016/897303f3-734b-45e3-b8de-2e1ea9bc0af6">
