### PR TITLE
471322 node tracing

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,8 +1,6 @@
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
-import convict from 'convict'
+import { cwd } from 'node:process'
 
-const dirname = path.dirname(fileURLToPath(import.meta.url))
+import convict from 'convict'
 
 const oneHour = 1000 * 60 * 60
 const eightHours = 1000 * 60 * 60 * 8
@@ -50,7 +48,7 @@ const config = convict({
   root: {
     doc: 'Project root',
     format: String,
-    default: path.normalize(path.resolve(dirname, '..', '..'))
+    default: cwd()
   },
   appBaseUrl: {
     doc: 'Application base URL',

--- a/src/server/admin/features/index.js
+++ b/src/server/admin/features/index.js
@@ -6,7 +6,6 @@ import {
   listFeaturesController
 } from '~/src/server/admin/features/controllers/index.js'
 import { scopes } from '~/src/server/common/constants/scopes.js'
-import { withTracing } from '~/src/server/common/helpers/tracing/tracing.js'
 
 const adminScope = authScope([`+${scopes.admin}`])
 
@@ -41,9 +40,7 @@ const features = {
             path: '/admin/features',
             ...listFeaturesController
           }
-        ]
-          .map(adminScope)
-          .map(withTracing)
+        ].map(adminScope)
       )
     }
   }

--- a/src/server/admin/index.js
+++ b/src/server/admin/index.js
@@ -1,7 +1,6 @@
 import { adminUsers } from '~/src/server/admin/users/index.js'
 import { adminTeams } from '~/src/server/admin/teams/index.js'
 import { features } from '~/src/server/admin/features/index.js'
-import { withTracing } from '~/src/server/common/helpers/tracing/tracing.js'
 
 const admin = {
   plugin: {
@@ -9,15 +8,13 @@ const admin = {
     register: async (server) => {
       await server.register([adminUsers, adminTeams, features])
 
-      server.route(
-        [
-          {
-            method: 'GET',
-            path: '/admin',
-            handler: (request, h) => h.redirect('/admin/users')
-          }
-        ].map(withTracing)
-      )
+      server.route([
+        {
+          method: 'GET',
+          path: '/admin',
+          handler: (request, h) => h.redirect('/admin/users')
+        }
+      ])
     }
   }
 }

--- a/src/server/admin/teams/index.js
+++ b/src/server/admin/teams/index.js
@@ -22,7 +22,6 @@ import {
 import { scopes } from '~/src/server/common/constants/scopes.js'
 import { deleteTeamController } from '~/src/server/admin/teams/controllers/delete/delete-team.js'
 import { confirmDeleteTeamController } from '~/src/server/admin/teams/controllers/delete/confirm-delete-team.js'
-import { withTracing } from '~/src/server/common/helpers/tracing/tracing.js'
 
 const adminScope = authScope([`+${scopes.admin}`])
 
@@ -137,9 +136,7 @@ const adminTeams = {
             path: '/admin/teams/{teamId}',
             ...teamController
           }
-        ]
-          .map(adminScope)
-          .map(withTracing)
+        ].map(adminScope)
       )
     }
   }

--- a/src/server/admin/users/index.js
+++ b/src/server/admin/users/index.js
@@ -21,7 +21,6 @@ import {
   userSummaryController
 } from '~/src/server/admin/users/controllers/index.js'
 import { scopes } from '~/src/server/common/constants/scopes.js'
-import { withTracing } from '~/src/server/common/helpers/tracing/tracing.js'
 
 const adminScope = authScope([`+${scopes.admin}`])
 
@@ -131,9 +130,7 @@ const adminUsers = {
             path: '/admin/users/{userId}',
             ...userController
           }
-        ]
-          .map(adminScope)
-          .map(withTracing)
+        ].map(adminScope)
       )
     }
   }

--- a/src/server/auth/index.js
+++ b/src/server/auth/index.js
@@ -1,17 +1,14 @@
 import { authCallbackController } from '~/src/server/auth/controller.js'
-import { withTracing } from '~/src/server/common/helpers/tracing/tracing.js'
 
 const auth = {
   plugin: {
     name: 'auth',
     register: (server) => {
-      server.route(
-        withTracing({
-          method: ['GET', 'POST'],
-          path: '/auth/callback',
-          ...authCallbackController
-        })
-      )
+      server.route({
+        method: ['GET', 'POST'],
+        path: '/auth/callback',
+        ...authCallbackController
+      })
     }
   }
 }

--- a/src/server/common/helpers/logging/logger-options.js
+++ b/src/server/common/helpers/logging/logger-options.js
@@ -10,17 +10,7 @@ const serviceConfig = config.get('service')
  * @type {{ecs: Omit<LoggerOptions, "mixin"|"transport">, "pino-pretty": {transport: {target: string}}}}
  */
 const formatters = {
-  ecs: {
-    ...ecsFormat(),
-    base: {
-      service: {
-        name: serviceConfig.name,
-        type: 'nodeJs',
-        version: serviceConfig.version,
-        environment: serviceConfig.environment
-      }
-    }
-  },
+  ecs: ecsFormat(),
   'pino-pretty': { transport: { target: 'pino-pretty' } }
 }
 
@@ -37,11 +27,23 @@ export const loggerOptions = {
   level: logConfig.level,
   ...formatters[logConfig.format],
   mixin() {
-    return {
-      trace: {
-        id: getTraceId()
+    const mixinValues = {}
+    const traceId = getTraceId()
+
+    if (serviceConfig.version) {
+      mixinValues.service = {
+        name: serviceConfig.name,
+        type: 'nodeJs',
+        version: serviceConfig.version,
+        environment: serviceConfig.environment
       }
     }
+
+    if (traceId) {
+      mixinValues.trace = { id: traceId }
+    }
+
+    return mixinValues
   }
 }
 

--- a/src/server/common/helpers/logging/logger-options.js
+++ b/src/server/common/helpers/logging/logger-options.js
@@ -1,9 +1,11 @@
 import { ecsFormat } from '@elastic/ecs-pino-format'
 
+import { getTraceId } from '~/src/server/common/helpers/tracing/async-local-storage.js'
 import { config } from '~/src/config/index.js'
 
 const logConfig = config.get('log')
 const serviceConfig = config.get('service')
+const tracingHeader = config.get('tracing.header')
 
 /**
  * @type {{ecs: Omit<LoggerOptions, "mixin"|"transport">, "pino-pretty": {transport: {target: string}}}}
@@ -34,7 +36,12 @@ export const loggerOptions = {
     remove: true
   },
   level: logConfig.level,
-  ...formatters[logConfig.format]
+  ...formatters[logConfig.format],
+  mixin() {
+    return {
+      [tracingHeader]: getTraceId()
+    }
+  }
 }
 
 /**

--- a/src/server/common/helpers/logging/logger-options.js
+++ b/src/server/common/helpers/logging/logger-options.js
@@ -5,7 +5,6 @@ import { config } from '~/src/config/index.js'
 
 const logConfig = config.get('log')
 const serviceConfig = config.get('service')
-const tracingHeader = config.get('tracing.header')
 
 /**
  * @type {{ecs: Omit<LoggerOptions, "mixin"|"transport">, "pino-pretty": {transport: {target: string}}}}
@@ -39,7 +38,9 @@ export const loggerOptions = {
   ...formatters[logConfig.format],
   mixin() {
     return {
-      [tracingHeader]: getTraceId()
+      trace: {
+        id: getTraceId()
+      }
     }
   }
 }

--- a/src/server/common/helpers/tracing/async-local-storage.js
+++ b/src/server/common/helpers/tracing/async-local-storage.js
@@ -1,0 +1,6 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+const asyncLocalStorage = new AsyncLocalStorage()
+const getTraceId = () => asyncLocalStorage.getStore()?.get('traceId')
+
+export { asyncLocalStorage, getTraceId }

--- a/src/server/common/helpers/tracing/tracing.js
+++ b/src/server/common/helpers/tracing/tracing.js
@@ -4,6 +4,12 @@ import {
 } from '~/src/server/common/helpers/tracing/async-local-storage.js'
 import { config } from '~/src/config/index.js'
 
+/**
+ * Wrap the request lifecycle in an asyncLocalStorage run call. This allows the
+ * passed store to be available during the request lifecycle.
+ * @param { Request } request
+ * @param { Map<string, string> } store
+ */
 function wrapLifecycle(request, store) {
   const requestLifecycle = request._lifecycle.bind(request)
   request._lifecycle = () => asyncLocalStorage.run(store, requestLifecycle)
@@ -43,5 +49,5 @@ const tracing = {
 export { tracing }
 
 /**
- * @import { Plugin } from '@hapi/hapi'
+ * @import { Request, Plugin } from '@hapi/hapi'
  */

--- a/src/server/common/helpers/tracing/tracing.js
+++ b/src/server/common/helpers/tracing/tracing.js
@@ -1,38 +1,47 @@
-import { AsyncLocalStorage } from 'node:async_hooks'
+import {
+  asyncLocalStorage,
+  getTraceId
+} from '~/src/server/common/helpers/tracing/async-local-storage.js'
 import { config } from '~/src/config/index.js'
 
-const asyncLocalStorage = new AsyncLocalStorage()
+function wrapLifecycle(request, store) {
+  const requestLifecycle = request._lifecycle.bind(request)
+  request._lifecycle = () => asyncLocalStorage.run(store, requestLifecycle)
+}
 
-function tracingMiddleware(handler) {
-  return (req, h) => {
-    if (req.headers?.[config.get('tracing.header')]) {
-      const requestId = req.headers?.[config.get('tracing.header')] || ''
-      // eslint-disable-next-line @typescript-eslint/require-await
-      return asyncLocalStorage.run({ requestId }, async () => {
-        return await handler(req, h)
-      })
+/**
+ * @satisfies {Plugin}
+ */
+const tracing = {
+  plugin: {
+    name: 'tracing',
+    version: '0.1.0',
+    register(server, options) {
+      if (options.tracingEnabled) {
+        server.ext('onRequest', (request, h) => {
+          const tracingHeader = options.tracingHeader
+          const traceId = request.headers[tracingHeader]
+          const store = new Map()
+          store.set('traceId', traceId)
+
+          wrapLifecycle(request, store)
+
+          return h.continue
+        })
+      }
+
+      server.decorate('request', 'getTraceId', getTraceId)
+      server.decorate('server', 'getTraceId', getTraceId)
     }
-    return handler(req, h)
+  },
+  options: {
+    tracingEnabled: config.get('tracing.enabled'),
+    tracingHeader: config.get('tracing.header')
   }
 }
 
-export function getTraceId() {
-  return asyncLocalStorage.getStore()?.requestId
-}
+export { tracing }
 
-export function withTracing(routes) {
-  if (!config.get('tracing.enabled')) {
-    return routes
-  }
-
-  const applyTracing = (route) => ({
-    ...route,
-    handler: tracingMiddleware(route.handler)
-  })
-
-  if (Array.isArray(routes)) {
-    return routes.map(applyTracing)
-  }
-
-  return applyTracing(routes)
-}
+/**
+ * @import { Plugin } from '@hapi/hapi'
+ */

--- a/src/server/common/helpers/tracing/tracing.test.js
+++ b/src/server/common/helpers/tracing/tracing.test.js
@@ -1,61 +1,155 @@
-import { config } from '~/src/config/index.js'
-import {
-  getTraceId,
-  withTracing
-} from '~/src/server/common/helpers/tracing/tracing.js'
+import { Server } from '@hapi/hapi'
+
+import { tracing } from '~/src/server/common/helpers/tracing/tracing.js'
 
 describe('#tracing', () => {
-  const route = {
-    handler: (req, h) => {
-      return { req, h, traceId: getTraceId() }
-    }
-  }
+  describe('When tracing is enabled', () => {
+    let server
 
-  const req = {
-    headers: {
-      'x-cdp-request-id': '12345'
-    }
-  }
+    beforeEach(async () => {
+      server = new Server()
 
-  it('apply tracing to a single route', async () => {
-    config.set('tracing.enabled', true)
-    const routeWithTracing = withTracing(route)
-    const resp = await routeWithTracing.handler(req, {})
-    expect(resp?.traceId).toBe('12345')
+      await server.register({
+        plugin: tracing.plugin,
+        options: { tracingEnabled: true, tracingHeader: 'x-cdp-request-id' }
+      })
+    })
+
+    afterEach(async () => {
+      await server.stop({ timeout: 0 })
+    })
+
+    test('Should register the plugin', () => {
+      expect(server.registrations).toEqual({
+        tracing: {
+          name: 'tracing',
+          options: { tracingEnabled: true, tracingHeader: 'x-cdp-request-id' },
+          version: '0.1.0'
+        }
+      })
+    })
+
+    test('Should have expected decorations', () => {
+      expect(server.decorations.request).toStrictEqual(['getTraceId'])
+      expect(server.decorations.server).toStrictEqual(['getTraceId'])
+    })
+
+    test('Should add "x-cdp-request-id" to the request store', async () => {
+      const mockTraceId = 'mock-trace-id-123456789'
+
+      server.route({
+        method: 'GET',
+        path: '/testing',
+        handler: (request, h) => {
+          expect(request.getTraceId()).toBe(mockTraceId)
+
+          return h.response({ message: 'success' }).code(200)
+        }
+      })
+
+      const { result, statusCode } = await server.inject({
+        method: 'GET',
+        url: '/testing',
+        headers: { 'x-cdp-request-id': mockTraceId }
+      })
+
+      expect(result).toEqual({ message: 'success' })
+      expect(statusCode).toBe(200)
+      expect.assertions(3)
+    })
   })
 
-  it('apply tracing to an array of routes', async () => {
-    config.set('tracing.enabled', true)
-    const routeWithTracing = withTracing([route, route])
+  describe('Without "x-cdp-request-id" header', () => {
+    let server
 
-    const resp1 = await routeWithTracing[0].handler(req, {})
-    expect(resp1?.traceId).toBe('12345')
+    beforeEach(async () => {
+      server = new Server()
 
-    const resp2 = await routeWithTracing[1].handler(req, {})
-    expect(resp2?.traceId).toBe('12345')
+      await server.register({
+        plugin: tracing.plugin,
+        options: { tracingEnabled: true, tracingHeader: 'x-cdp-request-id' }
+      })
+    })
+
+    afterEach(async () => {
+      await server.stop({ timeout: 0 })
+    })
+
+    test('"x-cdp-request-id" should not be in the request store', async () => {
+      server.route({
+        method: 'GET',
+        path: '/cats-url',
+        handler: (request, h) => {
+          expect(request.getTraceId()).toBeUndefined()
+
+          return h.response({ message: 'success' }).code(200)
+        }
+      })
+
+      const { result, statusCode } = await server.inject({
+        method: 'GET',
+        url: '/cats-url'
+      })
+
+      expect(result).toEqual({ message: 'success' })
+      expect(statusCode).toBe(200)
+      expect.assertions(3)
+    })
   })
 
-  it('not apply tracing to an array of routes when disabled', async () => {
-    config.set('tracing.enabled', false)
-    const routeWithTracing = withTracing(route)
-    const resp = await routeWithTracing.handler(req, {})
-    expect(resp?.traceId).toBeUndefined()
-  })
+  describe('When tracing is disabled', () => {
+    let server
 
-  it('work when header is not present', async () => {
-    config.set('tracing.enabled', true)
-    const routeWithTracing = withTracing(route)
-    const resp = await routeWithTracing.handler({}, {})
-    expect(resp?.traceId).toBeUndefined()
-  })
+    beforeEach(async () => {
+      server = new Server()
 
-  it('work when header is present but blank', async () => {
-    config.set('tracing.enabled', true)
-    const routeWithTracing = withTracing(route)
-    const resp = await routeWithTracing.handler(
-      { headers: { 'x-cdp-request-id': '' } },
-      {}
-    )
-    expect(resp?.traceId).toBeUndefined()
+      await server.register({
+        plugin: tracing.plugin,
+        options: { tracingEnabled: false, tracingHeader: 'x-cdp-request-id' }
+      })
+    })
+
+    afterEach(async () => {
+      await server.stop({ timeout: 0 })
+    })
+
+    test('Should have registered the plugin', () => {
+      expect(server.registrations).toEqual({
+        tracing: {
+          name: 'tracing',
+          options: { tracingEnabled: false, tracingHeader: 'x-cdp-request-id' },
+          version: '0.1.0'
+        }
+      })
+    })
+
+    test('Should have expected decorations', () => {
+      expect(server.decorations.request).toStrictEqual(['getTraceId'])
+      expect(server.decorations.server).toStrictEqual(['getTraceId'])
+    })
+
+    test('Should not add "x-cdp-request-id" to the request store', async () => {
+      const mockTraceId = 'mock-trace-id-4564569'
+
+      server.route({
+        method: 'GET',
+        path: '/different-url',
+        handler: (request, h) => {
+          expect(request.getTraceId()).toBeUndefined()
+
+          return h.response({ message: 'success' }).code(200)
+        }
+      })
+
+      const { result, statusCode } = await server.inject({
+        method: 'GET',
+        url: '/different-url',
+        headers: { 'x-cdp-request-id': mockTraceId }
+      })
+
+      expect(result).toEqual({ message: 'success' })
+      expect(statusCode).toBe(200)
+      expect.assertions(3)
+    })
   })
 })

--- a/src/server/create/index.js
+++ b/src/server/create/index.js
@@ -15,7 +15,6 @@ import { createEnvTestSuiteRoutes } from '~/src/server/create/env-test-suite/ind
 import { createPerfTestSuiteRoutes } from '~/src/server/create/perf-test-suite/index.js'
 import { provideFormContextValues } from '~/src/server/common/helpers/form/provide-form-context-values.js'
 import { createSmokeTestSuiteRoutes } from '~/src/server/create/smoke-test-suite/index.js'
-import { withTracing } from '~/src/server/common/helpers/tracing/tracing.js'
 
 const serviceTeamAndAdminUserScope = authScope([scopes.tenant, scopes.admin])
 
@@ -69,9 +68,7 @@ const create = {
           ...createTestSuiteRoutes,
           ...createPerfTestSuiteRoutes,
           ...createSmokeTestSuiteRoutes
-        ]
-          .map(serviceTeamAndAdminUserScope)
-          .map(withTracing)
+        ].map(serviceTeamAndAdminUserScope)
       )
     }
   }

--- a/src/server/deploy-service/index.js
+++ b/src/server/deploy-service/index.js
@@ -16,7 +16,6 @@ import {
   urls,
   formSteps
 } from '~/src/server/deploy-service/helpers/multistep-form/steps.js'
-import { withTracing } from '~/src/server/common/helpers/tracing/tracing.js'
 
 const serviceTeamAndAdminUserScope = authScope([scopes.tenant, scopes.admin])
 
@@ -69,9 +68,7 @@ const deployService = {
               path: '/deploy-service/deploy/{multiStepFormId}',
               ...deployController
             }
-          ]
-            .map(serviceTeamAndAdminUserScope)
-            .map(withTracing)
+          ].map(serviceTeamAndAdminUserScope)
         }
       })
 
@@ -87,9 +84,7 @@ const deployService = {
             path: '/deploy-service/available-memory',
             ...availableMemoryController
           }
-        ]
-          .map(serviceTeamAndAdminUserScope)
-          .map(withTracing)
+        ].map(serviceTeamAndAdminUserScope)
       )
     }
   }

--- a/src/server/deployments/index.js
+++ b/src/server/deployments/index.js
@@ -4,7 +4,6 @@ import {
   deploymentsListController
 } from '~/src/server/deployments/controllers/index.js'
 import { pagination } from '~/src/server/common/constants/pagination.js'
-import { withTracing } from '~/src/server/common/helpers/tracing/tracing.js'
 
 const deployments = {
   plugin: {
@@ -20,28 +19,26 @@ const deployments = {
         }
       ])
 
-      server.route(
-        [
-          {
-            method: 'GET',
-            path: '/deployments',
-            handler: (request, h) =>
-              h.redirect(
-                `/deployments/dev?page=${pagination.page}&size=${pagination.size}`
-              )
-          },
-          {
-            method: 'GET',
-            path: '/deployments/{environment}',
-            ...deploymentsListController
-          },
-          {
-            method: 'GET',
-            path: '/deployments/{environment}/{deploymentId}',
-            ...deploymentController
-          }
-        ].map(withTracing)
-      )
+      server.route([
+        {
+          method: 'GET',
+          path: '/deployments',
+          handler: (request, h) =>
+            h.redirect(
+              `/deployments/dev?page=${pagination.page}&size=${pagination.size}`
+            )
+        },
+        {
+          method: 'GET',
+          path: '/deployments/{environment}',
+          ...deploymentsListController
+        },
+        {
+          method: 'GET',
+          path: '/deployments/{environment}/{deploymentId}',
+          ...deploymentController
+        }
+      ])
     }
   }
 }

--- a/src/server/home/index.js
+++ b/src/server/home/index.js
@@ -1,19 +1,16 @@
 import { homeController } from '~/src/server/home/controller.js'
-import { withTracing } from '~/src/server/common/helpers/tracing/tracing.js'
 
 const home = {
   plugin: {
     name: 'home',
     register: (server) => {
-      server.route(
-        [
-          {
-            method: 'GET',
-            path: '/',
-            ...homeController
-          }
-        ].map(withTracing)
-      )
+      server.route([
+        {
+          method: 'GET',
+          path: '/',
+          ...homeController
+        }
+      ])
     }
   }
 }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -24,6 +24,7 @@ import { pulse } from '~/src/server/common/helpers/pulse.js'
 import { addDecorators } from '~/src/server/common/helpers/add-decorators.js'
 import { s3Client } from '~/src/server/common/helpers/aws/s3-client.js'
 import { contentSecurityPolicy } from '~/src/server/common/helpers/csp/content-security-policy.js'
+import { tracing } from '~/src/server/common/helpers/tracing/tracing.js'
 
 const enableSecureContext = config.get('enableSecureContext')
 
@@ -97,8 +98,8 @@ async function createServer() {
 
   addDecorators(server)
 
-  // Add request logger before all other plugins, so we can see errors
-  await server.register(requestLogger)
+  // Add tracer and request logger before all other plugins
+  await server.register([tracing, requestLogger])
 
   if (enableSecureContext) {
     await server.register(secureContext)

--- a/src/server/login/index.js
+++ b/src/server/login/index.js
@@ -1,19 +1,16 @@
 import { loginController } from '~/src/server/login/controller.js'
-import { withTracing } from '~/src/server/common/helpers/tracing/tracing.js'
 
 const login = {
   plugin: {
     name: 'login',
     register: (server) => {
-      server.route(
-        [
-          {
-            method: 'GET',
-            path: '/login',
-            ...loginController
-          }
-        ].map(withTracing)
-      )
+      server.route([
+        {
+          method: 'GET',
+          path: '/login',
+          ...loginController
+        }
+      ])
     }
   }
 }

--- a/src/server/logout/index.js
+++ b/src/server/logout/index.js
@@ -1,19 +1,16 @@
 import { logoutController } from '~/src/server/logout/controller.js'
-import { withTracing } from '~/src/server/common/helpers/tracing/tracing.js'
 
 const logout = {
   plugin: {
     name: 'logout',
     register: (server) => {
-      server.route(
-        [
-          {
-            method: 'GET',
-            path: '/logout',
-            ...logoutController
-          }
-        ].map(withTracing)
-      )
+      server.route([
+        {
+          method: 'GET',
+          path: '/logout',
+          ...logoutController
+        }
+      ])
     }
   }
 }

--- a/src/server/running-services/index.js
+++ b/src/server/running-services/index.js
@@ -1,19 +1,16 @@
 import { runningServicesListController } from '~/src/server/running-services/controllers/index.js'
-import { withTracing } from '~/src/server/common/helpers/tracing/tracing.js'
 
 const runningServices = {
   plugin: {
     name: 'running services',
     register: (server) => {
-      server.route(
-        [
-          {
-            method: 'GET',
-            path: '/running-services',
-            ...runningServicesListController
-          }
-        ].map(withTracing)
-      )
+      server.route([
+        {
+          method: 'GET',
+          path: '/running-services',
+          ...runningServicesListController
+        }
+      ])
     }
   }
 }

--- a/src/server/services/about/index.js
+++ b/src/server/services/about/index.js
@@ -5,7 +5,6 @@ import {
 } from '~/src/server/services/about/controllers/index.js'
 import { provideTabs } from '~/src/server/services/helpers/provide-tabs.js'
 import { provideService } from '~/src/server/services/helpers/provide-service.js'
-import { withTracing } from '~/src/server/common/helpers/tracing/tracing.js'
 
 const aboutService = {
   plugin: {
@@ -28,26 +27,24 @@ const aboutService = {
         }
       ])
 
-      server.route(
-        [
-          {
-            method: 'GET',
-            path: '/services',
-            ...serviceListController
-          },
-          {
-            method: 'GET',
-            path: '/services/{serviceId}',
-            ...serviceController
-          },
-          {
-            method: 'GET',
-            // TODO align this url with the other services urls: '/services/{serviceId}/create-status'
-            path: '/services/create-status/{serviceId}',
-            ...serviceCreateStatusController
-          }
-        ].map(withTracing)
-      )
+      server.route([
+        {
+          method: 'GET',
+          path: '/services',
+          ...serviceListController
+        },
+        {
+          method: 'GET',
+          path: '/services/{serviceId}',
+          ...serviceController
+        },
+        {
+          method: 'GET',
+          // TODO align this url with the other services urls: '/services/{serviceId}/create-status'
+          path: '/services/create-status/{serviceId}',
+          ...serviceCreateStatusController
+        }
+      ])
     }
   }
 }

--- a/src/server/services/secrets/index.js
+++ b/src/server/services/secrets/index.js
@@ -12,7 +12,6 @@ import { provideSubNavigation } from '~/src/server/services/secrets/helpers/prov
 import { addServiceOwnerScope } from '~/src/server/services/helpers/add-service-owner-scope.js'
 import { provideFormContextValues } from '~/src/server/common/helpers/form/provide-form-context-values.js'
 import { provideService } from '~/src/server/services/helpers/provide-service.js'
-import { withTracing } from '~/src/server/common/helpers/tracing/tracing.js'
 
 const serviceOwnerOrAdminUserScope = authScope([
   scopes.admin,
@@ -89,9 +88,7 @@ const serviceSecrets = {
             path: '/services/{serviceId}/secrets/{environment}/create',
             ...createSecretController
           }
-        ]
-          .map(serviceOwnerOrAdminUserScope)
-          .map(withTracing)
+        ].map(serviceOwnerOrAdminUserScope)
       )
     }
   }

--- a/src/server/services/terminal/index.js
+++ b/src/server/services/terminal/index.js
@@ -9,7 +9,6 @@ import { provideTabs } from '~/src/server/services/helpers/provide-tabs.js'
 import { provideService } from '~/src/server/services/helpers/provide-service.js'
 import { addServiceOwnerScope } from '~/src/server/services/helpers/add-service-owner-scope.js'
 import { provideFormContextValues } from '~/src/server/common/helpers/form/provide-form-context-values.js'
-import { withTracing } from '~/src/server/common/helpers/tracing/tracing.js'
 
 const serviceOwnerOrAdminUserScope = authScope([
   scopes.admin,
@@ -69,9 +68,7 @@ const serviceTerminal = {
             path: '/services/{serviceId}/terminal/{environment}/{token}',
             ...webShellBrowserController
           }
-        ]
-          .map(serviceOwnerOrAdminUserScope)
-          .map(withTracing)
+        ].map(serviceOwnerOrAdminUserScope)
       )
     }
   }

--- a/src/server/teams/index.js
+++ b/src/server/teams/index.js
@@ -11,7 +11,6 @@ import {
 import { authScope } from '~/src/server/common/helpers/auth/auth-scope.js'
 import { sessionNames } from '~/src/server/common/constants/session-names.js'
 import { provideFormContextValues } from '~/src/server/common/helpers/form/provide-form-context-values.js'
-import { withTracing } from '~/src/server/common/helpers/tracing/tracing.js'
 
 const teamScope = authScope(['+{params.teamId}'])
 
@@ -30,52 +29,50 @@ const teams = {
         }
       ])
 
-      server.route(
-        [
+      server.route([
+        {
+          method: 'GET',
+          path: '/teams',
+          ...teamsListController
+        },
+        {
+          method: 'GET',
+          path: '/teams/{teamId}',
+          ...teamController
+        },
+        ...[
           {
             method: 'GET',
-            path: '/teams',
-            ...teamsListController
+            path: '/teams/{teamId}/edit',
+            ...teamEditStartController
           },
           {
             method: 'GET',
-            path: '/teams/{teamId}',
-            ...teamController
+            path: '/teams/{teamId}/team-details',
+            ...teamDetailsFormController
           },
-          ...[
-            {
-              method: 'GET',
-              path: '/teams/{teamId}/edit',
-              ...teamEditStartController
-            },
-            {
-              method: 'GET',
-              path: '/teams/{teamId}/team-details',
-              ...teamDetailsFormController
-            },
-            {
-              method: 'POST',
-              path: '/teams/{teamId}/team-details',
-              ...teamDetailsController
-            },
-            {
-              method: 'GET',
-              path: '/teams/{teamId}/add-member',
-              ...addMemberFormController
-            },
-            {
-              method: 'POST',
-              path: '/teams/{teamId}/add-member',
-              ...addMemberController
-            },
-            {
-              method: 'POST',
-              path: '/teams/{teamId}/remove-member/{userId}',
-              ...removeMemberController
-            }
-          ].map(teamScope)
-        ].map(withTracing)
-      )
+          {
+            method: 'POST',
+            path: '/teams/{teamId}/team-details',
+            ...teamDetailsController
+          },
+          {
+            method: 'GET',
+            path: '/teams/{teamId}/add-member',
+            ...addMemberFormController
+          },
+          {
+            method: 'POST',
+            path: '/teams/{teamId}/add-member',
+            ...addMemberController
+          },
+          {
+            method: 'POST',
+            path: '/teams/{teamId}/remove-member/{userId}',
+            ...removeMemberController
+          }
+        ].map(teamScope)
+      ])
     }
   }
 }

--- a/src/server/test-suites/index.js
+++ b/src/server/test-suites/index.js
@@ -8,7 +8,6 @@ import {
   testSuiteReportController
 } from '~/src/server/test-suites/controllers/index.js'
 import { stopTestSuiteController } from '~/src/server/test-suites/controllers/stop-test-suite.js'
-import { withTracing } from '~/src/server/common/helpers/tracing/tracing.js'
 
 const testSuites = {
   plugin: {
@@ -25,45 +24,43 @@ const testSuites = {
         }
       ])
 
-      server.route(
-        [
-          {
-            method: 'GET',
-            path: '/test-suites',
-            ...testSuiteListController
-          },
-          {
-            method: 'GET',
-            path: '/test-suites/{serviceId}',
-            ...testSuiteController
-          },
-          {
-            method: 'GET',
-            path: '/test-suites/create-status/{serviceId}',
-            ...testSuiteStatusController
-          },
-          {
-            method: 'POST',
-            path: '/test-suites/run',
-            ...triggerTestSuiteRunController
-          },
-          {
-            method: 'POST',
-            path: '/test-suites/{serviceId}/{runId}/stop',
-            ...stopTestSuiteController
-          },
-          {
-            method: 'GET',
-            path: '/test-suites/test-results/{environment}/{tag}/{serviceId}/{runId}/{assetPath*}',
-            ...testResultsController
-          },
-          {
-            method: 'GET',
-            path: '/test-suites/report/{environment}/{serviceId}/{runId}/{assetPath*}',
-            ...testSuiteReportController
-          }
-        ].map(withTracing)
-      )
+      server.route([
+        {
+          method: 'GET',
+          path: '/test-suites',
+          ...testSuiteListController
+        },
+        {
+          method: 'GET',
+          path: '/test-suites/{serviceId}',
+          ...testSuiteController
+        },
+        {
+          method: 'GET',
+          path: '/test-suites/create-status/{serviceId}',
+          ...testSuiteStatusController
+        },
+        {
+          method: 'POST',
+          path: '/test-suites/run',
+          ...triggerTestSuiteRunController
+        },
+        {
+          method: 'POST',
+          path: '/test-suites/{serviceId}/{runId}/stop',
+          ...stopTestSuiteController
+        },
+        {
+          method: 'GET',
+          path: '/test-suites/test-results/{environment}/{tag}/{serviceId}/{runId}/{assetPath*}',
+          ...testResultsController
+        },
+        {
+          method: 'GET',
+          path: '/test-suites/report/{environment}/{serviceId}/{runId}/{assetPath*}',
+          ...testSuiteReportController
+        }
+      ])
     }
   }
 }

--- a/types/cdp-portal-frontend.d.ts
+++ b/types/cdp-portal-frontend.d.ts
@@ -18,10 +18,12 @@ declare module '@hapi/hapi' {
     userIsMemberOfATeam: (scopes: string[]) => Promise<boolean>
     userIsServiceOwner: (scopes: string[]) => Promise<boolean>
     userIsTeamMember: (scope: string) => Promise<boolean>
+    getTraceId: () => string | undefined
   }
 
   interface Server {
     s3Client: S3Client
     secureContext: SecureContext
+    getTraceId: () => string | undefined
   }
 }


### PR DESCRIPTION
Bit of a simplification and refactor on this work:
- remove the need to add `withTracer` on all routes
- get `AsyncLocalStorage` to play nice with Hapi.js 
- add `x-cdp-request-id` to logging `mixin`
- add `debug` logs to all `fetcher` and `authedFetcher` calls


