### PR TITLE
484916: add git hook to extract ticket id from branch

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,19 @@
+#!/bin/sh
+set +e
+
+BRANCH_NAME=$(git symbolic-ref --short HEAD)
+TICKET_ID_REGEX="^[0-9]{5,8}"
+COMMIT_EDIT_MSG_PATH="$1"
+COMMIT_MSG=$(head -n1 "$1")
+
+# If the branch name contains a ticket ID
+if [[ $BRANCH_NAME =~ $TICKET_ID_REGEX ]]; then
+ TICKET_ID=${BASH_REMATCH[0]}
+
+ # If the ticket ID is not already in the commit message, prepend it.
+ # Don't add ticket ID for a second time, fEx. when doing fixups or amending commits
+ if [[ ! $COMMIT_MSG =~ $TICKET_ID ]]; then
+  # Prepend the ticket ID to the start of the 1st line
+  sed -i.bak -e "1s/^/${TICKET_ID}:/" "$COMMIT_EDIT_MSG_PATH"
+ fi
+fi


### PR DESCRIPTION
- Extract ticket id from branch name `484916-ticket-id-commit-message-hook` extracts `484916`
- Works with `--fixup` and `--amend`
- Ignored if no matching ticket number at the beginning of the branch name