### PR TITLE
A few tweaks

### DIFF
--- a/src/client/assets/stylesheets/core/_grid.scss
+++ b/src/client/assets/stylesheets/core/_grid.scss
@@ -6,24 +6,30 @@
 
 .app-grid-column-one-third {
   flex: 1;
+  align-self: flex-start;
 }
 
 .app-grid-column-two-thirds {
   flex: 2;
+  align-self: flex-start;
 }
 
 .app-grid-column-one-half {
   flex: 1;
+  align-self: flex-start;
 }
 
 .app-grid-column-one-quarter {
   flex: 1;
+  align-self: flex-start;
 }
 
 .app-grid-column-two-quarters {
   flex: 2;
+  align-self: flex-start;
 }
 
 .app-grid-column-three-quarters {
   flex: 3;
+  align-self: flex-start;
 }

--- a/src/server/common/components/application-link/macro.njk
+++ b/src/server/common/components/application-link/macro.njk
@@ -1,0 +1,3 @@
+{% macro appApplicationLink(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/server/common/components/application-link/template.njk
+++ b/src/server/common/components/application-link/template.njk
@@ -1,0 +1,4 @@
+{# TODO - make this work well with vanity urls and backend API urls #}
+<a class="app-link"
+   href="https://{{ params.environment }}.cdp-int.defra.cloud/{{ params.serviceName }}"
+   target="_blank" rel="noopener noreferrer">{{ params.serviceName }}.{{ params.environment }}</a>

--- a/src/server/common/components/application-link/template.test.js
+++ b/src/server/common/components/application-link/template.test.js
@@ -1,0 +1,1 @@
+test.todo('#application-link')

--- a/src/server/common/templates/layouts/page.njk
+++ b/src/server/common/templates/layouts/page.njk
@@ -33,6 +33,7 @@
 {% from "hero/macro.njk" import appHero %}
 {% from "logs-dashboard-link/macro.njk" import appLogsDashboardLink %}
 {% from "metrics-dashboard-link/macro.njk" import appMetricsDashboardLink %}
+{% from "application-link/macro.njk" import appApplicationLink %}
 
 {% if isXhr %}
   {% extends "layouts/xhr.njk" %}

--- a/src/server/deployments/views/deployment.njk
+++ b/src/server/deployments/views/deployment.njk
@@ -42,17 +42,6 @@
               </div>
             </div>
 
-            <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
-              <li>
-                <p>
-                  {{ appLogsDashboardLink({
-                    serviceName: deployment.service,
-                    environment: deployment.environment
-                  }) }}
-                </p>
-              </li>
-            </ul>
-
             {% call appPanel() %}
               <section>
                 <div class="app-row">
@@ -102,6 +91,24 @@
                     <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Updated</h2>
                     <p>
                       {{ appTime({ datetime: deployment.deployedAt, formatString: "k:mm:ss EE do MMM yyyy" }) }}
+                    </p>
+                  </div>
+
+                  <div class="app-grid-column-one-third">
+                    <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Application url</h2>
+                    <p>
+                      {{ appApplicationLink({
+                        serviceName: deployment.service,
+                        environment: deployment.environment
+                      }) }}
+                    </p>
+
+                    <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Application logs</h2>
+                    <p>
+                      {{ appLogsDashboardLink({
+                        serviceName: deployment.service,
+                        environment: deployment.environment
+                      }) }}
                     </p>
                   </div>
                 </div>

--- a/src/server/services/views/service.njk
+++ b/src/server/services/views/service.njk
@@ -33,16 +33,17 @@
           heading: "Application Urls",
           icon: appGlobeIcon({ classes: "app-icon-small"}),
           intro: {
-            text: "View your application's deployment. In all the environemnts you have deployed to."
+            text: "View your application's deployments in any environments you have deployed to."
           }
         }) %}
           <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
 
             {% for env in envsWithDeployment %}
               <li>
-                <a class="app-link"
-                   href="https://{{ env }}.cdp-int.defra.cloud/{{ service.serviceName }}"
-                   target="_blank" rel="noopener noreferrer">{{ env }}</a>
+                {{ appApplicationLink({
+                  environment: env,
+                  serviceName: service.serviceName
+                }) }}
               </li>
             {% endfor %}
 
@@ -50,7 +51,7 @@
         {% endcall %}
 
         {% call appSummaryItem({
-          heading: "Logs",
+          heading: "Application Logs",
           icon: appLogsIcon({ classes: "app-icon-small"}),
           intro: {
             text: "View your application's OpenSearch logs for monitoring and troubleshooting issues."
@@ -71,7 +72,7 @@
         {% endcall %}
 
         {% call appSummaryItem({
-          heading: "Metrics",
+          heading: "Application Metrics",
           icon: appChartIcon({ classes: "app-icon-small"}),
           intro: {
             text: "Browse your application's Grafana observability metrics data and graphs."
@@ -93,7 +94,7 @@
 
       {% call appSummary() %}
         {% call appSummaryItem({
-          heading: "Config",
+          heading: "Application Config",
           icon: appWrenchIcon({ classes: "app-icon-small"}),
           intro: {
             text: "Pass environment variables to you application in CDP environments."

--- a/src/server/test-suites/views/list.njk
+++ b/src/server/test-suites/views/list.njk
@@ -15,7 +15,7 @@
       { text: "Last Updated", size: "medium" }
     ],
     entityRows: entityRows,
-    noResult: "Currently there are no services"
+    noResult: "Currently there are no test suites"
   }) }}
 
 {% endblock %}


### PR DESCRIPTION
- Abstract the application url into a component to be used in multiple places
- Update the copy in the Service page so section titles are prefixed with "Application", to match "Application Urls"
- Update no test suite message in test suite list
- Bring all items in app-grid to the start
- Add Application urls and log urls in to deployments

## Demo

### Deployments
<img width="2550" alt="Screenshot 2024-02-29 at 17 19 32" src="https://github.com/DEFRA/cdp-portal-frontend/assets/2305016/bd3622ed-161a-4bed-a454-356d1d0e45b6">

### Service page
<img width="2543" alt="Screenshot 2024-02-29 at 17 19 43" src="https://github.com/DEFRA/cdp-portal-frontend/assets/2305016/20fec355-df4c-49f2-8dd8-b7dc53ea8a48">

