### PR TITLE
Secrets non404

### DIFF
--- a/src/server/services/secrets/transformers/environment-secrets.js
+++ b/src/server/services/secrets/transformers/environment-secrets.js
@@ -62,6 +62,11 @@ function environmentSecrets(
     pendingSecretKeys.length === 0 && !exceptionMessage
       ? 'Secret added and now available'
       : null
+  const isSecretsSetup =
+    secrets &&
+    (secrets.keys?.length > 0 ||
+      secrets.pending?.length > 0 ||
+      secrets.lastUpdated)
 
   return {
     serviceSecrets,
@@ -69,7 +74,7 @@ function environmentSecrets(
     shouldPoll,
     successMessage,
     exceptionMessage,
-    isSecretsSetup: secrets !== null
+    isSecretsSetup
   }
 }
 

--- a/src/server/services/secrets/transformers/environment-secrets.js
+++ b/src/server/services/secrets/transformers/environment-secrets.js
@@ -62,11 +62,12 @@ function environmentSecrets(
     pendingSecretKeys.length === 0 && !exceptionMessage
       ? 'Secret added and now available'
       : null
+
   const isSecretsSetup =
     secrets &&
-    (secrets.keys?.length > 0 ||
-      secrets.pending?.length > 0 ||
-      secrets.lastUpdated)
+    (secrets.lastUpdated !== undefined ||
+      secrets.keys?.length > 0 ||
+      secrets.pending?.length > 0)
 
   return {
     serviceSecrets,

--- a/src/server/services/secrets/transformers/environment-secrets.test.js
+++ b/src/server/services/secrets/transformers/environment-secrets.test.js
@@ -99,4 +99,41 @@ describe('#environmentSecrets', () => {
     expect(result.serviceSecrets.keys).toEqual([])
     expect(result.platformSecrets).toEqual([])
   })
+
+  test('Should return secrets not setup if empty', () => {
+    const secrets = {}
+    const result = environmentSecrets(secrets, [])
+
+    expect(result.isSecretsSetup).toBe(false)
+  })
+
+  test('Should return secrets setup even if no keys', () => {
+    const secrets = {
+      keys: [],
+      pending: [],
+      lastUpdated: new Date().toISOString()
+    }
+    const result = environmentSecrets(secrets, [])
+
+    expect(result.isSecretsSetup).toBe(true)
+  })
+
+  test('Should return secrets setup even if no updated date', () => {
+    const secrets = {
+      keys: ['KEY_1'],
+      pending: []
+    }
+    const result = environmentSecrets(secrets, [])
+
+    expect(result.isSecretsSetup).toBe(true)
+  })
+
+  test('Should return secrets setup even if pending', () => {
+    const secrets = {
+      pending: ['KEY_1']
+    }
+    const result = environmentSecrets(secrets, [])
+
+    expect(result.isSecretsSetup).toBe(true)
+  })
 })


### PR DESCRIPTION
Handle responses from PBE secrets endpoint.
Secrets may be setup. May be setup but empty. 

Handles it more gracefully.