### PR TITLE
481471: Fix canLaunchTerminal to check against correctly filtered environments

### DIFF
--- a/src/server/common/helpers/csp/content-security-policy.js
+++ b/src/server/common/helpers/csp/content-security-policy.js
@@ -1,12 +1,12 @@
 import Blankie from 'blankie'
 
 import { config } from '~/src/config/index.js'
-import { getAllEnvironmentKebabNamesExceptProd } from '~/src/server/common/helpers/environments/get-environments.js'
+import { getAllEnvironmentKebabNames } from '~/src/server/common/helpers/environments/get-environments.js'
 
 const terminalProxyUrl = config.get('terminalProxyUrl')
 const terminalProxyDomains = [
   ...new Set(
-    getAllEnvironmentKebabNamesExceptProd().map((environment) =>
+    getAllEnvironmentKebabNames().map((environment) =>
       terminalProxyUrl.replace('{environment}', environment)
     )
   )

--- a/src/server/common/helpers/environments/get-environments.js
+++ b/src/server/common/helpers/environments/get-environments.js
@@ -21,16 +21,4 @@ function getEnvironmentsThatNeed(scopes = []) {
 function getAllEnvironmentKebabNames() {
   return Object.values(environments).map(({ kebabName }) => kebabName)
 }
-
-function getAllEnvironmentKebabNamesExceptProd() {
-  return getAllEnvironmentKebabNames().filter(
-    (env) => env !== environments.prod.kebabName
-  )
-}
-
-export {
-  getEnvironments,
-  getEnvironmentsThatNeed,
-  getAllEnvironmentKebabNames,
-  getAllEnvironmentKebabNamesExceptProd
-}
+export { getEnvironments, getEnvironmentsThatNeed, getAllEnvironmentKebabNames }

--- a/src/server/services/terminal/helpers/can-launch-terminal.js
+++ b/src/server/services/terminal/helpers/can-launch-terminal.js
@@ -12,7 +12,7 @@ function terminalEnvironments(scope) {
 }
 
 function canLaunchTerminal(scope, environment) {
-  if (!getEnvironments(scope).includes(environment)) {
+  if (!terminalEnvironments(scope).includes(environment)) {
     throw Boom.forbidden('Cannot launch terminal in this environment')
   }
 }

--- a/src/server/services/terminal/helpers/can-launch-terminal.test.js
+++ b/src/server/services/terminal/helpers/can-launch-terminal.test.js
@@ -2,14 +2,24 @@ import { canLaunchTerminal } from '~/src/server/services/terminal/helpers/can-la
 import { scopes } from '~/src/server/common/constants/scopes.js'
 
 describe('#canLaunchTerminal', () => {
-  test('Should not throw for Admin and allowed Admin environment', () => {
+  test('Should not throw for Admin and allowed environment', () => {
     expect(() => canLaunchTerminal([scopes.admin], 'dev')).not.toThrow()
+  })
+
+  test('Should not throw for Admin and allowed Admin environment', () => {
+    expect(() => canLaunchTerminal([scopes.admin], 'infra-dev')).not.toThrow()
   })
 
   test('Should throw for Tenant with unavailable environment', () => {
     expect(() =>
       canLaunchTerminal([scopes.externalTest], 'management')
     ).toThrow('Cannot launch terminal in this environment')
+  })
+
+  test('Should throw for admin without breakglass for prod', () => {
+    expect(() => canLaunchTerminal([scopes.admin], 'prod')).toThrow(
+      'Cannot launch terminal in this environment'
+    )
   })
 
   test('Should not throw for breakglass user with production environment', () => {

--- a/src/server/services/terminal/helpers/schema/launch-terminal-params-validation.test.js
+++ b/src/server/services/terminal/helpers/schema/launch-terminal-params-validation.test.js
@@ -1,5 +1,6 @@
 import Joi from 'joi'
 import { launchTerminalParamsValidation } from '~/src/server/services/terminal/helpers/schema/launch-terminal-params-validation.js'
+import { scopes } from '~/src/server/common/constants/scopes.js'
 
 describe('#launchTerminalParamsValidation', () => {
   describe('With breakglass user', () => {
@@ -10,7 +11,7 @@ describe('#launchTerminalParamsValidation', () => {
         context: {
           auth: {
             credentials: {
-              scope: ['breakglass']
+              scope: [scopes.breakglass]
             }
           }
         }
@@ -84,6 +85,56 @@ describe('#launchTerminalParamsValidation', () => {
           '"environment" must be one of [dev, test, perf-test]'
         )
       )
+    })
+
+    test('Should allow for env and return expected validated params', () => {
+      const params = { serviceId: 'service123', environment: 'dev' }
+      const result = launchTerminalParamsValidation(params, options)
+
+      expect(result).toEqual(params)
+    })
+  })
+
+  describe('With Admin user', () => {
+    let options
+
+    beforeEach(() => {
+      options = {
+        context: {
+          auth: {
+            credentials: {
+              scope: [scopes.admin]
+            }
+          }
+        }
+      }
+    })
+
+    test('Should throw error for prod environment', () => {
+      const params = { serviceId: 'service123', environment: 'prod' }
+
+      expect(() => launchTerminalParamsValidation(params, options)).toThrow(
+        new Joi.ValidationError(
+          '"environment" must be one of [infra-dev, management, dev, test, perf-test]'
+        )
+      )
+    })
+
+    test('Should throw error for invalid environment', () => {
+      const params = { serviceId: 'service123', environment: 'not-an-env' }
+
+      expect(() => launchTerminalParamsValidation(params, options)).toThrow(
+        new Joi.ValidationError(
+          '"environment" must be one of [infra-dev, management, dev, test, perf-test]'
+        )
+      )
+    })
+
+    test('Should allow for env and return expected validated params', () => {
+      const params = { serviceId: 'service123', environment: 'infra-dev' }
+      const result = launchTerminalParamsValidation(params, options)
+
+      expect(result).toEqual(params)
     })
   })
 })


### PR DESCRIPTION
- allow prod for terminal security policy