### PR TITLE
Adjustments to the main nav reflow

### DIFF
--- a/src/server/common/templates/partials/navigation/_navigation.scss
+++ b/src/server/common/templates/partials/navigation/_navigation.scss
@@ -9,59 +9,10 @@ $border-width: 4px;
   background-color: $app-light-grey;
 }
 
-.app-navigation__list {
-  @include govuk-media-query($from: desktop-huge) {
-    display: flex;
-    height: govuk-px-to-rem($navigation-height);
-  }
-}
-
-.app-navigation__primary {
+.app-navigation__primary, .app-navigation__actions, .app-navigation__admin {
   margin: 0;
   padding: 0;
   list-style: none;
-
-  @include govuk-media-query($from: desktop-huge) {
-    display: flex;
-    flex: 3;
-  }
-}
-
-.app-navigation__actions {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-
-  @include govuk-media-query($from: desktop-huge) {
-    display: flex;
-    flex: 1;
-    justify-content: flex-end;
-  }
-}
-
-.app-navigation__admin {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-
-  @include govuk-media-query($from: desktop-huge) {
-    position: relative;
-    display: flex;
-    flex: 0 0 75px;
-    justify-content: flex-end;
-    margin-left: govuk-spacing(3);
-
-    &::before {
-      content: "";
-      box-sizing: border-box;
-      position: absolute;
-      top: 20%;
-      left: 0;
-      width: 2px;
-      height: 60%;
-      border-left: 2px solid govuk-colour("blue");
-    }
-  }
 }
 
 .app-navigation__list-item {
@@ -84,20 +35,12 @@ $border-width: 4px;
 .app-navigation__link {
   @include govuk-link-style-no-visited-state;
   border: 0;
-  margin: govuk-spacing(1) 0 govuk-spacing(2);
+  margin: govuk-spacing(1) 0;
   padding: 0;
   @include govuk-font(24, "bold");
   display: inline-block;
   text-decoration: none;
   border-bottom: 4px solid transparent;
-
-  @include govuk-media-query($from: desktop-huge) {
-    margin: 0;
-    display: flex;
-    height: $navigation-height - $border-width;
-    height: govuk-px-to-rem($navigation-height - $border-width);
-    align-items: center;
-  }
 
   &:hover {
     color: govuk-colour("black");
@@ -119,3 +62,50 @@ $border-width: 4px;
     color: govuk-colour("black");
   }
 }
+
+@include govuk-media-query($from: desktop-big) {
+  .app-navigation__list {
+    display: flex;
+    height: govuk-px-to-rem($navigation-height);
+  }
+
+  .app-navigation__primary {
+    display: flex;
+    width: 75%;
+  }
+
+  .app-navigation__actions {
+    display: flex;
+    width: 25%;
+    justify-content: flex-end;
+  }
+
+  .app-navigation__link {
+    margin: 0 0 govuk-spacing(2);
+    display: flex;
+    height: $navigation-height - $border-width;
+    height: govuk-px-to-rem($navigation-height - $border-width);
+    align-items: center;
+  }
+
+  .app-navigation__list-item--section {
+    position: relative;
+
+    &::before {
+      content: "";
+      box-sizing: border-box;
+      position: absolute;
+      top: 20%;
+      left: 0;
+      width: 2px;
+      height: 60%;
+      border-left: 2px solid govuk-colour("blue");
+    }
+
+    .app-navigation__link {
+      margin-left: govuk-spacing(3);
+    }
+  }
+}
+
+

--- a/src/server/common/templates/partials/navigation/navigation.njk
+++ b/src/server/common/templates/partials/navigation/navigation.njk
@@ -25,12 +25,10 @@
             </a>
           </li>
         {% endfor %}
-      </ul>
 
-      {% if navigation.admin | length %}
-        <ul class="app-navigation__admin">
+        {% if navigation.admin | length %}
           {% for item in navigation.admin %}
-            <li class="app-navigation__list-item">
+            <li class="app-navigation__list-item app-navigation__list-item--section">
               <a class="app-navigation__link{% if item.isActive %} app-navigation__link--active{% endif %}"
                  href="{{ item.url }}"
                  data-testid="nav-{{ item.text | lower | replace(" ", "-") }}"
@@ -39,8 +37,8 @@
               </a>
             </li>
           {% endfor %}
-        </ul>
-      {% endif %}
+        {% endif %}
+      </ul>
     </div>
   </div>
 </nav>


### PR DESCRIPTION
- Make the main nave a little nicer with when it reflows
- There is still work to do to move this into a show/hide component
- But for the moment this tidies the code up a little
- Makes the biggest reflow happen only when it really needs to
- Aligns whitespace better

## Logged In
### Large 
<img width="1998" alt="large-logged-in" src="https://github.com/user-attachments/assets/1e869026-8529-4cf8-ab4c-f0a8ff10c0f8" />

### Medium
<img width="1265" alt="medium-logged-in" src="https://github.com/user-attachments/assets/5a459ca2-3b60-4d62-b346-fbd5680cb0de" />

### Small
<img width="895" alt="small-logged-in" src="https://github.com/user-attachments/assets/4251a9e1-6a83-4484-beab-52712a7638c7" />


## Logged out
### Large 
<img width="1602" alt="Screenshot 2025-01-30 at 16 32 01" src="https://github.com/user-attachments/assets/a248ff5e-d77d-4789-a237-230ed5e71191" />


### Medium

<img width="1254" alt="Screenshot 2025-01-30 at 16 36 39" src="https://github.com/user-attachments/assets/0596017a-1641-4829-bb9e-2a5eb13f686a" />


### Small
<img width="897" alt="Screenshot 2025-01-30 at 16 31 53" src="https://github.com/user-attachments/assets/9699f3b7-a805-4ef5-9a9d-a4208f816c74" />
