### PR TITLE
Expose version number

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -11,6 +11,13 @@ const isTest = process.env.NODE_ENV === 'test'
 const isDevelopment = process.env.NODE_ENV === 'development'
 
 const config = convict({
+  containerVersion: {
+    doc: 'The container version, this variable is injected into your docker container in CDP environments',
+    format: String,
+    nullable: true,
+    default: null,
+    env: 'CONTAINER_VERSION'
+  },
   port: {
     doc: 'The port to bind.',
     format: 'port',
@@ -219,6 +226,13 @@ const config = convict({
       format: ['ecs', 'pino-pretty'],
       default: isProduction ? 'ecs' : 'pino-pretty',
       env: 'LOG_FORMAT'
+    },
+    redact: {
+      doc: 'Log paths to redact',
+      format: Array,
+      default: isProduction
+        ? ['req.headers.authorization', 'req.headers.cookie', 'res.headers']
+        : ['req', 'res', 'container_version', 'responseTime']
     }
   },
   azureTenantId: {

--- a/src/config/nunjucks/context/index.js
+++ b/src/config/nunjucks/context/index.js
@@ -43,6 +43,7 @@ async function context(request) {
     authedUser,
     blankOption: defaultOption,
     breadcrumbs: [],
+    containerVersion: config.get('containerVersion'),
     eventName,
     getAssetPath,
     githubOrg: config.get('githubOrg'),

--- a/src/server/common/helpers/logging/logger-options.js
+++ b/src/server/common/helpers/logging/logger-options.js
@@ -2,6 +2,9 @@ import { ecsFormat } from '@elastic/ecs-pino-format'
 
 import { config } from '~/src/config'
 
+const logConfig = config.get('log')
+const containerVersion = config.get('containerVersion')
+
 /**
  * @type {{ecs: Omit<LoggerOptions, "mixin"|"transport">, "pino-pretty": {transport: {target: string}}}}
  */
@@ -14,14 +17,15 @@ const formatters = {
  * @satisfies {Options}
  */
 export const loggerOptions = {
-  enabled: config.get('log.enabled'),
+  enabled: logConfig.enabled,
   ignorePaths: ['/health'],
+  base: { container_version: containerVersion },
   redact: {
-    paths: ['req.headers.authorization', 'req.headers.cookie', 'res.headers'],
+    paths: logConfig.redact,
     remove: true
   },
-  level: config.get('log.level'),
-  ...formatters[config.get('log.format')]
+  level: logConfig.level,
+  ...formatters[logConfig.format]
 }
 
 /**

--- a/src/server/common/templates/layouts/page.njk
+++ b/src/server/common/templates/layouts/page.njk
@@ -61,6 +61,9 @@
 
 {% block head %}
   <link href="{{ getAssetPath("application.css") }}" rel="stylesheet">
+  {% if containerVersion %}
+    <meta name="container-version" content="{{ containerVersion }}">
+  {% endif %}
 {% endblock %}
 
 {% block header %}


### PR DESCRIPTION
- expose `CONTAINER_VERSION` in
  - logs as `container_version`
  - `<meta name="container-version" content="3.1.0">` on every page 
- Make logs less noisy locally

## Local logs

> with `res`, `req` and `container_version` redacted
<img width="335" alt="local-logs" src="https://github.com/user-attachments/assets/64227cd5-bb1a-477c-a163-21651bf14eb5">


## Prod logs

> as logs appear in prod
<img width="2033" alt="prod-logs" src="https://github.com/user-attachments/assets/d7b03e3f-0175-436c-b462-01f09b3c4090">


## HTML Meta tag
> example

<img width="379" alt="Screenshot 2024-10-25 at 17 29 59" src="https://github.com/user-attachments/assets/cf67b878-d986-414e-9cf8-dea8c647211c">


