### PR TITLE
Fix service tab permissions

### DIFF
--- a/src/server/services/helpers/provide-tabs.js
+++ b/src/server/services/helpers/provide-tabs.js
@@ -7,6 +7,7 @@
 async function provideTabs(request, h) {
   const authedUser = await request.getUserSession()
   const isAdmin = authedUser?.isAdmin
+  const isTenant = authedUser?.isTenant
   const response = request.response
 
   if (response.variety === 'view') {
@@ -34,7 +35,7 @@ async function provideTabs(request, h) {
       }
     ]
 
-    if (authedUser) {
+    if (isAdmin || isTenant) {
       response.source.context.tabDetails.tabs.push({
         isActive: request.path.startsWith(`/services/${imageName}/buckets`),
         url: request.routeLookup('services/{serviceId}/buckets', {

--- a/src/server/services/helpers/provide-tabs.test.js
+++ b/src/server/services/helpers/provide-tabs.test.js
@@ -42,7 +42,8 @@ describe('#provideTabs', () => {
         .mockReturnValueOnce(`/services/${mockServiceName}/secrets`)
         .mockReturnValueOnce(`/services/${mockServiceName}/terminal`)
       mockUserSession.mockResolvedValue({
-        isAdmin: true
+        isAdmin: true,
+        isTenant: true
       })
     })
 
@@ -129,7 +130,8 @@ describe('#provideTabs', () => {
       mockUserIsServiceOwner.mockResolvedValue(true)
 
       mockUserSession.mockResolvedValue({
-        isAdmin: false
+        isAdmin: false,
+        isTenant: true
       })
       mockRouteLookup
         .mockReturnValueOnce(`/services/${mockServiceName}`)
@@ -222,7 +224,8 @@ describe('#provideTabs', () => {
       mockUserIsServiceOwner.mockResolvedValue(false)
 
       mockUserSession.mockResolvedValue({
-        isAdmin: false
+        isAdmin: false,
+        isTenant: true
       })
       mockRouteLookup
         .mockReturnValueOnce(`/services/${mockServiceName}`)


### PR DESCRIPTION
Users that have AAD login but are not CDP users, should not see the proxy or buckets tabs. Logged in users that are onboarded to CDP should see these tabs, as should admin


## Logged out user can view the portal
<img width="2655" alt="Screenshot 2025-01-16 at 12 07 51" src="https://github.com/user-attachments/assets/9e5120fd-6fb5-4b53-82ab-e9fb022064d0" />


## AAD user not onboarded to the portal but logged in via AAD
<img width="2650" alt="Screenshot 2025-01-16 at 12 03 08" src="https://github.com/user-attachments/assets/43f2df24-a310-417c-a6a7-0b725edb8088" />

## Logged in CDP portal tenant user viewing service they do not own

<img width="2649" alt="Screenshot 2025-01-16 at 12 04 07" src="https://github.com/user-attachments/assets/8ba5864d-0a73-4e8b-9123-3a3776388645" />

## Logged in CDP portal tenant user viewing service they own

<img width="2652" alt="Screenshot 2025-01-16 at 12 12 22" src="https://github.com/user-attachments/assets/059a164e-6351-49d2-8168-bd7922cbca63" />


## Logged in CDP portal Admin user
<img width="2652" alt="Screenshot 2025-01-16 at 12 04 54" src="https://github.com/user-attachments/assets/abc69cb6-d40b-47d4-ba36-9ef0c86b2c29" />

