### PR TITLE
478761 permissions UI part iv

### DIFF
--- a/src/server/common/helpers/auth/azure-oidc.js
+++ b/src/server/common/helpers/auth/azure-oidc.js
@@ -42,11 +42,11 @@ const azureOidc = {
             'offline_access',
             'user.read'
           ],
-          profile: async function (credentials, _params, authedGet) {
+          profile: async function (credentials, _params, get) {
             const payload = jwt.token.decode(credentials.token).decoded.payload
             const endpoint = config.get('userServiceBackendUrl') + '/scopes'
 
-            const { scopes, scopeFlags } = await authedGet(endpoint, {
+            const { scopes, scopeFlags } = await get(endpoint, {
               options: { agent: false }
             })
 

--- a/src/server/common/helpers/auth/azure-oidc.js
+++ b/src/server/common/helpers/auth/azure-oidc.js
@@ -44,7 +44,7 @@ const azureOidc = {
           ],
           profile: async function (credentials, _params, authedGet) {
             const payload = jwt.token.decode(credentials.token).decoded.payload
-            const endpoint = config.get('userServiceBackendUrl') + `/scopes`
+            const endpoint = config.get('userServiceBackendUrl') + '/scopes'
 
             const { scopes, scopeFlags } = await authedGet(endpoint)
 

--- a/src/server/common/helpers/auth/azure-oidc.js
+++ b/src/server/common/helpers/auth/azure-oidc.js
@@ -46,7 +46,9 @@ const azureOidc = {
             const payload = jwt.token.decode(credentials.token).decoded.payload
             const endpoint = config.get('userServiceBackendUrl') + '/scopes'
 
-            const { scopes, scopeFlags } = await authedGet(endpoint)
+            const { scopes, scopeFlags } = await authedGet(endpoint, {
+              options: { agent: false }
+            })
 
             credentials.profile = {
               id: payload.oid,

--- a/src/server/common/helpers/proxy/setup-wreck-agents.js
+++ b/src/server/common/helpers/proxy/setup-wreck-agents.js
@@ -3,7 +3,8 @@ import Wreck from '@hapi/wreck'
 import { createLogger } from '~/src/server/common/helpers/logging/logger.js'
 
 /**
- * Provide Wreck http client agents
+ * Set the Global Wreck agents
+ * To disable for a specific instance pass the { agent: false } option
  * @param {ProxyAgent} proxy
  */
 function setupWreckAgents(proxy) {


### PR DESCRIPTION
## Stop the call to user service backend on login going via the proxy

Because we globally add proxy agents to all `Wreck` instances in `setupWreckAgents()`, due to the `azure-oidc` `bell` `plugin` needing to call `login.microsoftonline.com` via the proxy. Means all calls using `Wreck` goes via the proxy.

As `bell` and therefore our `azure-oidc` plugin uses `Wreck` internally. We need to disable the proxy when we use the `bell`, `profile`, `get()` argument/helper function https://hapi.dev/module/bell/api/?v=13.0.2#options  to call the user service backend, on login. As we do not wish this call to go via the proxy.


## The future

Its a little brute force adding proxy Agents to all `Wreck` instances. As the needs change for this I suspect we can make this a little more intelligent.