### PR TITLE
Documentation tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ awslocal s3 mb s3://cdp-documentation --endpoint-url http://localhost:4566
 ## Upload docs to localstack S3
 git clone https://github.com/DEFRA/cdp-documentation/
 cd cdp-documentation
-awslocal s3 sync . s3://cdp-documentation --exclude ".editorconfig" --exclude ".github/*" --exclude ".git/*" --exclude ".gitignore" --exclude "CONTRIBUTING.md"--delete
+awslocal s3 sync . s3://cdp-documentation --exclude ".editorconfig" --exclude ".github/*" --exclude ".git/*" --exclude ".gitignore" --exclude "CONTRIBUTING.md" --delete
 ```
 
 ### Terminal

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -14,12 +14,26 @@ const isTest = process.env.NODE_ENV === 'test'
 const isDevelopment = process.env.NODE_ENV === 'development'
 
 const config = convict({
-  serviceVersion: {
-    doc: 'The service version, this variable is injected into your docker container in CDP environments',
-    format: String,
-    nullable: true,
-    default: null,
-    env: 'SERVICE_VERSION'
+  service: {
+    name: {
+      doc: 'Applications Service Name',
+      format: String,
+      default: 'Core Delivery Platform - Portal'
+    },
+    version: {
+      doc: 'The service version, this variable is injected into your docker container in CDP environments',
+      format: String,
+      nullable: true,
+      default: null,
+      env: 'SERVICE_VERSION'
+    },
+    environment: {
+      doc: 'The environment the app is running in',
+      format: String,
+      nullable: true,
+      default: null,
+      env: 'ENVIRONMENT'
+    }
   },
   port: {
     doc: 'The port to bind.',
@@ -32,11 +46,6 @@ const config = convict({
     format: Number,
     default: oneYear,
     env: 'STATIC_CACHE_TIMEOUT'
-  },
-  serviceName: {
-    doc: 'Applications Service Name',
-    format: String,
-    default: 'Core Delivery Platform - Portal'
   },
   root: {
     doc: 'Project root',

--- a/src/config/nunjucks/context/index.js
+++ b/src/config/nunjucks/context/index.js
@@ -41,13 +41,17 @@ async function context(request) {
     return `${assetPath}/${webpackAssetPath}`
   }
 
+  const serviceConfig = config.get('service')
+
   return {
     appBaseUrl: config.get('appBaseUrl'),
     assetPath: `${assetPath}/assets`,
     authedUser,
     blankOption: defaultOption,
     breadcrumbs: [],
-    serviceVersion: config.get('serviceVersion'),
+    serviceName: serviceConfig.name,
+    serviceVersion: serviceConfig.version,
+    serviceEnvironment: serviceConfig.environment,
     eventName,
     getAssetPath,
     githubOrg: config.get('githubOrg'),
@@ -59,7 +63,6 @@ async function context(request) {
     navigation: await buildNavigation(request),
     noValue,
     routeLookup: (id, options) => request.routeLookup(id, options),
-    serviceName: config.get('serviceName'),
     supportChannel: config.get('supportChannel'),
     userIsMemberOfATeam: userIsMemberOfATeam(authedUser),
     userIsTeamMember: userIsTeamMember(authedUser)

--- a/src/server/common/components/documentation/_documentation.scss
+++ b/src/server/common/components/documentation/_documentation.scss
@@ -1,5 +1,7 @@
 @use "govuk-frontend" as *;
 @use "helpers/link" as *;
+@use "variables/colours" as *;
+@use "variables/border-radius" as *;
 
 // stylelint-disable max-nesting-depth
 %nested-lists {
@@ -81,6 +83,15 @@ $govuk-wrapper-margin: 60px;
   .app-link {
     @include app-link;
     @include govuk-link-style-text;
+
+    code {
+      padding: .15em .3em;
+      margin: 0;
+      font-size: 85%;
+      white-space: break-spaces;
+      background-color: $app-grey;
+      border-radius: $app-border-radius;
+    }
   }
 }
 

--- a/src/server/common/components/documentation/_markdown.scss
+++ b/src/server/common/components/documentation/_markdown.scss
@@ -16,7 +16,8 @@ $caution: #cf222e;
     @extend %govuk-list--bullet;
 
     & + h2,
-    & + h3 {
+    & + h3,
+    & + h4 {
       padding-top: govuk-spacing(1);
     }
 
@@ -81,7 +82,7 @@ $caution: #cf222e;
 
   h1 {
     @extend %govuk-heading-xl;
-    margin-bottom: govuk-spacing(4);
+    margin-bottom: govuk-spacing(6);
   }
 
   h2 {
@@ -94,12 +95,18 @@ $caution: #cf222e;
     margin-bottom: govuk-spacing(2);
   }
 
+  h4 {
+    @extend %govuk-heading-s;
+    margin-bottom: govuk-spacing(2);
+  }
+
   p {
     @extend %govuk-body-m;
     margin-bottom: govuk-spacing(3);
 
     & + h2,
-    & + h3 {
+    & + h3,
+    & + h4 {
       padding-top: govuk-spacing(3);
     }
   }
@@ -113,7 +120,7 @@ $caution: #cf222e;
   }
 
   code {
-    padding: .2em .4em;
+    padding: .15em .3em;
     margin: 0;
     font-size: 85%;
     white-space: break-spaces;

--- a/src/server/common/components/header/_header.scss
+++ b/src/server/common/components/header/_header.scss
@@ -1,4 +1,5 @@
 @use "govuk-frontend" as *;
+@use "variables/border-radius" as *;
 
 .app-header {
   @include govuk-font(19);
@@ -14,30 +15,41 @@
 
 .app-header__container {
   margin-bottom: govuk-spacing(-2);
-  padding: govuk-spacing(3) govuk-spacing(6) govuk-spacing(1);
+  padding: govuk-spacing(3) govuk-spacing(6);
   border-bottom: govuk-spacing(2) solid $govuk-brand-colour;
-
-  @include govuk-media-query($from: desktop-big) {
-    display: flex;
-  }
+  display: flex;
 }
 
 .app-header__content {
   @include govuk-media-query($from: desktop-big) {
     flex: 4;
+    display: flex;
+    align-items: center;
+
   }
+}
+
+.app-header__service-name {
+  display: inline-block;
+  @include govuk-font(36);
+}
+
+.app-header__service-environment {
+  @include govuk-font(19);
+  padding: govuk-spacing(1) govuk-spacing(2);
+  margin-left: govuk-spacing(4);
+  border-radius: $app-border-radius;
+  background-color: govuk-colour("blue");
 }
 
 .app-header__actions {
   @include govuk-font(19);
-  margin-bottom: govuk-spacing(2);
 
   @include govuk-media-query($from: desktop-big) {
     flex: 2;
     display: flex;
     justify-content: flex-end;
-    align-self: center;
-    margin: govuk-spacing(1) 0 govuk-spacing(2) auto;
+    align-self: flex-end;
   }
 }
 
@@ -60,10 +72,4 @@
   &:focus {
     @include govuk-focused-text;
   }
-}
-
-.app-header__service-name {
-  display: inline-block;
-  margin-bottom: govuk-spacing(2);
-  @include govuk-font(36);
 }

--- a/src/server/common/components/header/template.njk
+++ b/src/server/common/components/header/template.njk
@@ -6,6 +6,11 @@
          data-testid="app-header-service-name">
         {{ params.serviceName }}
       </a>
+
+      {% if serviceEnvironment === "infra-dev" %}
+        <span class="app-header__service-environment">{{ serviceEnvironment | title }}</span>
+      {% endif %}
+
     </div>
     <div class="app-header__actions">
       {% if authedUser.displayName %}

--- a/src/server/common/helpers/logging/logger-options.js
+++ b/src/server/common/helpers/logging/logger-options.js
@@ -3,8 +3,7 @@ import { ecsFormat } from '@elastic/ecs-pino-format'
 import { config } from '~/src/config/index.js'
 
 const logConfig = config.get('log')
-const serviceName = config.get('serviceName')
-const serviceVersion = config.get('serviceVersion')
+const serviceConfig = config.get('service')
 
 /**
  * @type {{ecs: Omit<LoggerOptions, "mixin"|"transport">, "pino-pretty": {transport: {target: string}}}}
@@ -14,9 +13,10 @@ const formatters = {
     ...ecsFormat(),
     base: {
       service: {
-        name: serviceName,
+        name: serviceConfig.name,
         type: 'nodeJs',
-        version: serviceVersion
+        version: serviceConfig.version,
+        environment: serviceConfig.environment
       }
     }
   },

--- a/src/server/common/helpers/proxy/proxy-fetch.js
+++ b/src/server/common/helpers/proxy/proxy-fetch.js
@@ -7,6 +7,7 @@ const nonProxyFetch = (url, opts) => {
   })
 }
 
+// TODO update to the new proxyFetch work and tests
 const proxyFetch = (url, opts) => {
   const proxy = config.get('httpsProxy') ?? config.get('httpProxy')
   if (!proxy) {

--- a/src/server/common/templates/layouts/page.njk
+++ b/src/server/common/templates/layouts/page.njk
@@ -56,6 +56,9 @@
   {% if serviceVersion %}
     <meta name="service-version" content="{{ serviceVersion }}">
   {% endif %}
+  {% if serviceEnvironment %}
+    <meta name="service-environment" content="{{ serviceEnvironment }}">
+  {% endif %}
 {% endblock %}
 
 {% block header %}

--- a/src/server/deployments/controllers/deployment.js
+++ b/src/server/deployments/controllers/deployment.js
@@ -38,7 +38,7 @@ const deploymentController = {
     const secretDetail = transformSecrets(deployment.secrets)
 
     return h.view('deployments/views/deployment', {
-      pageTitle: `${deployment.service} v${deployment.version} deployment - ${formattedEnvironment}`,
+      pageTitle: `${deployment.service} ${deployment.version} deployment - ${formattedEnvironment}`,
       heading: `${formattedEnvironment} deployment`,
       caption: `Microservice deployment for <strong>${deployment.service}</strong>, version <strong>${deployment.version}</strong>.`,
       deployment,

--- a/src/server/documentation/helpers/documentation-structure.js
+++ b/src/server/documentation/helpers/documentation-structure.js
@@ -5,9 +5,10 @@ import { ListObjectsV2Command } from '@aws-sdk/client-s3'
 
 import { fetchS3File } from '~/src/server/documentation/helpers/s3-file-handler.js'
 
-/** @typedef {{ name: string, contents: string[] }} Folder */
-
-/** @typedef {{ name: string  }} Page */
+/**
+ * @typedef {{ name: string, contents: string[] }} Folder
+ * @typedef {{ name: string  }} Page
+ */
 
 /**
  * Get the order of a README.md pages internal links
@@ -35,15 +36,18 @@ async function getPageInternalLinksOrder(markdown) {
 /** @typedef {{ text: string, href: string, level: number }} Link */
 
 /**
- * Build the structure of the documentation repository as link objects
  * @typedef {object} Options
  * @property {string} name - list object key
  * @property {string} content - folder or page key
  * @property {string} docsRoute - documentation root route
  * @property {Folder[]} folders
  * @property {Page[]} pages
+ */
+
+/**
+ * Build the structure of the documentation repository as link objects
  * @param {Options} options
- * @returns Link[]
+ * @returns  Link[] | Link[][] | undefined
  */
 function buildLinkStructure({ name, content, docsRoute, folders, pages }) {
   if (!content.endsWith('.md')) {
@@ -98,7 +102,7 @@ function buildLinkStructure({ name, content, docsRoute, folders, pages }) {
  * Get ordered links that reflect the structure of the documentation repository
  * @param {Request} request
  * @param {string} bucket
- * @returns {Promise<Array>}
+ * @returns {Promise<[]>}
  */
 async function documentationStructure(request, bucket) {
   const command = new ListObjectsV2Command({

--- a/src/server/documentation/helpers/extensions/heading.js
+++ b/src/server/documentation/helpers/extensions/heading.js
@@ -4,9 +4,10 @@ const headingExtension = {
   renderer(token) {
     const { text, depth: level } = token
     const internalAnchorId = text.toLowerCase().replace(/\W+/g, '-')
+    const parsedText = this.parser.parseInline(token.tokens)
 
     return `<h${level} id="${internalAnchorId}">
-                <a class="heading-link" href="#${internalAnchorId}">${text}</a>
+                <a class="heading-link" href="#${internalAnchorId}">${parsedText}</a>
               </h${level}>`
   }
 }

--- a/src/server/documentation/helpers/extensions/heading.test.js
+++ b/src/server/documentation/helpers/extensions/heading.test.js
@@ -1,10 +1,21 @@
+import { Marked } from 'marked'
 import { load } from 'cheerio'
 
 import { headingExtension } from '~/src/server/documentation/helpers/extensions/heading.js'
 
 describe('#headingExtension', () => {
-  test('Should render expected heading', () => {
-    const html = headingExtension.renderer({ text: 'Introduction', depth: 1 })
+  let testMarked
+
+  beforeEach(() => {
+    testMarked = new Marked({
+      pedantic: false,
+      gfm: true,
+      extensions: [headingExtension]
+    })
+  })
+
+  test('Should render expected heading', async () => {
+    const html = await testMarked.parse('# Introduction')
     const $html = load(html)
     const $heading = $html('h1')
     const $anchor = $heading.find('a')
@@ -12,5 +23,20 @@ describe('#headingExtension', () => {
     expect($heading).toHaveLength(1)
     expect($anchor.attr('href')).toBe('#introduction')
     expect($anchor.text()).toBe('Introduction')
+  })
+
+  test('Should render heading, containing markdown, as expected', async () => {
+    const html = await testMarked.parse('# 44: All the `things` section')
+
+    const $html = load(html)
+    const $heading = $html('h1')
+    const $anchor = $heading.find('a')
+    const $code = $anchor.find('code')
+
+    expect($heading).toHaveLength(1)
+    expect($anchor.attr('href')).toBe('#44-all-the-things-section')
+    expect($anchor.text()).toBe('44: All the things section')
+    expect($anchor.html()).toBe('44: All the <code>things</code> section')
+    expect($code.text()).toBe('things')
   })
 })

--- a/src/server/documentation/helpers/extensions/link.js
+++ b/src/server/documentation/helpers/extensions/link.js
@@ -9,10 +9,12 @@ const linkExtension = {
   name: 'link',
   level: 'block',
   renderer(token) {
+    const parsedText = this.parser.parseInline(token.tokens)
+
     if (isExternalLink(token.href)) {
-      return `<a href="${token.href}" target="_blank" rel="noopener noreferrer">${token.text}</a>`
+      return `<a href="${token.href}" target="_blank" rel="noopener noreferrer">${parsedText}</a>`
     } else {
-      return `<a href="${token.href}">${token.text}</a>`
+      return `<a href="${token.href}">${parsedText}</a>`
     }
   }
 }

--- a/src/server/documentation/helpers/extensions/link.test.js
+++ b/src/server/documentation/helpers/extensions/link.test.js
@@ -1,13 +1,21 @@
+import { Marked } from 'marked'
 import { load } from 'cheerio'
 
 import { linkExtension } from '~/src/server/documentation/helpers/extensions/link.js'
 
 describe('#linkExtension', () => {
-  test('Should render an external link', () => {
-    const html = linkExtension.renderer({
-      href: 'https://example.com',
-      text: 'Example'
+  let testMarked
+
+  beforeEach(() => {
+    testMarked = new Marked({
+      pedantic: false,
+      gfm: true,
+      extensions: [linkExtension]
     })
+  })
+
+  test('Should render an external link', async () => {
+    const html = await testMarked.parse('[Example](https://example.com)')
     const $html = load(html)
     const $link = $html('a')
 
@@ -16,11 +24,8 @@ describe('#linkExtension', () => {
     expect($link.attr('rel')).toBe('noopener noreferrer')
   })
 
-  test('Should render a portal link', () => {
-    const html = linkExtension.renderer({
-      href: 'https://portal/home',
-      text: 'Home'
-    })
+  test('Should render a portal link', async () => {
+    const html = await testMarked.parse('[Home](https://portal/home)')
     const $html = load(html)
     const $link = $html('a')
 
@@ -30,11 +35,10 @@ describe('#linkExtension', () => {
     expect($link.attr('rel')).toBeUndefined()
   })
 
-  test('Should render an in page link', () => {
-    const html = linkExtension.renderer({
-      href: 'in-page/link#section-heading',
-      text: 'Section Heading'
-    })
+  test('Should render an in page link', async () => {
+    const html = await testMarked.parse(
+      '[Section Heading](in-page/link#section-heading)'
+    )
     const $html = load(html)
     const $link = $html('a')
 
@@ -42,5 +46,22 @@ describe('#linkExtension', () => {
     expect($link.text()).toBe('Section Heading')
     expect($link.attr('target')).toBeUndefined()
     expect($link.attr('rel')).toBeUndefined()
+  })
+
+  test('Should render a link, containing markdown, as expected', async () => {
+    const html = await testMarked.parse(
+      '[Section `with highlight` link](https://portal/home)'
+    )
+    const $html = load(html)
+    const $link = $html('a')
+    const $code = $link.find('code')
+
+    expect($link.attr('href')).toBe('https://portal/home')
+    expect($link.text()).toBe('Section with highlight link')
+    expect($link.html()).toBe('Section <code>with highlight</code> link')
+    expect($link.attr('target')).toBeUndefined()
+    expect($link.attr('rel')).toBeUndefined()
+
+    expect($code.text()).toBe('with highlight')
   })
 })

--- a/src/server/documentation/helpers/markdown-handler.js
+++ b/src/server/documentation/helpers/markdown-handler.js
@@ -2,7 +2,7 @@ import startCase from 'lodash/startCase.js'
 import { GetObjectCommand } from '@aws-sdk/client-s3'
 
 import { statusCodes } from '~/src/server/common/constants/status-codes.js'
-import { getHtml } from '~/src/server/documentation/helpers/markdown/get-html.js'
+import { buildPageHtml } from '~/src/server/documentation/helpers/markdown/build-page-html.js'
 import { docsBreadcrumbs } from '~/src/server/documentation/helpers/docs-breadcrumbs.js'
 import { buildDocsNav } from '~/src/server/documentation/helpers/markdown/build-docs-nav.js'
 
@@ -27,7 +27,7 @@ function buildPageTitle(documentationPath) {
 
 async function markdownHandler(request, h, documentationPath, bucket) {
   const markdown = await fetchMarkdown(request, documentationPath, bucket)
-  const { html, toc } = await getHtml(markdown)
+  const { html, toc } = await buildPageHtml(markdown)
   const nav = await buildDocsNav(request, bucket)
   const pageTitle = buildPageTitle(documentationPath)
 

--- a/src/server/documentation/helpers/markdown/build-page-html.js
+++ b/src/server/documentation/helpers/markdown/build-page-html.js
@@ -1,6 +1,5 @@
 import { Marked } from 'marked'
 import markedAlert from 'marked-alert'
-import { escapeHtml } from '@hapi/hoek'
 
 import { linkExtension } from '~/src/server/documentation/helpers/extensions/link.js'
 import { headingExtension } from '~/src/server/documentation/helpers/extensions/heading.js'
@@ -11,18 +10,19 @@ const docsMarked = new Marked({
   extensions: [linkExtension, headingExtension]
 }).use(markedAlert())
 
-async function getHtml(markdown) {
+async function buildPageHtml(markdown) {
   const headingElements = []
 
   const walkTokens = (token) => {
     if (token.type === 'heading') {
       const { text, depth: level } = token
       const internalAnchorId = text.toLowerCase().replace(/\W+/g, '-')
+      const parsedText = docsMarked.parseInline(text)
 
       headingElements.push({
         anchor: internalAnchorId,
         level,
-        text: escapeHtml(text)
+        text: parsedText
       })
     }
   }
@@ -69,4 +69,4 @@ function buildTableOfContents(links) {
   return html
 }
 
-export { getHtml }
+export { buildPageHtml }

--- a/src/server/documentation/helpers/markdown/build-page-html.test.js
+++ b/src/server/documentation/helpers/markdown/build-page-html.test.js
@@ -1,11 +1,11 @@
 import { load } from 'cheerio'
 
-import { getHtml } from '~/src/server/documentation/helpers/markdown/get-html.js'
+import { buildPageHtml } from '~/src/server/documentation/helpers/markdown/build-page-html.js'
 
-describe('#getHtml', () => {
+describe('#buildPageHtml', () => {
   test('Should convert markdown to HTML', async () => {
     const markdown = '# Heading\n\nThis is a paragraph.'
-    const { html } = await getHtml(markdown)
+    const { html } = await buildPageHtml(markdown)
 
     const $html = load(html)
     const $heading = $html('h1')
@@ -22,7 +22,7 @@ describe('#getHtml', () => {
 
   test('Should generate expected table of contents', async () => {
     const markdown = '# Heading 1\n\n## Heading 2\n\n### Heading 3'
-    const { toc } = await getHtml(markdown)
+    const { toc } = await buildPageHtml(markdown)
 
     const $toc = load(toc)
     const $link1 = $toc('ul').first().find('a').first()
@@ -40,7 +40,7 @@ describe('#getHtml', () => {
   })
 
   test('Should handle empty markdown input', async () => {
-    const { html, toc } = await getHtml('')
+    const { html, toc } = await buildPageHtml('')
 
     expect(html).toBe('')
     expect(toc).toBe('')


### PR DESCRIPTION
A few Friday tweaks to docs and displaying if the app is on `infra-dev`

## Associated PR
- https://github.com/DEFRA/cdp-portal-tests/pull/55
- https://github.com/DEFRA/cdp-documentation/pull/82

## Allow markdown inside links and headers

> Parse markdown in headers and links. 
### Before
<img width="1817" alt="Screenshot 2024-11-11 at 11 50 30" src="https://github.com/user-attachments/assets/bf68cbd9-c82f-4123-acaf-a3145aabcf17">



### After 
<img width="1487" alt="Screenshot 2024-11-11 at 11 34 21" src="https://github.com/user-attachments/assets/0fe4b245-5e27-489f-ae8b-5506f1edea87">

## Show `infra-dev` when on `infra-dev`
<img width="1939" alt="Screenshot 2024-11-11 at 11 35 47" src="https://github.com/user-attachments/assets/b4a51a3c-8b3c-4156-8b40-00172eb0b2c9">


