### PR TITLE
Non strict headers to support Microsoft cookies

### DIFF
--- a/src/server/common/helpers/auth/session-cookie.js
+++ b/src/server/common/helpers/auth/session-cookie.js
@@ -20,7 +20,8 @@ const sessionCookie = {
           path: '/',
           password: config.get('sessionCookiePassword'),
           isSecure: config.get('isProduction'),
-          ttl: config.get('sessionCookieTtl')
+          ttl: config.get('sessionCookieTtl'),
+          clearInvalid: true
         },
         keepAlive: true,
         requestDecoratorName: 'sessionCookie',

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -76,7 +76,10 @@ async function createServer() {
           client: redisClient
         })
       }
-    ]
+    ],
+    state: {
+      strictHeader: false
+    }
   })
 
   // TODO refactor cache and decorate it on to server and request. No need for it to be on server.app


### PR DESCRIPTION
Some Microft auth cookies need less strict cookie validation in Hapi.

This workaround was described in https://github.com/hapijs/hapi/issues/2513