### PR TITLE
204100 user managed secrets part II

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -253,34 +253,12 @@ const config = convict({
       env: 'AUDIT_SOURCE'
     }
   },
-  secrets: {
-    // TODO this will be moved to one place. For the moment just adding it as config for ease
-    global: {
-      doc: 'Platform supplied "Global" secret keys that cannot be overridden',
-      format: Array,
-      default: [
-        {
-          key: 'REDIS_KEY_PREFIX',
-          description: 'Automatically generated Redis key prefix'
-        },
-        {
-          key: 'REDIS_USERNAME',
-          description: 'Automatically generated Redis username'
-        },
-        {
-          key: 'REDIS_PASSWORD',
-          description: 'Automatically generated Redis password'
-        },
-        {
-          key: 'SQUID_USERNAME',
-          description: 'Automatically generated Squid proxy username'
-        },
-        {
-          key: 'SQUID_PASSWORD',
-          description: 'Automatically generated Squid proxy password'
-        }
-      ]
-    }
+  platformGlobalSecretKeys: {
+    doc: 'Global Platform level secret keys. These keys are not to be overridden',
+    format: Array,
+    default:
+      'SQUID_USERNAME,SQUID_PASSWORD,REDIS_USERNAME,REDIS_PASSWORD,REDIS_KEY_PREFIX,CDP_HTTP_PROXY,CDP_HTTPS_PROXY,HTTP_PROXY,HTTPS_PROXY',
+    env: 'PLATFORM_GLOBAL_SECRET_KEYS'
   }
 })
 

--- a/src/server/common/constants/platform-global-secret-keys-descriptions.js
+++ b/src/server/common/constants/platform-global-secret-keys-descriptions.js
@@ -1,0 +1,15 @@
+const platformGlobalSecretKeysDescriptions = {
+  SQUID_USERNAME: 'Automatically generated Squid proxy username.',
+  SQUID_PASSWORD: 'Automatically generated Squid proxy password.',
+  REDIS_USERNAME: 'Automatically generated Redis username.',
+  REDIS_PASSWORD: 'Automatically generated Redis password.',
+  REDIS_KEY_PREFIX: 'Automatically generated Redis cache key prefix name.',
+  CDP_HTTP_PROXY: 'CDP http proxy url.',
+  CDP_HTTPS_PROXY: 'CDP https proxy url.',
+  HTTP_PROXY:
+    'CDP http proxy url. Applied to environment variable named by convention.',
+  HTTPS_PROXY:
+    'CDP https proxy url. Applied to environment variable named by convention.'
+}
+
+export { platformGlobalSecretKeysDescriptions }

--- a/src/server/services/controllers/secrets/update-form.js
+++ b/src/server/services/controllers/secrets/update-form.js
@@ -8,9 +8,7 @@ import { provideService } from '~/src/server/services/helpers/pre/provide-servic
 import { addServiceOwnerScope } from '~/src/server/services/helpers/add-service-owner-scope'
 import { getEnvironmentsByTeam } from '~/src/server/common/helpers/environments/get-environments-by-team'
 
-const globalSecretKeys = config
-  .get('secrets.global')
-  .map((globalSecret) => globalSecret.key)
+const platformGlobalSecretKeys = config.get('platformGlobalSecretKeys')
 
 const updateSecretFormController = {
   options: {
@@ -34,7 +32,7 @@ const updateSecretFormController = {
       }),
       query: Joi.object({
         secretKey: Joi.string()
-          .not(...globalSecretKeys)
+          .not(...platformGlobalSecretKeys)
           .min(1)
           .max(256)
           .required()

--- a/src/server/services/helpers/schema/secret-validation.js
+++ b/src/server/services/helpers/schema/secret-validation.js
@@ -5,14 +5,12 @@ import { config, environments } from '~/src/config'
 import { validation } from '~/src/server/common/constants/validation'
 
 function secretValidation(teamId) {
-  const globalSecretKeys = config
-    .get('secrets.global')
-    .map((globalSecret) => globalSecret.key)
+  const platformGlobalSecretKeys = config.get('platformGlobalSecretKeys')
 
   const adminTeamId = config.get('oidcAdminGroupId')
   const schema = {
     secretKey: Joi.string()
-      .not(...globalSecretKeys)
+      .not(...platformGlobalSecretKeys)
       .min(1)
       .max(256)
       .required()

--- a/src/server/services/helpers/schema/secret-validation.js
+++ b/src/server/services/helpers/schema/secret-validation.js
@@ -11,23 +11,32 @@ function secretValidation(teamId) {
   const schema = {
     secretKey: Joi.string()
       .not(...platformGlobalSecretKeys)
+      .pattern(/^\w*$/)
+      .pattern(/^[a-zA-Z0-9]\w*[a-zA-Z0-9]$/, {
+        name: 'startAndEndWithCharacter'
+      })
       .min(1)
-      .max(256)
+      .max(512)
       .required()
       .messages({
+        'string.pattern.base':
+          'Any case letters and numbers with underscore separators',
+        'string.pattern.name': 'Start and end with a letter or number',
         'string.min': validation.minCharacters(1),
-        'string.max': validation.maxCharacters(256),
+        'string.max': validation.maxCharacters(512),
         'any.invalid': validation.notAllowed,
         'any.required': validation.enterValue,
         'string.empty': validation.enterValue
       }),
     secretValue: Joi.string()
+      .pattern(/^\S*$/)
       .min(1)
-      .max(256)
+      .max(512)
       .required()
       .messages({
+        'string.pattern.base': 'Should not include spaces',
         'string.min': validation.minCharacters(1),
-        'string.max': validation.maxCharacters(256),
+        'string.max': validation.maxCharacters(512),
         'any.required': validation.enterValue,
         'string.empty': validation.enterValue
       }),


### PR DESCRIPTION
- Solidify Platform config secret keys to be used
- Add descriptions object for displaying descriptions in the UI
- Update Secret Name and Key validations

## Of note
- As discussed earlier these envs/secrets need to be updated and service redeployed but as these envs/secrets won't change too much its not something we need to engineer out yet
- I've kept the validation regex light, maybe we see how this goes and update if there are issues from users?
- I have just hardcoded a description object in the Frontend. This felt more sensible than trying to cram these things into a JSON `stringified` object in an env and parsing it. Which interestingly `convictjs` handles fine

## Associated work
- https://github.com/DEFRA/cdp-app-config/pull/510

## Demo
<img width="1184" alt="Screenshot 2024-07-25 at 15 06 17" src="https://github.com/user-attachments/assets/c83f787a-3d57-4750-b8bd-ce4e8b6683dc">
<img width="676" alt="Screenshot 2024-07-25 at 15 07 10" src="https://github.com/user-attachments/assets/5a0da307-af88-4990-96e7-ea46b5540772">
