### PR TITLE
Guard 404 from secrets call better

### DIFF
--- a/src/server/deploy-service/controllers/deploy/summary.js
+++ b/src/server/deploy-service/controllers/deploy/summary.js
@@ -25,10 +25,17 @@ const summaryController = {
       ({ value }) => value === parseInt(deployment?.memory, 10)
     )
 
-    const { secrets } = await fetchSecrets(
-      deployment.environment,
-      deployment.imageName
-    )
+    let secrets
+    try {
+      const secretsResponse = await fetchSecrets(
+        deployment.environment,
+        deployment.imageName
+      )
+      secrets = secretsResponse.secrets
+    } catch (error) {
+      request.logger.error(error, 'No secrets found')
+      secrets = []
+    }
 
     return h.view('deploy-service/views/summary', {
       pageTitle: 'Deploy Service Summary',
@@ -39,7 +46,7 @@ const summaryController = {
       deploymentRows: deploymentRows(deployment, cpuDetail, memoryDetail),
       formButtonText: 'Deploy',
       deployment,
-      secrets: secrets.sort()
+      secrets: secrets?.sort()
     })
   }
 }

--- a/src/server/deploy-service/views/summary.njk
+++ b/src/server/deploy-service/views/summary.njk
@@ -42,8 +42,7 @@
                     <li>
                       <a
                         class="app-link"
-                        href="https://github.com/DEFRA/cdp-app-config/tree/main/services/{{ deployment.imageName }}/{{
-                        deployment.environment }}/{{ deployment.imageName }}.env"
+                        href="https://github.com/DEFRA/cdp-app-config/tree/main/services/{{ deployment.imageName }}/{{ deployment.environment }}/{{ deployment.imageName }}.env"
                         target="_blank"
                         rel="noopener noreferrer">
                         {{ deployment.imageName }} - {{ deployment.environment }} - config
@@ -60,19 +59,23 @@
                     </li>
                   </ul>
                 </div>
+
                 <div class="app-row__item-flex-two">
-
                   <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Secrets</h2>
-
                   <p class="govuk-!-margin-bottom-2">
                     The secret environment variables available to this deployment are:
                   </p>
-
-                  <ul class="govuk-list govuk-!-margin-0">
-                    {% for secret in secrets %}
-                      <li><code>{{ secret }}</code></li>
-                    {% endfor %}
-                  </ul>
+                  {% if secrets | length %}
+                    <ul class="govuk-list govuk-!-margin-0">
+                      {% for secret in secrets %}
+                        <li><code>{{ secret }}</code></li>
+                      {% endfor %}
+                    </ul>
+                  {% else %}
+                  <p class="govuk-!-margin-bottom-2">
+                    No secrets currently available
+                  </p>
+                  {% endif %}
                 </div>
               </div>
             </section>


### PR DESCRIPTION
## With a 404 from secrets
> This also logs the error


<img width="1568" alt="Screenshot 2024-07-16 at 10 36 41" src="https://github.com/user-attachments/assets/1a458869-8d22-4414-8851-91ef0ba01d7b">
