### PR TITLE
Refactor authed fetcher to work without request

### DIFF
--- a/src/server/admin/teams/helpers/fetch/add-member-to-team.test.js
+++ b/src/server/admin/teams/helpers/fetch/add-member-to-team.test.js
@@ -3,7 +3,7 @@ import nock from 'nock'
 import { config } from '~/src/config/index.js'
 import { cdpTeamFixture } from '~/src/__fixtures__/admin/cdp-team.js'
 import { addMemberToTeam } from '~/src/server/admin/teams/helpers/fetch/index.js'
-import { authedFetcher } from '~/src/server/common/helpers/fetch/authed-fetcher.js'
+import { authedFetcherDecorator } from '~/src/server/common/helpers/fetch/authed-fetcher.js'
 import { getError, NoErrorThrownError } from '~/test-helpers/get-error.js'
 
 describe('#addUserToTeam', () => {
@@ -13,7 +13,7 @@ describe('#addUserToTeam', () => {
     config.get('userServiceBackendUrl') + `/teams/${teamId}/add/${userId}`
   )
   const mockRequest = {
-    authedFetcher: authedFetcher({
+    authedFetcher: authedFetcherDecorator({
       getUserSession: jest.fn().mockResolvedValue({}),
       logger: {
         info: jest.fn(),

--- a/src/server/admin/teams/helpers/fetch/remove-member-from-team.test.js
+++ b/src/server/admin/teams/helpers/fetch/remove-member-from-team.test.js
@@ -3,7 +3,7 @@ import nock from 'nock'
 import { config } from '~/src/config/index.js'
 import { cdpTeamFixture } from '~/src/__fixtures__/admin/cdp-team.js'
 import { removeMemberFromTeam } from '~/src/server/admin/teams/helpers/fetch/index.js'
-import { authedFetcher } from '~/src/server/common/helpers/fetch/authed-fetcher.js'
+import { authedFetcherDecorator } from '~/src/server/common/helpers/fetch/authed-fetcher.js'
 import { getError, NoErrorThrownError } from '~/test-helpers/get-error.js'
 
 describe('#removeUserFromTeam', () => {
@@ -13,7 +13,7 @@ describe('#removeUserFromTeam', () => {
     config.get('userServiceBackendUrl') + `/teams/${teamId}/remove/${userId}`
   )
   const mockRequest = {
-    authedFetcher: authedFetcher({
+    authedFetcher: authedFetcherDecorator({
       getUserSession: jest.fn().mockResolvedValue({}),
       logger: {
         error: jest.fn(),

--- a/src/server/common/helpers/add-decorators.js
+++ b/src/server/common/helpers/add-decorators.js
@@ -1,6 +1,6 @@
 import { isXhr } from '~/src/server/common/helpers/is-xhr.js'
 import { routeLookupDecorator } from '~/src/server/common/helpers/route-lookup/index.js'
-import { authedFetcher } from '~/src/server/common/helpers/fetch/authed-fetcher.js'
+import { authedFetcherDecorator } from '~/src/server/common/helpers/fetch/authed-fetcher.js'
 import { getUserSession } from '~/src/server/common/helpers/auth/get-user-session.js'
 import { dropUserSession } from '~/src/server/common/helpers/auth/drop-user-session.js'
 import { userIsTeamMemberDecorator } from '~/src/server/common/helpers/user/user-is-team-member.js'
@@ -13,7 +13,7 @@ import { userIsServiceOwnerDecorator } from '~/src/server/common/helpers/user/us
  */
 function addDecorators(server) {
   server.decorate('request', 'isXhr', isXhr)
-  server.decorate('request', 'authedFetcher', authedFetcher, {
+  server.decorate('request', 'authedFetcher', authedFetcherDecorator, {
     apply: true
   })
   server.decorate('request', 'getUserSession', getUserSession)

--- a/src/server/create/journey-test-suite/views/detail-form.njk
+++ b/src/server/create/journey-test-suite/views/detail-form.njk
@@ -32,8 +32,7 @@
               name: "repositoryName",
               classes: "app-input app-input--wide",
               hint: {
-                html: "Lowercase letters, numbers and hyphens. Maximum 32 characters. E.g.
-                <em>birds-of-prey-user-journey-tests</em>",
+                html: "Lowercase letters, numbers and hyphens. Maximum 32 characters. E.g. seed-vault-journey-tests",
                 classes: "app-hint"
               },
               formGroup: {

--- a/src/server/create/microservice/views/detail-form.njk
+++ b/src/server/create/microservice/views/detail-form.njk
@@ -30,7 +30,7 @@
               name: "repositoryName",
               classes: "app-input app-input--wide",
               hint: {
-                html: "Lowercase letters, numbers and hyphens. Maximum 32 characters. E.g. <em>bee-pollen-frontend</em>",
+                html: "Lowercase letters, numbers and hyphens. Maximum 32 characters. E.g. seed-vault-frontend",
                 classes: "app-hint"
               },
               formGroup: {


### PR DESCRIPTION
- Refactor authedFetcher to work without the need for a request arg
- Rename functions so the decorator and authedFetcher are better named
- Update node-fetch import
- Update tests to use decorator

## Use

```
await request.authedFetcher('http://-api-endpoint')
```
or

```
import { authedFetcher } from '~/src/server/common/helpers/fetch/authed-fetcher.js'

await authedFetcher('http://-api-endpoint', 'token')
```


