### PR TITLE
Guard reponse.ok better

### DIFF
--- a/src/client/common/helpers/fetch/autocomplete/fetch-versions.js
+++ b/src/client/common/helpers/fetch/autocomplete/fetch-versions.js
@@ -4,7 +4,7 @@ async function fetchVersions(value) {
   )
   const json = await response.json()
 
-  if (response.ok) {
+  if (response?.ok) {
     return json
   }
 

--- a/src/client/common/helpers/fetch/create/fetch-is-name-available.js
+++ b/src/client/common/helpers/fetch/create/fetch-is-name-available.js
@@ -4,7 +4,7 @@ async function fetchIsNameAvailable(value) {
   )
   const json = await response.json()
 
-  if (response.ok) {
+  if (response?.ok) {
     return json
   }
 

--- a/src/client/common/helpers/fetch/select/fetch-memory.js
+++ b/src/client/common/helpers/fetch/select/fetch-memory.js
@@ -4,7 +4,7 @@ async function fetchMemory(value) {
   )
   const json = await response.json()
 
-  if (response.ok) {
+  if (response?.ok) {
     return json
   }
 

--- a/src/server/admin/teams/controllers/save/create-team.js
+++ b/src/server/admin/teams/controllers/save/create-team.js
@@ -29,7 +29,7 @@ const createTeamController = {
         )
       })
 
-      if (response.ok) {
+      if (response?.ok) {
         await setStepComplete(request, h, 'allSteps')
 
         request.yar.flash(sessionNames.notifications, {

--- a/src/server/admin/teams/controllers/save/edit-team.js
+++ b/src/server/admin/teams/controllers/save/edit-team.js
@@ -22,7 +22,7 @@ const editTeamController = {
         serviceCodes: cdpTeam.serviceCode ? [cdpTeam.serviceCode] : []
       })
 
-      if (response.ok) {
+      if (response?.ok) {
         await setStepComplete(request, h, 'allSteps')
 
         request.yar.flash(sessionNames.notifications, {

--- a/src/server/admin/users/controllers/delete/delete-user.js
+++ b/src/server/admin/users/controllers/delete/delete-user.js
@@ -23,7 +23,7 @@ const deleteUserController = {
         method: 'delete'
       })
 
-      if (response.ok) {
+      if (response?.ok) {
         request.yar.flash(sessionNames.notifications, {
           text: 'User deleted and removed from all teams',
           type: 'success'

--- a/src/server/admin/users/controllers/save/create-user.js
+++ b/src/server/admin/users/controllers/save/create-user.js
@@ -31,7 +31,7 @@ const createUserController = {
         )
       })
 
-      if (response.ok) {
+      if (response?.ok) {
         await setStepComplete(request, h, 'allSteps')
 
         request.yar.flash(sessionNames.notifications, {

--- a/src/server/admin/users/controllers/save/edit-user.js
+++ b/src/server/admin/users/controllers/save/edit-user.js
@@ -29,7 +29,7 @@ const editUserController = {
         })
       })
 
-      if (response.ok) {
+      if (response?.ok) {
         await setStepComplete(request, h, 'allSteps')
 
         request.yar.flash(sessionNames.notifications, {

--- a/src/server/common/helpers/fetch/authed-fetcher.js
+++ b/src/server/common/helpers/fetch/authed-fetcher.js
@@ -64,7 +64,7 @@ function authedFetcher(request) {
         const json = await response.json()
 
         // status 200-299
-        if (response.ok) {
+        if (response?.ok) {
           return { json, response }
         }
 

--- a/src/server/create/journey-test-suite/controllers/create.js
+++ b/src/server/create/journey-test-suite/controllers/create.js
@@ -56,7 +56,7 @@ const testSuiteCreateController = {
           }
         )
 
-        if (response.ok) {
+        if (response?.ok) {
           request.yar.clear(sessionNames.validationFailure)
           await request.yar.commit(h)
 

--- a/src/server/create/microservice/controllers/create.js
+++ b/src/server/create/microservice/controllers/create.js
@@ -65,7 +65,7 @@ const microserviceCreateController = {
           }
         )
 
-        if (response.ok) {
+        if (response?.ok) {
           await setStepComplete(request, h, 'allSteps')
 
           request.yar.clear(sessionNames.validationFailure)

--- a/src/server/create/perf-test-suite/controllers/create.js
+++ b/src/server/create/perf-test-suite/controllers/create.js
@@ -57,7 +57,7 @@ const perfTestSuiteCreateController = {
           }
         )
 
-        if (response.ok) {
+        if (response?.ok) {
           await setStepComplete(request, h, 'allSteps')
 
           request.yar.clear(sessionNames.validationFailure)

--- a/src/server/create/repository/controllers/create.js
+++ b/src/server/create/repository/controllers/create.js
@@ -58,7 +58,7 @@ const repositoryCreateController = {
           }
         )
 
-        if (response.ok) {
+        if (response?.ok) {
           request.yar.clear(sessionNames.validationFailure)
           await request.yar.commit(h)
 

--- a/src/server/create/smoke-test-suite/controllers/create.js
+++ b/src/server/create/smoke-test-suite/controllers/create.js
@@ -57,7 +57,7 @@ const smokeTestSuiteCreateController = {
           }
         )
 
-        if (response.ok) {
+        if (response?.ok) {
           await setStepComplete(request, h, 'allSteps')
 
           request.yar.clear(sessionNames.validationFailure)

--- a/src/server/deploy-service/controllers/deploy/deploy.js
+++ b/src/server/deploy-service/controllers/deploy/deploy.js
@@ -33,7 +33,7 @@ const deployController = {
         }
       )
 
-      if (response.ok) {
+      if (response?.ok) {
         await setStepComplete(request, h, 'allSteps')
 
         request.yar.flash(sessionNames.notifications, {

--- a/src/server/services/controllers/secrets/create.js
+++ b/src/server/services/controllers/secrets/create.js
@@ -99,7 +99,7 @@ const createSecretController = {
           }
         )
 
-        if (response.ok) {
+        if (response?.ok) {
           request.yar.clear(sessionNames.validationFailure)
           request.yar.flash(sessionNames.notifications, {
             text: json.message,

--- a/src/server/services/controllers/secrets/update.js
+++ b/src/server/services/controllers/secrets/update.js
@@ -91,7 +91,7 @@ const updateSecretController = {
           }
         )
 
-        if (response.ok) {
+        if (response?.ok) {
           request.yar.clear(sessionNames.validationFailure)
           request.yar.flash(sessionNames.notifications, {
             text: 'Secret being created', // TODO should have this in self service ops?

--- a/src/server/teams/controllers/edit/team-details.js
+++ b/src/server/teams/controllers/edit/team-details.js
@@ -56,7 +56,7 @@ const teamDetailsController = {
       })
       const json = await response.json()
 
-      if (response.ok) {
+      if (response?.ok) {
         request.yar.clear(sessionNames.cdpTeam)
         request.yar.clear(sessionNames.validationFailure)
         await request.yar.commit(h)

--- a/src/server/test-suites/controllers/trigger-test-suite-run.js
+++ b/src/server/test-suites/controllers/trigger-test-suite-run.js
@@ -43,7 +43,7 @@ const triggerTestSuiteRunController = {
       try {
         const { response } = await runTest(request, imageName, environment)
 
-        if (response.ok) {
+        if (response?.ok) {
           // TODO align this to use sendMessage
           request.audit.send({
             event: 'test run requested',


### PR DESCRIPTION
WE have been seeing issues where potentially the response is null. This will guard these errors better and enable them to provide a more understandable error


<img width="917" alt="Screenshot 2024-08-06 at 16 37 27" src="https://github.com/user-attachments/assets/4e8bc90c-207a-465d-840d-af0388a044cc">
