### PR TITLE
Add support for alert email addresses to Portal UI

### DIFF
--- a/src/__fixtures__/admin/cdp-team-without-github.js
+++ b/src/__fixtures__/admin/cdp-team-without-github.js
@@ -7,6 +7,7 @@ const cdpTeamWithoutGithubFixture = {
     createdAt: '2023-08-23T16:18:28.742Z',
     updatedAt: '2023-08-30T08:03:23.657Z',
     teamId: '47c04343-4c0e-4326-9848-bef7c1e2eedd',
+    alertEmailAddresses: ['alerts@cdp.com'],
     users: [
       {
         userId: '014ee26b-e738-4bcc-9621-a5289dba7351',

--- a/src/__fixtures__/admin/cdp-team.js
+++ b/src/__fixtures__/admin/cdp-team.js
@@ -9,6 +9,7 @@ const cdpTeamFixture = {
     github: 'cdp-platform',
     teamId: 'aabe63e7-87ef-4beb-a596-c810631fc474',
     serviceCodes: ['CDP'],
+    alertEmailAddresses: ['alerts@cdp.com'],
     users: [
       {
         userId: '0ddadf17-beaf-4aef-a415-ca044dbdd18d',

--- a/src/__fixtures__/team.js
+++ b/src/__fixtures__/team.js
@@ -9,6 +9,7 @@ const teamFixture = {
   updatedAt: '2023-10-03T11:11:31.085Z',
   github: 'cdp-platform',
   teamId: 'aabe63e7-87ef-4beb-a596-c810631fc474',
+  alertEmailAddresses: ['alerts@cdp.com'],
   users: [
     {
       userId: '0ddadf17-beaf-4aef-a415-ca044dbdd18d',

--- a/src/server/admin/teams/controllers/save/create-team.js
+++ b/src/server/admin/teams/controllers/save/create-team.js
@@ -24,7 +24,8 @@ const createTeamController = {
             name: cdpTeam.name,
             description: cdpTeam.description,
             github: cdpTeam.github,
-            serviceCodes: cdpTeam.serviceCode ? [cdpTeam.serviceCode] : []
+            serviceCodes: cdpTeam.serviceCode ? [cdpTeam.serviceCode] : [],
+            alertEmailAddresses: cdpTeam.alertEmailAddresses
           })
         )
       })

--- a/src/server/admin/teams/controllers/save/edit-team.js
+++ b/src/server/admin/teams/controllers/save/edit-team.js
@@ -19,7 +19,8 @@ const editTeamController = {
         name: cdpTeam.name,
         description: cdpTeam.description,
         github: cdpTeam.github,
-        serviceCodes: cdpTeam.serviceCode ? [cdpTeam.serviceCode] : []
+        serviceCodes: cdpTeam.serviceCode ? [cdpTeam.serviceCode] : [],
+        alertEmailAddresses: cdpTeam.alertEmailAddresses
       })
 
       if (response?.ok) {

--- a/src/server/admin/teams/controllers/save/team-details.js
+++ b/src/server/admin/teams/controllers/save/team-details.js
@@ -14,13 +14,16 @@ const teamDetailsController = {
     const redirectLocation = payload?.redirectLocation
 
     const name = payload?.name || undefined
-    const serviceCode = payload?.serviceCode || undefined
     const description = payload?.description || undefined
+    const serviceCode = payload?.serviceCode || undefined
+    const alertEmailAddresses =
+      payload?.alertEmailAddresses?.split(/\s*,\s*/) || undefined
 
     const sanitisedPayload = {
       name,
+      description,
       serviceCode,
-      description
+      alertEmailAddresses
     }
 
     const validationResult = teamValidation.validate(sanitisedPayload, {

--- a/src/server/admin/teams/helpers/fetch/edit-team.js
+++ b/src/server/admin/teams/helpers/fetch/edit-team.js
@@ -9,6 +9,7 @@ async function editTeam(request, teamId, payload) {
       name: payload.name,
       description: payload.description,
       serviceCodes: payload.serviceCodes,
+      alertEmailAddresses: payload.alertEmailAddresses,
       github: payload.github
     })
   })

--- a/src/server/admin/teams/helpers/schema/team-validation.js
+++ b/src/server/admin/teams/helpers/schema/team-validation.js
@@ -25,6 +25,7 @@ const teamValidation = Joi.object({
       'string.max': validation.exactLetters(3),
       'string.pattern.base': 'Provide 3 uppercase letters'
     }),
+  alertEmailAddresses: Joi.array().items(Joi.string().email()).optional(),
   description: Joi.string()
     .max(256)
     .optional()

--- a/src/server/admin/teams/transformers/transform-summary-team-rows.js
+++ b/src/server/admin/teams/transformers/transform-summary-team-rows.js
@@ -56,13 +56,18 @@ function transformSummaryTeamRows(cdpTeam) {
   return [
     buildRow('Name', teamDetails.name, teamDetailsPath),
     buildRow('Description', teamDetails.description, teamDetailsPath),
-    buildRow('Service Code', teamDetails.serviceCode, teamDetailsPath),
     buildRow(
       'GitHub team',
       githubTeamUiValue,
       'find-github-team',
       'githubSearch',
       teamDetails.github
+    ),
+    buildRow('Service Code', teamDetails.serviceCode, teamDetailsPath),
+    buildRow(
+      'Alert Emails',
+      teamDetails.alertEmailAddresses?.join('<br>'),
+      teamDetailsPath
     )
   ]
 }

--- a/src/server/admin/teams/transformers/transform-summary-team-rows.test.js
+++ b/src/server/admin/teams/transformers/transform-summary-team-rows.test.js
@@ -53,6 +53,26 @@ describe('#transformSummaryTeamRows', () => {
           items: [
             {
               classes: 'app-link',
+              href: '/admin/teams/find-github-team?redirectLocation=summary&githubSearch=forestry-management',
+              text: 'Change',
+              visuallyHiddenText: 'GitHub team'
+            }
+          ]
+        },
+        key: {
+          classes: 'app-summary__heading',
+          text: 'GitHub team'
+        },
+        value: {
+          html: `<span data-testid="github-team"><a class="app-link" href="https://github.com/orgs/${githubOrg}/teams/forestry-management" target="_blank" rel="noopener noreferrer">@forestry-management</a></span>`
+        }
+      },
+      {
+        actions: {
+          classes: 'app-summary__action',
+          items: [
+            {
+              classes: 'app-link',
               href: '/admin/teams/team-details?redirectLocation=summary',
               text: 'Change',
               visuallyHiddenText: 'Service Code'
@@ -73,18 +93,18 @@ describe('#transformSummaryTeamRows', () => {
           items: [
             {
               classes: 'app-link',
-              href: '/admin/teams/find-github-team?redirectLocation=summary&githubSearch=forestry-management',
+              href: '/admin/teams/team-details?redirectLocation=summary',
               text: 'Change',
-              visuallyHiddenText: 'GitHub team'
+              visuallyHiddenText: 'Alert Emails'
             }
           ]
         },
         key: {
           classes: 'app-summary__heading',
-          text: 'GitHub team'
+          text: 'Alert Emails'
         },
         value: {
-          html: `<span data-testid="github-team"><a class="app-link" href="https://github.com/orgs/${githubOrg}/teams/forestry-management" target="_blank" rel="noopener noreferrer">@forestry-management</a></span>`
+          html: null
         }
       }
     ])

--- a/src/server/admin/teams/transformers/transform-team-to-entity-data-list.js
+++ b/src/server/admin/teams/transformers/transform-team-to-entity-data-list.js
@@ -26,6 +26,15 @@ function transformTeamToEntityDataList(team) {
     },
     {
       heading: {
+        text: 'Alert Emails'
+      },
+      entity: {
+        kind: 'html',
+        value: team.alertEmailAddresses?.join('<br>')
+      }
+    },
+    {
+      heading: {
         text: 'Created'
       },
       entity: {

--- a/src/server/admin/teams/transformers/transform-team-to-entity-data-list.test.js
+++ b/src/server/admin/teams/transformers/transform-team-to-entity-data-list.test.js
@@ -28,6 +28,15 @@ describe('#transformCdpTeamToEntityDataList', () => {
         }
       },
       {
+        heading: {
+          text: 'Alert Emails'
+        },
+        entity: {
+          kind: 'html',
+          value: 'alerts@cdp.com'
+        }
+      },
+      {
         entity: {
           kind: 'date',
           value: '2023-09-28T12:52:14.673Z'

--- a/src/server/admin/teams/transformers/transform-team-to-entity-row.js
+++ b/src/server/admin/teams/transformers/transform-team-to-entity-row.js
@@ -24,6 +24,10 @@ function transformTeamToEntityRow(team) {
       value: team.serviceCodes
     },
     {
+      kind: 'html',
+      value: team.alertEmailAddresses?.join('<br>')
+    },
+    {
       kind: 'text',
       value: team.users.length
     }

--- a/src/server/admin/teams/transformers/transform-team-to-entity-row.test.js
+++ b/src/server/admin/teams/transformers/transform-team-to-entity-row.test.js
@@ -27,6 +27,10 @@ describe('#transformCdpTeamToEntityRow', () => {
         value: ['CDP']
       },
       {
+        kind: 'html',
+        value: 'alerts@cdp.com'
+      },
+      {
         kind: 'text',
         value: 2
       }

--- a/src/server/admin/teams/views/save/team-details-form.njk
+++ b/src/server/admin/teams/views/save/team-details-form.njk
@@ -71,6 +71,33 @@
                 } if formErrors.serviceCode.message
               }) }}
 
+              {{ govukInput({
+                label: {
+                  text: "Alert Emails (optional)",
+                  classes: "app-label"
+                },
+                id: "alertEmailAddresses",
+                name: "alertEmailAddresses",
+                hint: {
+                  text: "Comma seperated list of email addresses"
+                },
+                classes: "app-input app-input--wide",
+                formGroup: {
+                  classes: "app-form-group app-form-group-js"
+                },
+                attributes: {
+                  "data-1p-ignore": ""
+                },
+                value: formValues.alertEmailAddresses,
+                errorMessage: {
+                  attributes: {
+                    "data-js": "app-error"
+                  },
+                  text: formErrors.alertEmailAddresses.message,
+                  classes: "govuk-!-margin-bottom-1 app-error-message"
+                } if formErrors.alertEmailAddresses.message
+              }) }}
+
               {{ govukTextarea({
                 label: {
                   text: "Description (optional)",

--- a/src/server/admin/teams/views/teams-list.njk
+++ b/src/server/admin/teams/views/teams-list.njk
@@ -18,10 +18,11 @@
 
       {{ appEntityList({
         headings: [
-          { text: "Name", size: "large" },
-          { text: "Description", size: "massive" },
+          { text: "Name", size: "medium" },
+          { text: "Description", size: "medium" },
           { text: "GitHub team", size: "medium" },
-          { text: "Service Codes", size: "medium" },
+          { text: "Service Codes", size: "small" },
+          { text: "Alert Emails", size: "large" },
           { text: "Members", size: "small" }
         ],
         entityRows: entityRows,

--- a/src/server/teams/transformers/team-to-entity-data-list.js
+++ b/src/server/teams/transformers/team-to-entity-data-list.js
@@ -26,6 +26,15 @@ function teamToEntityDataList(team) {
     },
     {
       heading: {
+        text: 'Alert Emails'
+      },
+      entity: {
+        kind: 'html',
+        value: team.alertEmailAddresses?.join('<br>')
+      }
+    },
+    {
+      heading: {
         text: 'Last updated'
       },
       entity: {

--- a/src/server/teams/transformers/team-to-entity-data-list.test.js
+++ b/src/server/teams/transformers/team-to-entity-data-list.test.js
@@ -29,6 +29,15 @@ describe('#teamToEntityDataList', () => {
       },
       {
         entity: {
+          kind: 'html',
+          value: 'alerts@cdp.com'
+        },
+        heading: {
+          text: 'Alert Emails'
+        }
+      },
+      {
+        entity: {
           kind: 'date',
           value: '2023-10-03T11:11:31.085Z'
         },


### PR DESCRIPTION
Raising this a draft as I had a few questions/ stylistic elements I wanted agreement on:
- Are we happy with the name `Email Addresses for Alerts`? 
- Are we happy with the casing of `Email Addresses for Alerts` - we have `GitHub team` and `Service Code`
- I tried to use the `list` kind but this doesn't appear to work for entityLists. Am using html with `team.alertEmailAddresses?.join('<br>')`. The presentation looks nice, but wanted confirmation we're happy with this
- When entering the email addresses, I've put the text entry as a comma separated list. It'll just be us seeing it so seems fine, but do we want this to be a list instead?
- I adjusted the size of the columns on the admin/teams presentation to remove some of the whitespace are we happy with this?
<img width="1514" alt="Screenshot 2024-11-13 at 17 08 40" src="https://github.com/user-attachments/assets/c3a4505c-b8fc-4b37-a974-2eb5b35cfda4">
<img width="1350" alt="Screenshot 2024-11-13 at 17 08 54" src="https://github.com/user-attachments/assets/8ceb946d-1992-4620-b17a-2208ac4132cd">
<img width="742" alt="Screenshot 2024-11-13 at 17 09 43" src="https://github.com/user-attachments/assets/c66b8c4e-42e4-456d-b4e4-02b22823c32f">
<img width="944" alt="Screenshot 2024-11-13 at 17 09 53" src="https://github.com/user-attachments/assets/1df4ad3d-efa9-4300-bce6-934cdda3d2c5">
<img width="884" alt="Screenshot 2024-11-13 at 17 10 13" src="https://github.com/user-attachments/assets/7e9d54f4-91d7-499b-97d5-87bd7599e65d">
<img width="1873" alt="Screenshot 2024-11-13 at 17 10 26" src="https://github.com/user-attachments/assets/5c9af328-a08e-4bc2-8479-c81c72402592">
