### PR TITLE
Fix issue with emails not allowed to be blank

### DIFF
--- a/src/server/admin/teams/controllers/save/team-details.js
+++ b/src/server/admin/teams/controllers/save/team-details.js
@@ -13,11 +13,12 @@ const teamDetailsController = {
     const payload = request?.payload
     const redirectLocation = payload?.redirectLocation
 
-    const name = payload?.name || undefined
-    const description = payload?.description || undefined
-    const serviceCode = payload?.serviceCode || undefined
-    const alertEmailAddresses =
-      payload?.alertEmailAddresses?.split(/\s*,\s*/) || undefined
+    const name = payload.name
+    const description = payload.description || undefined
+    const serviceCode = payload.serviceCode || undefined
+    const alertEmailAddresses = payload.alertEmailAddresses
+      ? payload.alertEmailAddresses.split(/\s*,\s*/)
+      : undefined
 
     const sanitisedPayload = {
       name,

--- a/src/server/admin/teams/helpers/schema/team-validation.js
+++ b/src/server/admin/teams/helpers/schema/team-validation.js
@@ -27,8 +27,8 @@ const teamValidation = Joi.object({
     }),
   alertEmailAddresses: Joi.array().items(Joi.string().email()).optional(),
   description: Joi.string()
-    .max(256)
     .optional()
+    .max(256)
     .messages({
       'string.max': validation.maxCharacters(256)
     })


### PR DESCRIPTION
## Issue
- When inputs are blank they are sent over as empty strings `""` so exist but are `falsey`
- The previous code would set `alertEmailAddresses` to `[""]` when no email had been entered into the input
- This would fail validation because the validation requires an array with emails, not an array with empty strings
```
ValidationError: "alertEmailAddresses[0]" is not allowed to be empty
```

## Fix
- Reworked the creation of the `alertEmailAddresses`
- Removed the optional chaining as there are always values here
- Moved `optional()` up the `Joi` chain to align with others