### PR TITLE
Proxy fetch in oidc calls, and jest jsdom fix

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   rootDir: '.',
-  testEnvironment: 'jsdom',
+  testEnvironment: 'jest-fixed-jsdom',
   verbose: true,
   resetModules: true,
   clearMocks: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "pino": "8.20.0",
         "pino-pretty": "11.0.0",
         "qs": "6.12.1",
+        "undici": "6.14.1",
         "useragent": "2.3.0",
         "uuid": "9.0.1"
       },
@@ -73,6 +74,7 @@
         "jest": "29.7.0",
         "jest-environment-jsdom": "29.7.0",
         "jest-fetch-mock": "3.0.3",
+        "jest-fixed-jsdom": "0.0.2",
         "json-server": "0.17.4",
         "mini-css-extract-plugin": "2.9.0",
         "nock": "13.5.4",
@@ -11154,6 +11156,18 @@
         "promise-polyfill": "^8.1.3"
       }
     },
+    "node_modules/jest-fixed-jsdom": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/jest-fixed-jsdom/-/jest-fixed-jsdom-0.0.2.tgz",
+      "integrity": "sha512-rQ7tcI7Sz3XGxEzk7Ic/4n3y83O0cGnSK3lFU3lqHhYaxp/00yoolBBOTnY6bLKkI1XzO4EMgyHYZ1IBRpEesw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "jest-environment-jsdom": "*"
+      }
+    },
     "node_modules/jest-get-type": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
@@ -16656,6 +16670,14 @@
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
+    },
+    "node_modules/undici": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.14.1.tgz",
+      "integrity": "sha512-mAel3i4BsYhkeVPXeIPXVGPJKeBzqCieZYoFsbWfUzd68JmHByhc1Plit5WlylxXFaGpgkZB8mExlxnt+Q1p7A==",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "5.26.5",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "pino": "8.20.0",
     "pino-pretty": "11.0.0",
     "qs": "6.12.1",
+    "undici": "6.14.1",
     "useragent": "2.3.0",
     "uuid": "9.0.1"
   },
@@ -97,6 +98,7 @@
     "jest": "29.7.0",
     "jest-environment-jsdom": "29.7.0",
     "jest-fetch-mock": "3.0.3",
+    "jest-fixed-jsdom": "0.0.2",
     "json-server": "0.17.4",
     "mini-css-extract-plugin": "2.9.0",
     "nock": "13.5.4",

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -207,6 +207,20 @@ const config = convict({
     format: String,
     env: 'DOCKER_HUB_URL',
     default: 'https://hub.docker.com/r/defradigital'
+  },
+  httpProxy: {
+    doc: 'HTTP Proxy',
+    format: String,
+    nullable: true,
+    default: null,
+    env: 'CDP_HTTP_PROXY'
+  },
+  httpsProxy: {
+    doc: 'HTTPS Proxy',
+    format: String,
+    nullable: true,
+    default: null,
+    env: 'CDP_HTTPS_PROXY'
   }
 })
 

--- a/src/server/common/helpers/auth/azure-oidc.js
+++ b/src/server/common/helpers/auth/azure-oidc.js
@@ -1,10 +1,10 @@
-import fetch from 'node-fetch'
 import jwt from '@hapi/jwt'
 import bell from '@hapi/bell'
 
 import { config } from '~/src/config'
 import { fetchTeams } from '~/src/server/teams/helpers/fetch'
 import { sessionNames } from '~/src/server/common/constants/session-names'
+import { proxyFetch } from '~/src/server/common/helpers/fetch/proxy-fetch'
 
 async function provideCdpGroups(groups = []) {
   const { teams: teamsWithGithub } = await fetchTeams(true)
@@ -19,7 +19,7 @@ const azureOidc = {
     register: async (server) => {
       await server.register(bell)
 
-      const oidc = await fetch(
+      const oidc = await proxyFetch(
         config.get('oidcWellKnownConfigurationUrl')
       ).then((res) => res.json())
 

--- a/src/server/common/helpers/auth/refresh-token.js
+++ b/src/server/common/helpers/auth/refresh-token.js
@@ -1,6 +1,5 @@
-import fetch from 'node-fetch'
-
 import { config } from '~/src/config'
+import { proxyFetch } from '~/src/server/common/helpers/fetch/proxy-fetch'
 
 async function refreshAccessToken(request) {
   const authedUser = await request.getUserSession()
@@ -20,7 +19,7 @@ async function refreshAccessToken(request) {
 
   request.logger.info('Azure OIDC access token expired, refreshing...')
 
-  return await fetch(request.server.app.oidc.token_endpoint, {
+  return await proxyFetch(request.server.app.oidc.token_endpoint, {
     method: 'post',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',

--- a/src/server/common/helpers/fetch/proxy-fetch.js
+++ b/src/server/common/helpers/fetch/proxy-fetch.js
@@ -1,0 +1,26 @@
+import { config } from '~/src/config'
+import { ProxyAgent, fetch as undiciFetch } from 'undici'
+
+const nonProxyFetch = (url, opts) => {
+  return undiciFetch(url, {
+    ...opts
+  })
+}
+
+const proxyFetch = (url, opts) => {
+  const proxy = config.get('httpsProxy') ?? config.get('httpProxy')
+  if (!proxy) {
+    return nonProxyFetch(url, opts)
+  } else {
+    return undiciFetch(url, {
+      ...opts,
+      dispatcher: new ProxyAgent({
+        uri: proxy,
+        keepAliveTimeout: 10,
+        keepAliveMaxTimeout: 10
+      })
+    })
+  }
+}
+
+export { proxyFetch }


### PR DESCRIPTION
OIDC calls now uses the proxy.

And to fix tests added a jest jsdom fix that keeps global node env vars.