### PR TITLE
265717 add search and filtering to deployments list page

### DIFF
--- a/src/client/assets/javascripts/application.js
+++ b/src/client/assets/javascripts/application.js
@@ -1,23 +1,27 @@
 import { initAll } from 'govuk-frontend'
 
-import { initModule } from '~/src/client/common/helpers/init-module'
-import { initClass } from '~/src/client/common/helpers/init-class'
-import { availability } from '~/src/server/common/components/availability/availability'
 import { Autocomplete } from '~/src/server/common/components/autocomplete/autocomplete'
-import { button } from '~/src/server/common/components/button/button'
-import { banner } from '~/src/server/common/components/banner/banner'
-import { search } from '~/src/server/common/components/search/search'
-import { protectForm } from '~/src/client/common/helpers/protect-form'
-import { readOut } from '~/src/server/common/components/read-out/read-out'
-import { errorMessages } from '~/src/client/common/helpers/error-messages'
+import { AutocompleteAdvanced } from '~/src/server/common/components/autocomplete/autocomplete-advanced'
 import { autoSubmit } from '~/src/client/common/helpers/auto-submit'
-import { poll } from '~/src/client/common/helpers/poll'
-import { paramsToHiddenInputs } from '~/src/client/common/helpers/params-to-hidden-inputs'
-import { populateSelectOptions } from '~/src/client/common/helpers/populate-select-options'
+import { availability } from '~/src/server/common/components/availability/availability'
+import { banner } from '~/src/server/common/components/banner/banner'
+import { button } from '~/src/server/common/components/button/button'
+import { clearDeploymentsListFilters } from '~/src/client/common/helpers/fetch/filters'
+import { errorMessages } from '~/src/client/common/helpers/error-messages'
 import { fetchIsNameAvailable } from '~/src/client/common/helpers/fetch/create/fetch-is-name-available'
 import { fetchMemory } from '~/src/client/common/helpers/fetch/select'
 import { fetchVersions } from '~/src/client/common/helpers/fetch/autocomplete'
+import { filters } from '~/src/server/common/components/filters/filters'
+import { initClass } from '~/src/client/common/helpers/init-class'
+import { initModule } from '~/src/client/common/helpers/init-module'
+import { paramsToHiddenInputs } from '~/src/client/common/helpers/params-to-hidden-inputs'
+import { poll } from '~/src/client/common/helpers/poll'
 import { populateAutocompleteSuggestions } from '~/src/client/common/helpers/populate-autocomplete-suggestions'
+import { populateSelectOptions } from '~/src/client/common/helpers/populate-select-options'
+import { protectForm } from '~/src/client/common/helpers/protect-form'
+import { readOut } from '~/src/server/common/components/read-out/read-out'
+import { search } from '~/src/server/common/components/search/search'
+import { tabs } from '~/src/server/common/components/tabs/tabs'
 import { xhrSubscriber } from '~/src/server/common/components/xhr-subscriber/xhr-subscriber'
 
 import '../stylesheets/application.scss'
@@ -31,13 +35,14 @@ import '../images/govuk-icon-mask.svg'
 
 initAll()
 
-// ClientSide namespace
-window.cdp = {}
+// ClientSide CDP namespace
+window.cdp = window.cdp || {}
 
 // Helper functions
 window.cdp.fetchVersions = fetchVersions
 window.cdp.fetchMemory = fetchMemory
 window.cdp.fetchIsNameAvailable = fetchIsNameAvailable
+window.cdp.clearDeploymentsListFilters = clearDeploymentsListFilters
 
 // Create multistep form flow, repository name readout
 initModule('app-read-out', readOut, '*=')
@@ -60,11 +65,12 @@ initModule('app-protected-inputs', protectForm, '*=')
 // Search
 initModule('app-search', search)
 
-// Populate autocomplete from a separate controller input
-initModule('app-autocomplete-controller', populateAutocompleteSuggestions)
-
 // Autocomplete
 initClass('app-autocomplete', Autocomplete)
+initClass('app-autocomplete-advanced', AutocompleteAdvanced)
+
+// Populate autocomplete from a separate controller input
+initModule('app-autocomplete-controller', populateAutocompleteSuggestions)
 
 // Xhr Container
 initModule('app-xhr-subscriber', xhrSubscriber)
@@ -80,3 +86,9 @@ initModule('app-poll', poll)
 
 // Notification banner
 initModule('app-notification', banner)
+
+// Filters
+initModule('app-filters', filters)
+
+// Tabs
+initModule('app-tabs', tabs)

--- a/src/client/assets/stylesheets/components/_all.scss
+++ b/src/client/assets/stylesheets/components/_all.scss
@@ -5,10 +5,11 @@
 @import "banner/banner";
 @import "breadcrumbs/breadcrumbs";
 @import "button/button";
-@import "entity/entity";
 @import "entity-actions/entity-actions";
 @import "entity-data-list/entity-data-list";
 @import "entity-list/entity-list";
+@import "entity/entity";
+@import "filters/filters";
 @import "footer/footer";
 @import "header/header";
 @import "heading/heading";
@@ -26,9 +27,9 @@
 @import "split-pane/split-pane";
 @import "status/status";
 @import "step-navigation/step-navigation";
+@import "summary-item/summary-item";
+@import "summary/summary";
 @import "tabs/tabs";
 @import "tag/tag";
 @import "tool-tip/tool-tip";
-@import "summary/summary";
-@import "summary-item/summary-item";
 @import "warning/warning";

--- a/src/client/assets/stylesheets/core/_pagination.scss
+++ b/src/client/assets/stylesheets/core/_pagination.scss
@@ -1,5 +1,6 @@
 .app-pagination {
-  margin-bottom: 0;
+  margin: govuk-spacing(4) 0;
+  justify-content: center;
 
   .govuk-pagination__item {
     border-radius: $app-border-radius;

--- a/src/client/assets/stylesheets/core/form/_group.scss
+++ b/src/client/assets/stylesheets/core/form/_group.scss
@@ -8,6 +8,10 @@
   margin-bottom: govuk-spacing(3);
 }
 
+.app-form-group--inline {
+  margin-bottom: 0;
+}
+
 .app-form-group,
 .govuk-form-group--error {
   & .govuk-error-message {

--- a/src/client/assets/stylesheets/core/form/_label.scss
+++ b/src/client/assets/stylesheets/core/form/_label.scss
@@ -2,3 +2,7 @@
   @include govuk-font(24, "bold");
   margin-bottom: govuk-spacing(1);
 }
+
+.app-label--inline {
+  display: inline-block;
+}

--- a/src/client/common/helpers/fetch/filters/clear-deployments-list-filters.js
+++ b/src/client/common/helpers/fetch/filters/clear-deployments-list-filters.js
@@ -1,0 +1,13 @@
+async function clearDeploymentsListFilters(event) {
+  event.preventDefault()
+
+  const queryParams = new URLSearchParams(window.location.search)
+
+  queryParams.delete('service')
+  queryParams.delete('user')
+  queryParams.delete('status')
+
+  window.location.search = queryParams.toString()
+}
+
+export { clearDeploymentsListFilters }

--- a/src/client/common/helpers/fetch/filters/index.js
+++ b/src/client/common/helpers/fetch/filters/index.js
@@ -1,0 +1,3 @@
+import { clearDeploymentsListFilters } from '~/src/client/common/helpers/fetch/filters/clear-deployments-list-filters'
+
+export { clearDeploymentsListFilters }

--- a/src/client/common/helpers/populate-autocomplete-suggestions.js
+++ b/src/client/common/helpers/populate-autocomplete-suggestions.js
@@ -38,9 +38,9 @@ function populateAutocompleteSuggestions($controller) {
       clearTimeout(delayedLoader)
       $loader?.classList?.remove('app-loader--is-loading')
 
-      const suggestionsName = $target.name
+      const suggestionsName = $target.id
 
-      window.suggestions[suggestionsName] = buildSuggestions(suggestions)
+      window.cdp.suggestions[suggestionsName] = buildSuggestions(suggestions)
 
       if (publishTo) {
         publish(publishTo, { queryParams: { [name]: value } })

--- a/src/config/nunjucks/filters/index.js
+++ b/src/config/nunjucks/filters/index.js
@@ -1,7 +1,15 @@
-import { assign, isArray, isNil } from 'lodash'
+import { assign, isArray, isNil, compact } from 'lodash'
 
 import { formatDate } from '~/src/server/common/helpers/date/format-date'
 import { relativeDate } from '~/src/server/common/helpers/date/relative-date'
 import { sanitizeUser } from '~/src/server/common/helpers/sanitize-user'
 
-export { assign, formatDate, relativeDate, isArray, sanitizeUser, isNil }
+export {
+  assign,
+  formatDate,
+  relativeDate,
+  isArray,
+  sanitizeUser,
+  isNil,
+  compact
+}

--- a/src/server/common/components/autocomplete/_autocomplete.scss
+++ b/src/server/common/components/autocomplete/_autocomplete.scss
@@ -1,3 +1,5 @@
+$tiny-width: 12em;
+$small-width: 24em;
 $width: 30em;
 $large-width: 40em;
 
@@ -7,12 +9,32 @@ $large-width: 40em;
   margin-bottom: govuk-spacing(4);
 }
 
+.app-autocomplete--tiny {
+  width: $tiny-width;
+
+  .app-autocomplete__suggestions {
+    width: calc(100% - 4px);
+  }
+}
+
+.app-autocomplete--small {
+  width: $small-width;
+
+  .app-autocomplete__suggestions {
+    width: calc(100% - 4px);
+  }
+}
+
 .app-autocomplete--wide {
   width: $large-width;
 
   .app-autocomplete__suggestions {
     width: calc(100% - 4px);
   }
+}
+
+.app-autocomplete--inline {
+  margin-bottom: 0;
 }
 
 .app-autocomplete__control {

--- a/src/server/common/components/autocomplete/autocomplete-advanced.js
+++ b/src/server/common/components/autocomplete/autocomplete-advanced.js
@@ -1,0 +1,78 @@
+import { Autocomplete } from '~/src/server/common/components/autocomplete/autocomplete'
+
+/**
+ * @classdesc Advanced Autocomplete component, supports hints.
+ * @class
+ * @augments Autocomplete
+ */
+class AutocompleteAdvanced extends Autocomplete {
+  createSuggestionElementTemplate() {
+    const $span = document.createElement('span')
+
+    const $itemValue = $span.cloneNode(true)
+    $itemValue.classList.add('app-suggestion__value')
+
+    const $hintContent = $span.cloneNode(true)
+    $hintContent.classList.add('app-suggestion__hint')
+
+    const $action = $span.cloneNode(true)
+    $action.classList.add('app-suggestion__action')
+
+    const $li = document.createElement('li')
+
+    $li.classList.add('app-autocomplete__suggestion')
+    $li.dataset.isMatch = 'false'
+    $li.setAttribute('role', 'option')
+    $li.setAttribute('tabindex', '-1')
+
+    $li.appendChild($itemValue)
+    $li.appendChild($hintContent)
+    $li.appendChild($action)
+
+    return $li
+  }
+
+  getPartialMatch(textValue) {
+    return ($suggestion) =>
+      $suggestion?.dataset?.text
+        .toLowerCase()
+        .includes(textValue.toLowerCase()) ||
+      $suggestion?.dataset?.hint.toLowerCase().includes(textValue.toLowerCase())
+  }
+
+  populateSuggestion($li, item) {
+    $li.dataset.value = item.value
+    $li.dataset.text = item.text
+
+    $li.firstElementChild.textContent = item.value
+
+    $li.dataset.hint = item.hint
+    $li.firstElementChild.nextElementSibling.textContent = item.hint
+
+    return $li
+  }
+
+  manageTextHighlight($suggestion, textValue = null) {
+    if (textValue) {
+      $suggestion.firstElementChild.innerHTML =
+        $suggestion.dataset?.text.replace(
+          new RegExp(textValue, 'gi'),
+          `<strong>$&</strong>`
+        )
+
+      $suggestion.firstElementChild.nextElementSibling.innerHTML =
+        $suggestion.dataset?.hint.replace(
+          new RegExp(textValue, 'gi'),
+          `<strong>$&</strong>`
+        )
+    } else {
+      $suggestion.firstElementChild.innerHTML = $suggestion.dataset?.text
+      $suggestion.firstElementChild.nextElementSibling.innerHTML =
+        $suggestion.dataset?.hint
+    }
+
+    return $suggestion
+  }
+}
+
+export { AutocompleteAdvanced }

--- a/src/server/common/components/autocomplete/autocomplete-advanced.test.js
+++ b/src/server/common/components/autocomplete/autocomplete-advanced.test.js
@@ -1,0 +1,702 @@
+import { renderTestComponent } from '~/test-helpers/component-helpers'
+import { AutocompleteAdvanced } from '~/src/server/common/components/autocomplete/autocomplete-advanced'
+import { publish } from '~/src/client/common/helpers/event-emitter'
+
+describe('#autocomplete-advanced', () => {
+  let autocompleteInput
+  let chevronButton
+  let suggestionsContainer
+
+  function setupAutoComplete(params) {
+    const $component = renderTestComponent('autocomplete', params)
+
+    // Add suggestions into the components <script /> tag
+    const scriptElement = document.createElement('script')
+    scriptElement.innerHTML = $component(
+      '[data-testid="app-autocomplete-suggestions"]'
+    )
+      .first()
+      .html()
+    document.getElementsByTagName('html')[0].appendChild(scriptElement)
+
+    // Append dropdown component to a form and then add it to the document
+    document.body.innerHTML = `<form id="mock-dropdown-form">
+        ${$component('[data-testid="app-autocomplete-group"]').first().html()}
+      </form>`
+
+    // Init ClientSide JavaScript
+    const autocompletes = Array.from(
+      document.querySelectorAll('[data-js="app-autocomplete-advanced"]')
+    )
+
+    if (autocompletes.length) {
+      autocompletes.forEach(
+        ($autocomplete) => new AutocompleteAdvanced($autocomplete)
+      )
+    }
+
+    autocompleteInput = document.querySelector(
+      '[data-testid="app-autocomplete-input"]'
+    )
+    chevronButton = document.querySelector('[data-testid="app-chevron-button"]')
+    suggestionsContainer = document.querySelector(
+      '[data-testid="app-autocomplete-suggestions"]'
+    )
+  }
+
+  describe('With suggestions', () => {
+    beforeEach(() => {
+      setupAutoComplete({
+        label: {
+          text: 'By'
+        },
+        hint: {
+          text: 'Choose a user'
+        },
+        id: 'user',
+        name: 'user',
+        template: 'advanced',
+        noSuggestionsMessage: 'choose Image name',
+        suggestions: [
+          {
+            text: 'RoboCop',
+            value: 'RoboCop',
+            hint: 'User Id: 12454878'
+          },
+          {
+            text: 'Roger Rabbit',
+            value: 'Roger Rabbit',
+            hint: 'User Id: 556456465'
+          },
+          {
+            text: 'Barbie',
+            value: 'Barbie',
+            hint: 'User Id: 67567576'
+          }
+        ]
+      })
+    })
+
+    describe('On load', () => {
+      test('Should not show suggestions', () => {
+        expect(suggestionsContainer.getAttribute('aria-expanded')).toEqual(
+          'false'
+        )
+      })
+
+      test('Should have enhanced select input', () => {
+        expect(autocompleteInput.tagName.toLowerCase()).toEqual('input')
+      })
+
+      test('Input should have control of suggestions', () => {
+        expect(autocompleteInput.getAttribute('aria-controls')).toEqual(
+          'app-autocomplete-user-suggestions'
+        )
+      })
+
+      test('Chevron button should have control of suggestions', () => {
+        expect(chevronButton.getAttribute('aria-owns')).toEqual(
+          'app-autocomplete-user-suggestions'
+        )
+      })
+
+      test('Chevron should be in closed position', () => {
+        expect(chevronButton.getAttribute('aria-label')).toEqual('Show')
+      })
+    })
+
+    describe('When clicked', () => {
+      beforeEach(() => {
+        autocompleteInput.click()
+      })
+
+      test('Should open suggestions', () => {
+        expect(suggestionsContainer.getAttribute('aria-expanded')).toEqual(
+          'true'
+        )
+      })
+
+      test('Should contain expected suggestions', () => {
+        const children = suggestionsContainer.children
+
+        expect(children.length).toEqual(3)
+
+        expect(children[0].textContent).toContain('RoboCopUser Id: 12454878')
+        expect(children[1].textContent).toEqual(
+          'Roger RabbitUser Id: 556456465'
+        )
+        expect(children[2].textContent).toEqual('BarbieUser Id: 67567576')
+      })
+    })
+
+    describe('When focussed', () => {
+      beforeEach(() => {
+        autocompleteInput.focus()
+      })
+
+      test('Should open suggestions', () => {
+        expect(suggestionsContainer.getAttribute('aria-expanded')).toEqual(
+          'true'
+        )
+        expect(autocompleteInput.getAttribute('aria-expanded')).toEqual('true')
+      })
+
+      test('Should contain expected suggestions when input focused', () => {
+        const children = suggestionsContainer.children
+
+        expect(children.length).toEqual(3)
+
+        expect(children[0].textContent).toEqual('RoboCopUser Id: 12454878')
+        expect(children[1].textContent).toEqual(
+          'Roger RabbitUser Id: 556456465'
+        )
+        expect(children[2].textContent).toEqual('BarbieUser Id: 67567576')
+      })
+    })
+
+    describe('When keyboard "tab" key pressed', () => {
+      beforeEach(() => {
+        autocompleteInput.focus()
+
+        const tabKeyEvent = new KeyboardEvent('keydown', { code: 'tab' })
+        autocompleteInput.dispatchEvent(tabKeyEvent)
+      })
+
+      test('Should close suggestions', () => {
+        expect(suggestionsContainer.getAttribute('aria-expanded')).toEqual(
+          'false'
+        )
+        expect(autocompleteInput.getAttribute('aria-expanded')).toEqual('false')
+      })
+    })
+
+    describe('When partial value', () => {
+      describe('Entered into input', () => {
+        beforeEach(() => {
+          autocompleteInput.focus()
+          autocompleteInput.value = 'abb'
+          autocompleteInput.dispatchEvent(new Event('input'))
+        })
+
+        test('Should open suggestions', () => {
+          expect(suggestionsContainer.getAttribute('aria-expanded')).toEqual(
+            'true'
+          )
+          expect(autocompleteInput.getAttribute('aria-expanded')).toEqual(
+            'true'
+          )
+        })
+
+        test('Should narrow to only expected suggestion', () => {
+          expect(suggestionsContainer.children.length).toEqual(1)
+          expect(suggestionsContainer.children[0].textContent).toEqual(
+            'Roger RabbitUser Id: 556456465'
+          )
+        })
+      })
+
+      describe('That matches multiple suggestions is entered into input', () => {
+        beforeEach(() => {
+          autocompleteInput.focus()
+          autocompleteInput.value = 'ro'
+          autocompleteInput.dispatchEvent(new Event('input'))
+        })
+
+        test('Should open suggestions', () => {
+          expect(suggestionsContainer.getAttribute('aria-expanded')).toEqual(
+            'true'
+          )
+          expect(autocompleteInput.getAttribute('aria-expanded')).toEqual(
+            'true'
+          )
+        })
+
+        test('Should narrow to only expected suggestions', () => {
+          expect(suggestionsContainer.children.length).toEqual(2)
+          expect(suggestionsContainer.children[0].textContent).toEqual(
+            'RoboCopUser Id: 12454878'
+          )
+          expect(suggestionsContainer.children[1].textContent).toEqual(
+            'Roger RabbitUser Id: 556456465'
+          )
+        })
+      })
+
+      describe('With crazy case value entered into input', () => {
+        beforeEach(() => {
+          autocompleteInput.focus()
+          autocompleteInput.value = 'Barb'
+          autocompleteInput.dispatchEvent(new Event('input'))
+        })
+
+        test('Should narrow to only expected case insensitive suggestion', () => {
+          expect(suggestionsContainer.children.length).toEqual(1)
+          expect(suggestionsContainer.children[0].textContent.trim()).toEqual(
+            'BarbieUser Id: 67567576'
+          )
+        })
+      })
+    })
+
+    describe('With exact match entered into input', () => {
+      beforeEach(() => {
+        autocompleteInput.focus()
+        autocompleteInput.value = 'Barbie'
+        autocompleteInput.dispatchEvent(new Event('input'))
+      })
+
+      test('Should show all suggestions', () => {
+        expect(suggestionsContainer.children.length).toEqual(3)
+      })
+
+      test('Should highlight matched suggestion', () => {
+        const matchedSuggestion = Array.from(
+          suggestionsContainer.children
+        ).find((suggestion) => suggestion.dataset.isMatch === 'true')
+
+        expect(matchedSuggestion.textContent.trim()).toEqual(
+          'BarbieUser Id: 67567576'
+        )
+        expect(matchedSuggestion.children[2].innerHTML).toContain(
+          'app-tick-icon'
+        )
+      })
+    })
+
+    describe('With hint text entered into input', () => {
+      beforeEach(() => {
+        autocompleteInput.focus()
+        autocompleteInput.value = 'Id: 556'
+        autocompleteInput.dispatchEvent(new Event('input'))
+        suggestionsContainer.children[0].click()
+      })
+
+      test('Should have selected expected suggestion', () => {
+        expect(autocompleteInput.value).toEqual('Roger Rabbit')
+      })
+
+      test('Should have selected expected matched suggestion', () => {
+        // Open suggestions
+        autocompleteInput.click()
+
+        const matchedSuggestion = Array.from(
+          suggestionsContainer.children
+        ).find((suggestion) => suggestion.dataset.isMatch === 'true')
+
+        expect(matchedSuggestion.textContent.trim()).toEqual(
+          'Roger RabbitUser Id: 556456465'
+        )
+        expect(matchedSuggestion.children[2].innerHTML).toContain(
+          'app-tick-icon'
+        )
+      })
+    })
+
+    describe('When value removed from input', () => {
+      beforeEach(() => {
+        autocompleteInput.focus()
+
+        // Add value to input
+        autocompleteInput.value = 'fro'
+        autocompleteInput.dispatchEvent(new Event('input'))
+
+        // Remove value from input
+        autocompleteInput.value = ''
+        autocompleteInput.dispatchEvent(new Event('input'))
+      })
+
+      test('Suggestions should be open', () => {
+        expect(suggestionsContainer.getAttribute('aria-expanded')).toEqual(
+          'true'
+        )
+        expect(autocompleteInput.getAttribute('aria-expanded')).toEqual('true')
+      })
+
+      test('Should contain expected suggestions', () => {
+        const children = suggestionsContainer.children
+
+        expect(children.length).toEqual(3)
+
+        expect(children[0].textContent).toEqual('RoboCopUser Id: 12454878')
+        expect(children[1].textContent).toEqual(
+          'Roger RabbitUser Id: 556456465'
+        )
+        expect(children[2].textContent).toEqual('BarbieUser Id: 67567576')
+      })
+    })
+
+    describe('When value without results entered into input', () => {
+      beforeEach(() => {
+        autocompleteInput.focus()
+        autocompleteInput.value = 'blah'
+        autocompleteInput.dispatchEvent(new Event('input'))
+      })
+
+      test('Should open suggestions', () => {
+        expect(suggestionsContainer.getAttribute('aria-expanded')).toEqual(
+          'true'
+        )
+        expect(autocompleteInput.getAttribute('aria-expanded')).toEqual('true')
+      })
+
+      test('Should provide no results message', () => {
+        expect(suggestionsContainer.children.length).toEqual(1)
+        expect(suggestionsContainer.children[0].textContent).toEqual(
+          ' - - no result - - '
+        )
+      })
+    })
+
+    describe('When no results message is clicked', () => {
+      beforeEach(() => {
+        autocompleteInput.focus()
+        autocompleteInput.value = 'ranDom'
+        autocompleteInput.dispatchEvent(new Event('input'))
+        suggestionsContainer.children[0].click()
+      })
+
+      test('Should not alter autocomplete value suggestions', () => {
+        expect(autocompleteInput.value).toEqual('ranDom')
+      })
+    })
+
+    describe('When "backspace" pressed in empty input', () => {
+      beforeEach(() => {
+        autocompleteInput.focus()
+        autocompleteInput.value = ''
+
+        const backspaceKeyEvent = new KeyboardEvent('keydown', {
+          code: 'backspace'
+        })
+        autocompleteInput.dispatchEvent(backspaceKeyEvent)
+      })
+
+      test('Input should keep focus', () => {
+        expect(document.activeElement).toEqual(autocompleteInput)
+      })
+
+      test('Suggestions should be closed', () => {
+        expect(suggestionsContainer.getAttribute('aria-expanded')).toEqual(
+          'false'
+        )
+        expect(autocompleteInput.getAttribute('aria-expanded')).toEqual('false')
+      })
+    })
+
+    describe('When keyboard "escape" key pressed', () => {
+      beforeEach(() => {
+        autocompleteInput.focus()
+
+        const escapeKeyEvent = new KeyboardEvent('keydown', {
+          code: 'escape'
+        })
+        autocompleteInput.dispatchEvent(escapeKeyEvent)
+      })
+
+      test('Input should keep focus', () => {
+        expect(document.activeElement).toEqual(autocompleteInput)
+      })
+
+      test('Suggestions should be closed', () => {
+        expect(suggestionsContainer.getAttribute('aria-expanded')).toEqual(
+          'false'
+        )
+        expect(autocompleteInput.getAttribute('aria-expanded')).toEqual('false')
+      })
+    })
+
+    describe('When keyboard "arrow" keys pressed', () => {
+      beforeEach(() => {
+        autocompleteInput.focus()
+      })
+
+      test('Once, should highlight first suggestion', () => {
+        const arrowDownKeyEvent = new KeyboardEvent('keydown', {
+          code: 'arrowdown'
+        })
+        autocompleteInput.dispatchEvent(arrowDownKeyEvent)
+
+        const children = suggestionsContainer.children
+
+        expect(children[0].getAttribute('aria-selected')).toEqual('true')
+        expect(children[1].getAttribute('aria-selected')).toEqual('false')
+        expect(children[2].getAttribute('aria-selected')).toEqual('false')
+
+        expect(autocompleteInput.getAttribute('aria-activedescendant')).toEqual(
+          'app-autocomplete-user-suggestion-1'
+        )
+      })
+
+      test('Twice, should have expected suggestion position information', () => {
+        const arrowDownKeyEvent = new KeyboardEvent('keydown', {
+          code: 'arrowdown'
+        })
+        autocompleteInput.dispatchEvent(arrowDownKeyEvent)
+        autocompleteInput.dispatchEvent(arrowDownKeyEvent)
+
+        const children = suggestionsContainer.children
+
+        expect(children[0].getAttribute('aria-posinset')).toEqual('0')
+        expect(children[1].getAttribute('aria-posinset')).toEqual('1')
+        expect(children[2].getAttribute('aria-posinset')).toEqual('2')
+
+        expect(autocompleteInput.getAttribute('aria-activedescendant')).toEqual(
+          'app-autocomplete-user-suggestion-2'
+        )
+      })
+
+      test('Up and Down keys, should highlight expected suggestion', () => {
+        const arrowDownKeyEvent = new KeyboardEvent('keydown', {
+          code: 'arrowdown'
+        })
+        autocompleteInput.dispatchEvent(arrowDownKeyEvent)
+        autocompleteInput.dispatchEvent(arrowDownKeyEvent)
+        autocompleteInput.dispatchEvent(arrowDownKeyEvent)
+
+        const arrowUpKeyEvent = new KeyboardEvent('keydown', {
+          code: 'arrowup'
+        })
+        autocompleteInput.dispatchEvent(arrowUpKeyEvent)
+        autocompleteInput.dispatchEvent(arrowUpKeyEvent)
+
+        const children = suggestionsContainer.children
+
+        expect(children[0].getAttribute('aria-posinset')).toEqual('0')
+        expect(children[1].getAttribute('aria-posinset')).toEqual('1')
+        expect(children[2].getAttribute('aria-posinset')).toEqual('2')
+
+        expect(autocompleteInput.getAttribute('aria-activedescendant')).toEqual(
+          'app-autocomplete-user-suggestion-1'
+        )
+      })
+    })
+
+    describe('When keyboard "enter" key pressed in suggestions', () => {
+      beforeEach(() => {
+        autocompleteInput.focus()
+
+        const arrowDownKeyEvent = new KeyboardEvent('keydown', {
+          code: 'arrowdown'
+        })
+        autocompleteInput.dispatchEvent(arrowDownKeyEvent)
+        autocompleteInput.dispatchEvent(arrowDownKeyEvent)
+
+        const enterKeyEvent = new KeyboardEvent('keydown', {
+          code: 'enter'
+        })
+        autocompleteInput.dispatchEvent(enterKeyEvent)
+      })
+
+      test('Should provide expected suggestion value', () => {
+        expect(autocompleteInput.value).toEqual('Roger Rabbit')
+      })
+
+      test('Input should keep focus', () => {
+        expect(document.activeElement).toEqual(autocompleteInput)
+      })
+
+      test('Suggestions should be closed', () => {
+        expect(suggestionsContainer.getAttribute('aria-expanded')).toEqual(
+          'false'
+        )
+        expect(autocompleteInput.getAttribute('aria-expanded')).toEqual('false')
+      })
+    })
+
+    describe('When suggestion is clicked', () => {
+      beforeEach(() => {
+        autocompleteInput.focus()
+        suggestionsContainer.children[1].click()
+      })
+
+      test('Should provide expected suggestion value', () => {
+        expect(autocompleteInput.value).toEqual('Roger Rabbit')
+      })
+
+      test('Input should keep focus', () => {
+        expect(document.activeElement).toEqual(autocompleteInput)
+      })
+
+      test('Suggestions should be closed', () => {
+        expect(suggestionsContainer.getAttribute('aria-expanded')).toEqual(
+          'false'
+        )
+        expect(autocompleteInput.getAttribute('aria-expanded')).toEqual('false')
+      })
+    })
+
+    describe('When keyboard "enter" key is pressed with input value', () => {
+      beforeEach(() => {
+        autocompleteInput.focus()
+
+        // Add value to input
+        autocompleteInput.value = 'fro'
+        autocompleteInput.dispatchEvent(new Event('input'))
+
+        const enterKeyEvent = new KeyboardEvent('keydown', {
+          code: 'enter'
+        })
+        autocompleteInput.dispatchEvent(enterKeyEvent)
+      })
+
+      test('Suggestions should be closed', () => {
+        expect(suggestionsContainer.getAttribute('aria-expanded')).toEqual(
+          'false'
+        )
+        expect(autocompleteInput.getAttribute('aria-expanded')).toEqual('false')
+      })
+    })
+
+    describe('When keyboard "enter" key is pressed without input value', () => {
+      beforeEach(() => {
+        autocompleteInput.focus()
+        autocompleteInput.value = ''
+
+        const escapeKeyEvent = new KeyboardEvent('keydown', {
+          code: 'escape'
+        })
+        autocompleteInput.dispatchEvent(escapeKeyEvent)
+
+        const enterKeyEvent = new KeyboardEvent('keydown', {
+          code: 'enter'
+        })
+        autocompleteInput.dispatchEvent(enterKeyEvent)
+      })
+
+      test('Suggestions should be open', () => {
+        expect(suggestionsContainer.getAttribute('aria-expanded')).toEqual(
+          'true'
+        )
+        expect(autocompleteInput.getAttribute('aria-expanded')).toEqual('true')
+      })
+    })
+
+    describe('When element outside of dropdown is clicked', () => {
+      beforeEach(() => {
+        autocompleteInput.focus()
+        document.body.click()
+      })
+
+      test('Suggestions should be closed', () => {
+        expect(suggestionsContainer.getAttribute('aria-expanded')).toEqual(
+          'false'
+        )
+        expect(autocompleteInput.getAttribute('aria-expanded')).toEqual('false')
+      })
+    })
+
+    describe('When "chevron" button is pressed', () => {
+      test('Once, should open suggestions', () => {
+        chevronButton.click()
+
+        expect(chevronButton.getAttribute('aria-label')).toEqual('Hide')
+        expect(suggestionsContainer.getAttribute('aria-expanded')).toEqual(
+          'true'
+        )
+      })
+
+      test('Twice, should close suggestions', () => {
+        chevronButton.click()
+        chevronButton.click()
+
+        expect(chevronButton.getAttribute('aria-label')).toEqual('Show')
+        expect(suggestionsContainer.getAttribute('aria-expanded')).toEqual(
+          'false'
+        )
+      })
+    })
+  })
+
+  describe('Without suggestions', () => {
+    beforeEach(() => {
+      setupAutoComplete({
+        label: {
+          text: 'By'
+        },
+        hint: {
+          text: 'Choose a user'
+        },
+        id: 'user',
+        name: 'user',
+        template: 'advanced',
+        noSuggestionsMessage: 'choose Image name',
+        suggestions: []
+      })
+    })
+
+    describe('When clicked', () => {
+      beforeEach(() => {
+        autocompleteInput.click()
+      })
+
+      test('Should contain expected no suggestions message', () => {
+        const children = suggestionsContainer.children
+
+        expect(children.length).toEqual(1)
+
+        expect(children[0].textContent).toContain('- - choose Image name - -')
+      })
+    })
+
+    describe('When no suggestions message clicked', () => {
+      beforeEach(() => {
+        autocompleteInput.click()
+        suggestionsContainer.children[0].click()
+      })
+
+      test('Should not change value', () => {
+        expect(autocompleteInput.value).toEqual('')
+      })
+    })
+  })
+
+  describe('When subscribed to a publisher', () => {
+    const mockPublisher = 'mock:publisher'
+
+    beforeEach(() => {
+      setupAutoComplete({
+        label: {
+          text: 'By'
+        },
+        hint: {
+          text: 'Choose a user'
+        },
+        id: 'user',
+        name: 'user',
+        template: 'advanced',
+        subscribeTo: mockPublisher,
+        noSuggestionsMessage: 'choose Image name',
+        suggestions: [
+          {
+            text: 'B. A. Baracus',
+            value: 'B. A. Baracus',
+            hint: 'Drink milk fool'
+          },
+          {
+            text: 'Arnold Schwarzenegger',
+            value: 'Arnold Schwarzenegger',
+            hint: 'Run get to the chopper'
+          }
+        ]
+      })
+    })
+
+    describe('With publish event', () => {
+      test('Should reset autocomplete', () => {
+        // enter value into autocomplete
+        autocompleteInput.focus()
+        autocompleteInput.value = 'Run get to the chopper'
+        autocompleteInput.dispatchEvent(new Event('input'))
+
+        // select first suggestion
+        suggestionsContainer.children[0].click()
+
+        expect(autocompleteInput.value).toEqual('Arnold Schwarzenegger')
+
+        publish(mockPublisher)
+
+        expect(autocompleteInput.value).toEqual('')
+      })
+    })
+  })
+})

--- a/src/server/common/components/autocomplete/autocomplete.test.js
+++ b/src/server/common/components/autocomplete/autocomplete.test.js
@@ -35,7 +35,7 @@ describe('#autocomplete', () => {
       ]
     })
 
-    // Add suggestions
+    // Add suggestions into the components <script /> tag
     const scriptElement = document.createElement('script')
     scriptElement.innerHTML = $component(
       '[data-testid="app-autocomplete-suggestions"]'
@@ -109,9 +109,9 @@ describe('#autocomplete', () => {
 
       expect(children.length).toEqual(3)
 
-      expect(children[0].textContent).toContain('RoboCopUser Id: 12454878')
-      expect(children[1].textContent).toEqual('Roger RabbitUser Id: 556456465')
-      expect(children[2].textContent).toEqual('BarbieUser Id: 67567576')
+      expect(children[0].textContent).toContain('RoboCop')
+      expect(children[1].textContent).toEqual('Roger Rabbit')
+      expect(children[2].textContent).toEqual('Barbie')
     })
   })
 
@@ -130,9 +130,9 @@ describe('#autocomplete', () => {
 
       expect(children.length).toEqual(3)
 
-      expect(children[0].textContent).toEqual('RoboCopUser Id: 12454878')
-      expect(children[1].textContent).toEqual('Roger RabbitUser Id: 556456465')
-      expect(children[2].textContent).toEqual('BarbieUser Id: 67567576')
+      expect(children[0].textContent).toEqual('RoboCop')
+      expect(children[1].textContent).toEqual('Roger Rabbit')
+      expect(children[2].textContent).toEqual('Barbie')
     })
   })
 
@@ -170,7 +170,7 @@ describe('#autocomplete', () => {
       test('Should narrow to only expected suggestion', () => {
         expect(suggestionsContainer.children.length).toEqual(1)
         expect(suggestionsContainer.children[0].textContent).toEqual(
-          'Roger RabbitUser Id: 556456465'
+          'Roger Rabbit'
         )
       })
     })
@@ -191,11 +191,9 @@ describe('#autocomplete', () => {
 
       test('Should narrow to only expected suggestions', () => {
         expect(suggestionsContainer.children.length).toEqual(2)
-        expect(suggestionsContainer.children[0].textContent).toEqual(
-          'RoboCopUser Id: 12454878'
-        )
+        expect(suggestionsContainer.children[0].textContent).toEqual('RoboCop')
         expect(suggestionsContainer.children[1].textContent).toEqual(
-          'Roger RabbitUser Id: 556456465'
+          'Roger Rabbit'
         )
       })
     })
@@ -210,7 +208,7 @@ describe('#autocomplete', () => {
       test('Should narrow to only expected case insensitive suggestion', () => {
         expect(suggestionsContainer.children.length).toEqual(1)
         expect(suggestionsContainer.children[0].textContent.trim()).toEqual(
-          'BarbieUser Id: 67567576'
+          'Barbie'
         )
       })
     })
@@ -232,10 +230,7 @@ describe('#autocomplete', () => {
         (suggestion) => suggestion.dataset.isMatch === 'true'
       )
 
-      expect(matchedSuggestion.textContent.trim()).toEqual(
-        'BarbieUser Id: 67567576'
-      )
-      expect(matchedSuggestion.children[2].innerHTML).toContain('app-tick-icon')
+      expect(matchedSuggestion.textContent.trim()).toEqual('Barbie')
     })
   })
 
@@ -262,9 +257,9 @@ describe('#autocomplete', () => {
 
       expect(children.length).toEqual(3)
 
-      expect(children[0].textContent).toEqual('RoboCopUser Id: 12454878')
-      expect(children[1].textContent).toEqual('Roger RabbitUser Id: 556456465')
-      expect(children[2].textContent).toEqual('BarbieUser Id: 67567576')
+      expect(children[0].textContent).toEqual('RoboCop')
+      expect(children[1].textContent).toEqual('Roger Rabbit')
+      expect(children[2].textContent).toEqual('Barbie')
     })
   })
 

--- a/src/server/common/components/autocomplete/helpers/build-suggestions.js
+++ b/src/server/common/components/autocomplete/helpers/build-suggestions.js
@@ -1,3 +1,5 @@
+import { pickBy, isNil } from 'lodash'
+
 const defaultSuggestion = {
   text: ' - - select - - ',
   disabled: true,
@@ -7,7 +9,7 @@ const defaultSuggestion = {
 function buildSuggestions(items) {
   const suggestions = items.map((item) => {
     const { value, text, hint } = item
-    return { value, text, hint }
+    return pickBy({ value, text, hint }, (value) => !isNil(value))
   })
 
   suggestions.unshift(defaultSuggestion)

--- a/src/server/common/components/autocomplete/helpers/build-suggestions.test.js
+++ b/src/server/common/components/autocomplete/helpers/build-suggestions.test.js
@@ -1,1 +1,134 @@
-test.todo('#buildSuggestions')
+import { relativeDate } from '~/src/server/common/helpers/date/relative-date'
+import { availableVersionsFixture } from '~/src/__fixtures__/available-versions'
+import { buildSuggestions } from '~/src/server/common/components/autocomplete/helpers/build-suggestions'
+
+describe('#buildSuggestions', () => {
+  test('Should provide expected suggestions with hint', () => {
+    expect(
+      buildSuggestions(
+        availableVersionsFixture.map((version) => ({
+          text: `${version.tag} - ${relativeDate(version.created)}`,
+          value: version.tag,
+          hint: relativeDate(version.created)
+        }))
+      )
+    ).toEqual([
+      {
+        attributes: {
+          selected: true
+        },
+        disabled: true,
+        text: ' - - select - - '
+      },
+      {
+        hint: 'Thu 7th Mar 2024 at 11:48',
+        text: '0.316.0 - Thu 7th Mar 2024 at 11:48',
+        value: '0.316.0'
+      },
+      {
+        hint: 'Wed 6th Mar 2024 at 14:32',
+        text: '0.315.0 - Wed 6th Mar 2024 at 14:32',
+        value: '0.315.0'
+      },
+      {
+        hint: 'Wed 6th Mar 2024 at 13:11',
+        text: '0.314.0 - Wed 6th Mar 2024 at 13:11',
+        value: '0.314.0'
+      },
+      {
+        hint: 'Wed 6th Mar 2024 at 13:06',
+        text: '0.313.0 - Wed 6th Mar 2024 at 13:06',
+        value: '0.313.0'
+      },
+      {
+        hint: 'Tue 5th Mar 2024 at 14:55',
+        text: '0.312.0 - Tue 5th Mar 2024 at 14:55',
+        value: '0.312.0'
+      }
+    ])
+  })
+
+  test('Should provide expected suggestions without hint', () => {
+    expect(
+      buildSuggestions(
+        availableVersionsFixture.map((version) => ({
+          text: `${version.tag} - ${relativeDate(version.created)}`,
+          value: version.tag
+        }))
+      )
+    ).toEqual([
+      {
+        attributes: {
+          selected: true
+        },
+        disabled: true,
+        text: ' - - select - - '
+      },
+      {
+        text: '0.316.0 - Thu 7th Mar 2024 at 11:48',
+        value: '0.316.0'
+      },
+      {
+        text: '0.315.0 - Wed 6th Mar 2024 at 14:32',
+        value: '0.315.0'
+      },
+      {
+        text: '0.314.0 - Wed 6th Mar 2024 at 13:11',
+        value: '0.314.0'
+      },
+      {
+        text: '0.313.0 - Wed 6th Mar 2024 at 13:06',
+        value: '0.313.0'
+      },
+      {
+        text: '0.312.0 - Tue 5th Mar 2024 at 14:55',
+        value: '0.312.0'
+      }
+    ])
+  })
+
+  test('Should only remove items that are null or undefined', () => {
+    const falseyValues = [null, undefined, 0, false, '']
+
+    expect(
+      buildSuggestions(
+        availableVersionsFixture.map((version, i) => ({
+          text: `${version.tag} - ${relativeDate(version.created)}`,
+          value: version.tag,
+          hint: falseyValues.at(i)
+        }))
+      )
+    ).toEqual([
+      {
+        attributes: {
+          selected: true
+        },
+        disabled: true,
+        text: ' - - select - - '
+      },
+      {
+        text: '0.316.0 - Thu 7th Mar 2024 at 11:48',
+        value: '0.316.0'
+      },
+      {
+        text: '0.315.0 - Wed 6th Mar 2024 at 14:32',
+        value: '0.315.0'
+      },
+      {
+        hint: 0,
+        text: '0.314.0 - Wed 6th Mar 2024 at 13:11',
+        value: '0.314.0'
+      },
+      {
+        hint: false,
+        text: '0.313.0 - Wed 6th Mar 2024 at 13:06',
+        value: '0.313.0'
+      },
+      {
+        hint: '',
+        text: '0.312.0 - Tue 5th Mar 2024 at 14:55',
+        value: '0.312.0'
+      }
+    ])
+  })
+})

--- a/src/server/common/components/autocomplete/template.njk
+++ b/src/server/common/components/autocomplete/template.njk
@@ -1,4 +1,3 @@
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/hint/macro.njk" import govukHint %}
 {% from "govuk/components/label/macro.njk" import govukLabel %}
 {% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
@@ -8,14 +7,21 @@
 {% from "loader/macro.njk" import appLoader %}
 
 <script data-testid="app-autocomplete-suggestions">
-  window.suggestions = window.suggestions || {};
-  window.suggestions.{{ params.name }} = {{ params.suggestions | dump | safe }}
+  window.cdp = window.cdp || {}
+  window.cdp.suggestions = window.cdp.suggestions || {};
+  window.cdp.suggestions.{{ params.name }} = {{ params.suggestions | dump | safe }}
 </script>
 
-<div class="govuk-form-group app-form-group{% if params.errorMessage.text %} govuk-form-group--error{% endif %}"
-     data-js="app-form-group" data-testid="app-autocomplete-group">
+{% set content = params.html | safe if params.html else params.text %}
+{% set removePassWidgets = params.removePassWidgets | default("true") %}
 
-  <label class="govuk-label app-label" id="{{ params.id }}-label" for="{{ params.id }}"
+<div
+  class="govuk-form-group app-form-group{% if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}{% if params.errorMessage.text %}govuk-form-group--error{% endif %}"
+  data-js="app-form-group" data-testid="app-autocomplete-group">
+
+  <label class="govuk-label{% if params.label.classes %} {{ params.label.classes }}{% endif %}"
+         id="{{ params.id }}-label"
+         for="{{ params.id }}"
          data-testid="app-autocomplete-label">
     {{ params.label.text }}
   </label>
@@ -42,25 +48,29 @@
   {% endif %}
 
   <div class="app-autocomplete{% if params.classes %} {{ params.classes }}{% endif %}"
-       data-js="app-autocomplete"
+       data-js="app-autocomplete{% if params.template %}-{{ params.template }}{% endif %}"
     {% if params.loader.name %} data-loader="{{ params.loader.name }}"{% endif %}
   >
     <div class="app-autocomplete__control">
       <select name="{{ params.name }}"
               id="{{ params.id }}"
-              class="govuk-select app-select{% if params.errorMessage.text %} govuk-select--error{% endif %}"
+              class="govuk-select app-select app-select--small{% if params.errorMessage.text %} govuk-select--error{%
+                endif %}"
               data-js="app-progressive-input{% if params.dataJs %} {{ params.dataJs }}{% endif %}"
-              {% if params.subscribeTo %}
-                data-subscribe-to="{{ params.subscribeTo }}"
-              {% endif %}
-              {% if params.previousChoiceMessage %}
-                data-previous-choice-message="{{ params.previousChoiceMessage }}"
-              {% endif %}
+        {% if params.subscribeTo %}
+          data-subscribe-to="{{ params.subscribeTo }}"
+        {% endif %}
+        {% if params.noSuggestionsMessage %}
+          data-no-suggestions-message="{{ params.noSuggestionsMessage }}"
+        {% endif %}
+        {% if removePassWidgets %}
+          data-remove-pass-widgets="{{ removePassWidgets }}"
+        {% endif %}
               data-testid="app-progressive-input">
         {% for suggestion in params.suggestions %}
           <option value="{{ suggestion.value }}"
                   {% if params.value == suggestion.value %}selected="selected"{% endif %}>
-            {{ suggestion.text }}
+            {{ suggestion.text }}{{ " - " + suggestion.hint if suggestion.hint }}
           </option>
         {% endfor %}
       </select>
@@ -99,14 +109,7 @@
         data-js="app-autocomplete-suggestions"
         data-testid="app-autocomplete-suggestions"></ul>
   </div>
-
-  {{ govukButton({
-    classes: "app-button app-button--secondary govuk-!-margin-bottom-4 js-hidden",
-    text: "Search",
-    attributes: {
-      "data-js": "app-no-js-submit-button"
-    }
-  }) }}
+  {{ caller() if caller else content }}
 </div>
 
 

--- a/src/server/common/components/entity-list/_entity-list.scss
+++ b/src/server/common/components/entity-list/_entity-list.scss
@@ -6,12 +6,12 @@
 }
 
 .app-entity-list__header {
-  @include govuk-font(24, "bold");
+  @include govuk-font(19, "bold");
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   line-height: 1.4;
-  padding: govuk-spacing(2) 0;
+  padding: 0 0 govuk-spacing(2);
 }
 
 .app-entity-list__table {
@@ -84,8 +84,4 @@
 .app-entity-list__item--massive {
   flex: 10;
   max-width: 400px;
-}
-
-.app-entity-list__footer {
-  margin: govuk-spacing(4) auto;
 }

--- a/src/server/common/components/entity-list/template.njk
+++ b/src/server/common/components/entity-list/template.njk
@@ -3,10 +3,10 @@
 {% from "entity/macro.njk" import appEntity with context %}
 
 <article class="app-entity-list"
-         data-testid="app-entity-list"{% if params.id %} data-xhr="{{ params.id }}"{% endif %}>
+         data-testid="app-entity-list">
   <header class="app-entity-list__header" data-testid="app-entity-list-header">
     {% for heading in params.headings %}
-      <div class=" app-entity-list__item app-entity-list__item--{{ heading.size }}"
+      <div class="app-entity-list__item app-entity-list__item--{{ heading.size }}"
            data-testid="app-entity-list-item-{{ loop.index }}">
         {{ heading.text }}
       </div>
@@ -19,8 +19,13 @@
           data-testid="app-entity-list-row-{{ loop.index }}">
 
         {% for entity in entityRow %}
-          <div class="app-entity-list__item app-entity-list__item--{{ params.headings[loop.index0].size }}{% if
-            entity.kind !== "tag" %} app-entity-list__item--ellipsis{% endif %}"
+          {% set headingDetail = params.headings[loop.index0] %}
+          {% set classes = [
+            "app-entity-list__item",
+            "app-entity-list__item--" + headingDetail.size
+          ] | compact %}
+
+          <div class="{{ classes | join(" ")  }}"
                data-testid="app-entity-list-item-{{ loop.index }}">
             {{ appEntity(entity | assign({}, {index: loop.index}, entity)) }}
           </div>
@@ -33,7 +38,7 @@
   </ul>
 
   {% if params.pagination.items.length > 1 %}
-    <footer class="app-entity-list__footer">
+    <footer>
       {{ govukPagination(params.pagination | assign({}, {classes: "app-pagination"}, params.pagination)) }}
     </footer>
   {% endif %}

--- a/src/server/common/components/entity-list/template.test.js
+++ b/src/server/common/components/entity-list/template.test.js
@@ -17,7 +17,6 @@ describe('Entity List Component', () => {
 
     beforeEach(() => {
       $entityList = renderTestComponent('entity-list', {
-        id: 'services',
         headings: [
           { text: 'Service', size: 'large' },
           { text: 'Version', size: 'small' },

--- a/src/server/common/components/filters/_filters.scss
+++ b/src/server/common/components/filters/_filters.scss
@@ -1,0 +1,33 @@
+.app-filters-form {
+  padding: govuk-spacing(4);
+  margin: govuk-spacing(4) govuk-spacing(-2) govuk-spacing(2);
+  background-color: $app-light-grey;
+  border-radius: $app-border-radius;
+}
+
+.app-filters {
+  @include govuk-media-query($from: desktop-wide) {
+    display: flex;
+  }
+}
+
+.app-filters__item {
+  margin-bottom: govuk-spacing(4);
+
+  @include govuk-media-query($from: desktop-wide) {
+    align-self: flex-end;
+    margin-right: govuk-spacing(2);
+    margin-bottom: 0;
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+}
+
+.app-filters__clear-all {
+  @include govuk-media-query($from: desktop-wide) {
+    flex: 4em;
+    align-self: flex-end;
+  }
+}

--- a/src/server/common/components/filters/filters.js
+++ b/src/server/common/components/filters/filters.js
@@ -1,0 +1,61 @@
+import { debounce, isFunction } from 'lodash'
+
+import { xhrRequest } from '~/src/client/common/helpers/xhr'
+
+function filters($form) {
+  if (!$form) {
+    return
+  }
+
+  const $clearAll = $form.querySelector('[data-js="app-filters-clear-all"]')
+
+  if ($clearAll) {
+    const clearAllFiltersName = $clearAll.dataset.clearAll
+    const clearFiltersFunction = window.cdp[clearAllFiltersName]
+
+    if (!isFunction(clearFiltersFunction)) {
+      return
+    }
+
+    $clearAll.addEventListener('click', clearFiltersFunction)
+  }
+
+  $form.addEventListener('input', debounce(handleFormSubmit, 300)) // minimal debounce whilst user is typing
+  $form.addEventListener('submit', handleFormSubmit)
+}
+
+function handleFormSubmit(event) {
+  const form = event.target.closest('form')
+  event.preventDefault()
+
+  submitForm(form).catch((error) => {
+    throw new Error(error)
+  })
+}
+
+async function submitForm($form) {
+  if ($form.dataset.isSubmitting === 'true') {
+    return
+  }
+
+  $form.dataset.isSubmitting = 'true'
+
+  const queryParams = Array.from($form.elements).reduce(
+    (validElements, element) => {
+      if (element.name && element.value) {
+        return {
+          ...validElements,
+          [element.name]: element.value
+        }
+      }
+      return validElements
+    },
+    {}
+  )
+
+  await xhrRequest($form.action, queryParams)
+
+  $form.dataset.isSubmitting = 'false'
+}
+
+export { filters }

--- a/src/server/common/components/filters/filters.test.js
+++ b/src/server/common/components/filters/filters.test.js
@@ -1,0 +1,1 @@
+test.todo('#filters')

--- a/src/server/common/components/filters/macro.njk
+++ b/src/server/common/components/filters/macro.njk
@@ -1,0 +1,3 @@
+{% macro appFilters(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/server/common/components/filters/template.njk
+++ b/src/server/common/components/filters/template.njk
@@ -1,0 +1,19 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set method = params.method | default("get") %}
+
+<form action="{{ params.action }}" method="{{ method }}" class="app-filters-form" data-js="app-filters">
+  {{ caller() }}
+
+  {% for key, value in params.hiddenInputs %}
+    <input type="hidden" name="{{ key }}" value="{{ value }}">
+  {% endfor %}
+
+  {{ govukButton({
+    classes: "app-button app-button--secondary js-hidden govuk-!-margin-top-2",
+    text: params.noJsButton.text,
+    attributes: {
+      "data-js": "app-no-js-submit-button"
+    }
+  }) }}
+</form>

--- a/src/server/common/components/list/_list.scss
+++ b/src/server/common/components/list/_list.scss
@@ -34,7 +34,7 @@
 
   // Highlight associated list content with list action button hover
   &:hover ~ .app-list-item__content {
-    color: govuk-tint(govuk-colour('black'), 40%);
+    color: govuk-tint(govuk-colour("black"), 40%);
 
     a {
       text-decoration: underline;

--- a/src/server/common/components/select/_select.scss
+++ b/src/server/common/components/select/_select.scss
@@ -17,6 +17,10 @@
   min-width: 4em;
 }
 
+.app-select--small {
+  min-width: 10em;
+}
+
 .app-select--wide {
   min-width: 24em;
 }

--- a/src/server/common/components/tabs/_tabs.scss
+++ b/src/server/common/components/tabs/_tabs.scss
@@ -1,5 +1,5 @@
 .app-tabs {
-  margin-top: govuk-spacing(4);
+  margin-top: 0;
 }
 
 .app-tabs__list {
@@ -19,7 +19,7 @@
 }
 
 .app-tabs__panel {
-  padding: govuk-spacing(4) govuk-spacing(2) 0;
+  padding: govuk-spacing(4) govuk-spacing(2);
 }
 
 @include govuk-media-query($from: tablet) {
@@ -48,7 +48,7 @@
     margin-top: govuk-spacing(2);
     margin-bottom: -$border-width;
 
-    border: $border-width solid $govuk-border-colour;
+    border: $border-width solid $app-mid-grey;
     border-bottom: 0;
     border-radius: $app-border-radius $app-border-radius 0 0;
     background-color: $govuk-body-background-colour;
@@ -59,7 +59,7 @@
   }
 
   .app-tabs__panel {
-    border-top: 1px solid $govuk-border-colour;
+    border-top: 1px solid $app-mid-grey;
     margin-left: govuk-spacing(-2);
     margin-right: govuk-spacing(-2);
   }

--- a/src/server/common/components/tabs/tabs.js
+++ b/src/server/common/components/tabs/tabs.js
@@ -1,29 +1,27 @@
 import qs from 'qs'
-import { isEmpty } from 'lodash'
 
-import { subscribe } from '~/src/client/common/helpers/event-emitter'
-import { eventName } from '~/src/client/common/constants/event-name'
+function prependQueryParams($tab, params) {
+  const hrefParts = $tab.href.split('?')
+  const href = hrefParts.at(0)
 
-function prependQueryParams($tab, queryParamString) {
-  const href = $tab.href.includes('?') ? $tab.href.split('?')[0] : $tab.href
-
-  $tab.href = href + queryParamString
+  $tab.href = href + qs.stringify(params, { addQueryPrefix: true })
 }
 
 function tabs($module) {
-  const queryParamString = location?.search
+  const params = qs.parse(location.search, { ignoreQueryPrefix: true })
   const $tabs = Array.from($module.querySelectorAll(`[data-js="app-tab"]`))
 
   document.addEventListener('DOMContentLoaded', () => {
-    $tabs.forEach(($tab) => prependQueryParams($tab, queryParamString))
+    $tabs.forEach(($tab) => prependQueryParams($tab, params))
   })
 
-  subscribe(eventName.xhrUpdate, (event) => {
-    const queryParamString = isEmpty(event.detail.params)
-      ? ''
-      : `?${qs.stringify(event.detail.params)}`
+  window.navigation.addEventListener('navigate', (event) => {
+    const searchString = event.destination.url.split('?').at(1)
+    const destinationParams = qs.parse(searchString, {
+      ignoreQueryPrefix: true
+    })
 
-    $tabs.forEach(($tab) => prependQueryParams($tab, queryParamString))
+    $tabs.forEach(($tab) => prependQueryParams($tab, destinationParams))
   })
 }
 

--- a/src/server/common/components/tabs/template.njk
+++ b/src/server/common/components/tabs/template.njk
@@ -16,7 +16,7 @@
   {% for tab in params.tabs %}
     {% if tab.isActive %}
       {% set content = tab.panel.html | safe if tab.panel.html else tab.panel.text %}
-      <div class="app-tabs__panel" data-testid="app-tabs-panel">
+      <section class="app-tabs__panel" data-testid="app-tabs-panel">
         {% if tabBreadcrumbs and tabBreadcrumbs.length > 1 %}
           {{ appBreadcrumbs({
             classes: "app-breadcrumbs--nested",
@@ -25,7 +25,7 @@
         {% endif %}
 
         {{ caller() if caller else content }}
-      </div>
+      </section>
     {% endif %}
   {% endfor %}
 </div>

--- a/src/server/common/constants/pagination.js
+++ b/src/server/common/constants/pagination.js
@@ -1,0 +1,6 @@
+const pagination = {
+  page: 1,
+  size: 50
+}
+
+export { pagination }

--- a/src/server/common/helpers/sort/sort-by-env.js
+++ b/src/server/common/helpers/sort/sort-by-env.js
@@ -1,7 +1,5 @@
 const order = ['infra-dev', 'management', 'dev', 'test', 'perf-test', 'prod']
 
-const sortByEnv = (a, b) => {
-  return order.indexOf(a) - order.indexOf(b)
-}
+const sortByEnv = (a, b) => order.indexOf(a) - order.indexOf(b)
 
 export { sortByEnv }

--- a/src/server/common/templates/layouts/page.njk
+++ b/src/server/common/templates/layouts/page.njk
@@ -1,10 +1,11 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
-{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
 {% from "autocomplete/macro.njk" import appAutocomplete %}
@@ -14,6 +15,7 @@
 {% from "entity-actions/macro.njk" import appEntityActions %}
 {% from "entity-data-list/macro.njk" import appEntityDataList with context %}
 {% from "entity-list/macro.njk" import appEntityList with context %}
+{% from "filters/macro.njk" import appFilters %}
 {% from "footer/macro.njk" import appFooter with context %}
 {% from "header/macro.njk" import appHeader with context %}
 {% from "heading/macro.njk" import appHeading %}

--- a/src/server/deploy-service/controllers/available-versions.js
+++ b/src/server/deploy-service/controllers/available-versions.js
@@ -9,7 +9,7 @@ const availableVersionsController = {
       )
 
       return availableVersions.map((version) => ({
-        text: `${version.tag} - ${relativeDate(version.created)}`,
+        text: version.tag,
         value: version.tag,
         hint: relativeDate(version.created)
       }))

--- a/src/server/deploy-service/controllers/deploy/details-form.js
+++ b/src/server/deploy-service/controllers/deploy/details-form.js
@@ -28,7 +28,7 @@ async function getAdditionalData(imageName) {
   const availableVersions = await fetchAvailableVersions(imageName)
   const availableVersionOptions = buildSuggestions(
     availableVersions.map((version) => ({
-      text: `${version.tag} - ${relativeDate(version.created)}`,
+      text: version.tag,
       value: version.tag,
       hint: relativeDate(version.created)
     }))

--- a/src/server/deploy-service/controllers/deploy/details.js
+++ b/src/server/deploy-service/controllers/deploy/details.js
@@ -23,7 +23,8 @@ const detailsController = {
     const validationResult = serviceValidation(
       deployableImageNames,
       availableVersions.map((version) => version.tag),
-      environments
+      environments,
+      payload.button
     ).validate(payload, {
       abortEarly: false
     })
@@ -34,6 +35,23 @@ const detailsController = {
       request.yar.flash(sessionNames.validationFailure, {
         formValues: payload,
         formErrors: errorDetails
+      })
+
+      const imageName = payload?.imageName
+      const queryString = qs.stringify(
+        {
+          ...(redirectLocation && { redirectLocation }),
+          ...(imageName && { imageName })
+        },
+        { addQueryPrefix: true }
+      )
+
+      return h.redirect(`/deploy-service/details${queryString}`)
+    }
+
+    if (!validationResult.error && payload.button === 'search') {
+      request.yar.flash(sessionNames.validationFailure, {
+        formValues: payload
       })
 
       const imageName = payload?.imageName

--- a/src/server/deploy-service/helpers/schema/service-validation.js
+++ b/src/server/deploy-service/helpers/schema/service-validation.js
@@ -1,6 +1,31 @@
 import Joi from 'joi'
 
-function serviceValidation(imageNames, availableVersions, environments) {
+function serviceValidation(
+  imageNames,
+  availableVersions,
+  environments,
+  buttonValue
+) {
+  // No clientside js fallback search
+  if (buttonValue === 'search') {
+    return Joi.object({
+      imageName: Joi.string()
+        .valid(...imageNames)
+        .required()
+        .messages({
+          'any.only': 'Choose an entry',
+          'any.required': 'Choose an entry',
+          'string.empty': 'Choose an entry'
+        }),
+      version: Joi.string().allow(null, ''),
+      environment: Joi.string()
+        .valid(...environments)
+        .allow(null, ''),
+      button: Joi.string().valid('search'),
+      redirectLocation: Joi.string().valid('summary', '')
+    })
+  }
+
   return Joi.object({
     imageName: Joi.string()
       .valid(...imageNames)
@@ -26,6 +51,7 @@ function serviceValidation(imageNames, availableVersions, environments) {
         'any.only': 'Choose an entry',
         'any.required': 'Choose an entry'
       }),
+    button: Joi.string().valid('submit'),
     redirectLocation: Joi.string().valid('summary', '')
   })
 }

--- a/src/server/deploy-service/views/details-form.njk
+++ b/src/server/deploy-service/views/details-form.njk
@@ -52,7 +52,7 @@
               items: deployableImageNameOptions
             }) }}
 
-            {{ appAutocomplete({
+            {% call appAutocomplete({
               id: "version",
               name: "version",
               label: {
@@ -61,10 +61,11 @@
               hint: {
                 text: "Elastic Container Registry (ECR) image version"
               },
+              template: "advanced",
               value: formValues.version,
               dataJs: "deploy-version",
               subscribeTo: eventName.autocompleteUpdate + "-version",
-              previousChoiceMessage:"choose Image name",
+              noSuggestionsMessage: "choose Image name",
               errorMessage: {
                 text: formErrors.version.message
               },
@@ -72,7 +73,19 @@
               loader: {
                 name: "deploy-version-loader"
               }
-            }) }}
+            }) %}
+
+              {{ govukButton({
+                classes: "app-button app-button--secondary js-hidden",
+                text: "Search",
+                name: "button",
+                value: "search",
+                attributes: {
+                  "data-js": "app-no-js-submit-button"
+                }
+              }) }}
+
+            {% endcall %}
 
             {{ govukSelect({
               id: "environment",
@@ -104,7 +117,9 @@
 
           {{ govukButton({
             classes: "app-button",
-            text: formButtonText
+            text: formButtonText,
+            name: "button",
+            value: "submit"
           }) }}
 
         </form>

--- a/src/server/deployments/controllers/deployment.js
+++ b/src/server/deployments/controllers/deployment.js
@@ -5,6 +5,7 @@ import { capitalize, isNull } from 'lodash'
 import { environments } from '~/src/config'
 import { provideDeployment } from '~/src/server/deployments/helpers/pre/provide-deployment'
 import { allEnvironmentsOnlyForAdmin } from '~/src/server/deployments/helpers/ext/all-environments-only-for-admin'
+import { pagination } from '~/src/server/common/constants/pagination'
 
 const deploymentController = {
   options: {
@@ -35,7 +36,7 @@ const deploymentController = {
       tabBreadcrumbs: [
         {
           text: capitalize(deployment.environment),
-          href: `/deployments/${deployment.environment}`
+          href: `/deployments/${deployment.environment}?page=${pagination.page}&size=${pagination.size}`
         },
         {
           text: `${deployment.service} - ${deployment.version}`

--- a/src/server/deployments/controllers/deployments-list.js
+++ b/src/server/deployments/controllers/deployments-list.js
@@ -7,11 +7,14 @@ import { deploymentsToEntityRow } from '~/src/server/deployments/transformers/de
 import { fetchDeployments } from '~/src/server/deployments/helpers/fetch/fetch-deployments'
 import { buildPagination } from '~/src/server/common/helpers/build-pagination'
 import { allEnvironmentsOnlyForAdmin } from '~/src/server/deployments/helpers/ext/all-environments-only-for-admin'
+import { buildSuggestions } from '~/src/server/common/components/autocomplete/helpers/build-suggestions'
+import { provideFormValues } from '~/src/server/deployments/helpers/ext/provide-form-values'
 
 const deploymentsListController = {
   options: {
     ext: {
-      onPreAuth: [allEnvironmentsOnlyForAdmin]
+      onPreAuth: [allEnvironmentsOnlyForAdmin],
+      onPostHandler: [provideFormValues]
     },
     validate: {
       params: Joi.object({

--- a/src/server/deployments/controllers/deployments-list.js
+++ b/src/server/deployments/controllers/deployments-list.js
@@ -1,10 +1,9 @@
 import Joi from 'joi'
 import Boom from '@hapi/boom'
-import { capitalize } from 'lodash'
+import { capitalize, upperFirst } from 'lodash'
 
 import { environments } from '~/src/config'
 import { deploymentsToEntityRow } from '~/src/server/deployments/transformers/deployments-to-entity-row'
-import { fetchDeployments } from '~/src/server/deployments/helpers/fetch/fetch-deployments'
 import { buildPagination } from '~/src/server/common/helpers/build-pagination'
 import { allEnvironmentsOnlyForAdmin } from '~/src/server/deployments/helpers/ext/all-environments-only-for-admin'
 import { buildSuggestions } from '~/src/server/common/components/autocomplete/helpers/build-suggestions'
@@ -22,10 +21,10 @@ const deploymentsListController = {
       }),
       query: Joi.object({
         service: Joi.string().allow(''),
-        user: Joi.string().allow(''), // TODO this should be userId?
+        user: Joi.string().allow(''),
         status: Joi.string().allow(''),
-        page: Joi.number().default(1),
-        size: Joi.number().default(100)
+        page: Joi.number(),
+        size: Joi.number()
       }),
       failAction: () => Boom.boomify(Boom.notFound())
     }
@@ -33,21 +32,54 @@ const deploymentsListController = {
   handler: async (request, h) => {
     const environment = request.params?.environment
 
-    const { data, page, pageSize, totalPages } = await fetchDeployments(
-      environment,
-      { page: request.query?.page, size: request.query?.size }
+    const filtersResponse = await request.server.methods.fetchFilters()
+    const serviceFilters = buildSuggestions(
+      filtersResponse.filters.services.map((serviceName) => ({
+        text: serviceName,
+        value: serviceName
+      }))
     )
+
+    const userFilters = buildSuggestions(
+      filtersResponse.filters.users.map((user) => ({
+        text: user.displayName,
+        value: user.id
+      }))
+    )
+
+    const order = ['running', 'pending', 'stopped', 'stopping']
+    const statusFilters = buildSuggestions(
+      filtersResponse.filters.statuses
+        .sort((a, b) => order.indexOf(a) - order.indexOf(b))
+        .map((status) => ({
+          text: upperFirst(status),
+          value: status
+        }))
+    )
+
+    const { data, page, pageSize, totalPages } =
+      await request.server.methods.fetchDeployments(environment, {
+        page: request.query?.page,
+        size: request.query?.size,
+        service: request.query.service,
+        user: request.query.user,
+        status: request.query.status
+      })
 
     const entityRows = data?.map(deploymentsToEntityRow)
 
     return h.view('deployments/views/list', {
       pageTitle: 'Deployments',
       heading: 'Deployments',
-      caption: 'Microservice deployment details across all environments.',
+      caption: 'Microservice deployment details.',
+      serviceFilters,
+      userFilters,
+      statusFilters,
       entityRows,
       environment,
+      hiddenInputs: { page, size: pageSize },
       pagination: buildPagination(page, pageSize, totalPages, request.query),
-      noResult: `Currently there are no deployments in ${capitalize(
+      noResult: `Nothing has matched what you are looking for in ${capitalize(
         environment
       )}`
     })

--- a/src/server/deployments/helpers/ext/provide-form-values.js
+++ b/src/server/deployments/helpers/ext/provide-form-values.js
@@ -1,0 +1,29 @@
+const provideFormValues = {
+  method: async (request, h) => {
+    const response = request.response
+
+    if (response.variety === 'view') {
+      if (!response.source?.context) {
+        response.source.context = {}
+      }
+
+      const query = request.query
+      const service = query.service
+      const user = query.user
+      const status = query.status
+
+      response.source.context.formValues = {
+        ...(service && { service }),
+        ...(user && { user }),
+        ...(status && { status })
+      }
+    }
+
+    return h.continue
+  },
+  options: {
+    before: ['yar']
+  }
+}
+
+export { provideFormValues }

--- a/src/server/deployments/helpers/fetch/fetch-filters.js
+++ b/src/server/deployments/helpers/fetch/fetch-filters.js
@@ -1,0 +1,11 @@
+import { config } from '~/src/config'
+import { fetcher } from '~/src/server/common/helpers/fetch/fetcher'
+
+async function fetchFilters() {
+  const endpoint = config.get('portalBackendApiUrl') + '/v2/deployments/filters'
+
+  const { json } = await fetcher(endpoint)
+  return json
+}
+
+export { fetchFilters }

--- a/src/server/deployments/helpers/provide-tabs.js
+++ b/src/server/deployments/helpers/provide-tabs.js
@@ -1,3 +1,7 @@
+import { pagination } from '~/src/server/common/constants/pagination'
+
+const paginationParams = `?page=${pagination.page}&size=${pagination.size}`
+
 async function provideTabs(request, h) {
   const authedUser = await request.getUserSession()
   const response = request.response
@@ -10,22 +14,22 @@ async function provideTabs(request, h) {
     response.source.context.tabs = [
       {
         isActive: request.path.startsWith('/deployments/dev'),
-        url: '/deployments/dev',
+        url: `/deployments/dev${paginationParams}`,
         label: 'Dev'
       },
       {
         isActive: request.path.startsWith('/deployments/test'),
-        url: '/deployments/test',
+        url: `/deployments/test${paginationParams}`,
         label: 'Test'
       },
       {
         isActive: request.path.startsWith('/deployments/perf-test'),
-        url: '/deployments/perf-test',
+        url: `/deployments/perf-test${paginationParams}`,
         label: 'Perf-test'
       },
       {
         isActive: request.path.startsWith('/deployments/prod'),
-        url: '/deployments/prod',
+        url: `/deployments/prod${paginationParams}`,
         label: 'Prod'
       }
     ]
@@ -34,12 +38,12 @@ async function provideTabs(request, h) {
       response.source.context.tabs.unshift(
         {
           isActive: request.path.startsWith('/deployments/infra-dev'),
-          url: '/deployments/infra-dev',
+          url: `/deployments/infra-dev${paginationParams}`,
           label: 'Infra-dev'
         },
         {
           isActive: request.path.startsWith('/deployments/management'),
-          url: '/deployments/management',
+          url: `/deployments/management${paginationParams}`,
           label: 'Management'
         }
       )

--- a/src/server/deployments/helpers/provide-tabs.test.js
+++ b/src/server/deployments/helpers/provide-tabs.test.js
@@ -32,32 +32,32 @@ describe('#provideTabs', () => {
         {
           isActive: false,
           label: 'Infra-dev',
-          url: '/deployments/infra-dev'
+          url: '/deployments/infra-dev?page=1&size=50'
         },
         {
           isActive: false,
           label: 'Management',
-          url: '/deployments/management'
+          url: '/deployments/management?page=1&size=50'
         },
         {
           isActive: false,
           label: 'Dev',
-          url: '/deployments/dev'
+          url: '/deployments/dev?page=1&size=50'
         },
         {
           isActive: false,
           label: 'Test',
-          url: '/deployments/test'
+          url: '/deployments/test?page=1&size=50'
         },
         {
           isActive: false,
           label: 'Perf-test',
-          url: '/deployments/perf-test'
+          url: '/deployments/perf-test?page=1&size=50'
         },
         {
           isActive: false,
           label: 'Prod',
-          url: '/deployments/prod'
+          url: '/deployments/prod?page=1&size=50'
         }
       ])
     })
@@ -76,32 +76,32 @@ describe('#provideTabs', () => {
         {
           isActive: true,
           label: 'Infra-dev',
-          url: '/deployments/infra-dev'
+          url: '/deployments/infra-dev?page=1&size=50'
         },
         {
           isActive: false,
           label: 'Management',
-          url: '/deployments/management'
+          url: '/deployments/management?page=1&size=50'
         },
         {
           isActive: false,
           label: 'Dev',
-          url: '/deployments/dev'
+          url: '/deployments/dev?page=1&size=50'
         },
         {
           isActive: false,
           label: 'Test',
-          url: '/deployments/test'
+          url: '/deployments/test?page=1&size=50'
         },
         {
           isActive: false,
           label: 'Perf-test',
-          url: '/deployments/perf-test'
+          url: '/deployments/perf-test?page=1&size=50'
         },
         {
           isActive: false,
           label: 'Prod',
-          url: '/deployments/prod'
+          url: '/deployments/prod?page=1&size=50'
         }
       ])
     })
@@ -118,22 +118,22 @@ describe('#provideTabs', () => {
         {
           isActive: false,
           label: 'Dev',
-          url: '/deployments/dev'
+          url: '/deployments/dev?page=1&size=50'
         },
         {
           isActive: false,
           label: 'Test',
-          url: '/deployments/test'
+          url: '/deployments/test?page=1&size=50'
         },
         {
           isActive: false,
           label: 'Perf-test',
-          url: '/deployments/perf-test'
+          url: '/deployments/perf-test?page=1&size=50'
         },
         {
           isActive: false,
           label: 'Prod',
-          url: '/deployments/prod'
+          url: '/deployments/prod?page=1&size=50'
         }
       ])
     })
@@ -152,22 +152,22 @@ describe('#provideTabs', () => {
         {
           isActive: true,
           label: 'Dev',
-          url: '/deployments/dev'
+          url: '/deployments/dev?page=1&size=50'
         },
         {
           isActive: false,
           label: 'Test',
-          url: '/deployments/test'
+          url: '/deployments/test?page=1&size=50'
         },
         {
           isActive: false,
           label: 'Perf-test',
-          url: '/deployments/perf-test'
+          url: '/deployments/perf-test?page=1&size=50'
         },
         {
           isActive: false,
           label: 'Prod',
-          url: '/deployments/prod'
+          url: '/deployments/prod?page=1&size=50'
         }
       ])
     })

--- a/src/server/deployments/views/list.njk
+++ b/src/server/deployments/views/list.njk
@@ -5,26 +5,109 @@
     title: heading,
     caption: caption
   }) }}
+
+  {% call appFilters({
+    action: "/deployments/" + environment,
+    noJsButton: {
+      text: "Search"
+    },
+    hiddenInputs: hiddenInputs
+  }) %}
+    {% call govukFieldset({
+      legend: {
+        text: "Search deployments",
+        classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-2"
+      }
+    }) %}
+      <p class="govuk-caption-m govuk-!-margin-bottom-3">
+        Search and filter microservice deployments across all environments.
+      </p>
+
+      <div class="app-filters">
+        <div class="app-filters__item">
+          {{ appAutocomplete({
+            id: "filters-service",
+            name: "service",
+            classes: "app-autocomplete--small app-autocomplete--inline",
+            label: {
+              text: "Service name",
+              classes: "govuk-label--s app-label--inline govuk-!-margin-bottom-1"
+            },
+            formGroup: {
+              classes: "app-form-group--inline"
+            },
+            value: formValues.service,
+            suggestions: serviceFilters
+          }) }}
+        </div>
+
+        <div class="app-filters__item">
+          {{ appAutocomplete({
+            id: "filters-status",
+            name: "status",
+            classes: "app-autocomplete--tiny app-autocomplete--inline",
+            label: {
+              text: "Status",
+              classes: "govuk-label--s app-label--inline govuk-!-margin-bottom-1"
+            },
+            formGroup: {
+              classes: "app-form-group--inline"
+            },
+            value: formValues.status,
+            suggestions: statusFilters
+          }) }}
+        </div>
+
+        <div class="app-filters__item">
+          {{ appAutocomplete({
+            id: "filters-user",
+            name: "user",
+            classes: "app-autocomplete--inline",
+            label: {
+              text: "User",
+              classes: "govuk-label--s app-label--inline govuk-!-margin-bottom-1"
+            },
+            formGroup: {
+              classes: "app-form-group--inline"
+            },
+            value: formValues.user,
+            suggestions: userFilters
+          }) }}
+        </div>
+
+        <p class="govuk-body-m govuk-!-margin-bottom-0 app-filters__clear-all">
+          <a href="/deployments/{{ environment }}"
+             class="govuk-link govuk-link--text-colour"
+             data-clear-all="clearDeploymentsListFilters"
+             data-js="app-filters-clear-all">
+            Clear all
+          </a>
+        </p>
+      </div>
+
+    {% endcall %}
+
+  {% endcall %}
+
 {% endblock %}
 
-{% block tabContent %}
+  {% block tabContent %}
+    {% block xhrContent %}
 
-  {% block xhrContent %}
+      <div data-xhr="deployments">
+        {{ appEntityList({
+          headings: [
+            { text: "Service deployment", size: "large" },
+            { text: "Version", size: "small" },
+            { text: "Status", size: "small" },
+            { text: "User", size: "massive" },
+            { text: "Created", size: "large" }
+          ],
+          entityRows: entityRows,
+          noResult: noResult,
+          pagination: pagination
+        }) }}
+      </div>
 
-    {{ appEntityList({
-      id: "deployments",
-      headings: [
-        { text: "Deployment", size: "medium" },
-        { text: "Version", size: "small" },
-        { text: "Status", size: "small" },
-        { text: "User", size: "large" },
-        { text: "Created", size: "large" }
-      ],
-      entityRows: entityRows,
-      noResult: noResult,
-      pagination: pagination
-    }) }}
-
+    {% endblock %}
   {% endblock %}
-
-{% endblock %}

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -68,6 +68,7 @@ async function createServer() {
     ]
   })
 
+  // TODO refactor cache and decorate it on to server and request. No need for it to be on server.app
   server.app.cache = server.cache({
     cache: 'session',
     segment: config.get('serverCacheSegment'),


### PR DESCRIPTION
Add progressive search and filtering to deployments list page to enable easy searching and filtering of deployments by `serviceName`, `user` and `status` across all `cdp` environments.

- Updates to `autocomplete` component
- Add server method caching for filters and deployments calls
- Create filters component
- Add work to use browser query params as state
- Brining in clientSide `window.cdp` namespace

## Associated PR
https://github.com/DEFRA/cdp-portal-backend/pull/147

## Demo
![search-and-filter-deployments](https://github.com/DEFRA/cdp-portal-frontend/assets/2305016/482c384f-bc92-4881-9954-2e9c073714e7)

<img width="2549" alt="Screenshot 2024-05-17 at 09 31 45" src="https://github.com/DEFRA/cdp-portal-frontend/assets/2305016/a5f114e6-8664-4788-b780-1126cf03ed2f">
