### PR TITLE
Bug fix for search

### DIFF
--- a/src/server/documentation/helpers/search-index.js
+++ b/src/server/documentation/helpers/search-index.js
@@ -165,7 +165,7 @@ async function searchIndex(request, bucket, query) {
   const queryTerm = query?.replace(/[*^:~+-]/g, '') ?? null
   const results = queryTerm
     ? builtSearchIndex.index.search(
-        `${queryTerm}^100 ${queryTerm}*^10 ${queryTerm}~2` // https://github.com/olivernn/lunr.js/issues/256#issuecomment-295407852
+        `${queryTerm}^100 ${queryTerm}*^50 *${queryTerm}^25 ${queryTerm}~4`
       )
     : []
 

--- a/src/server/documentation/helpers/search-index.js
+++ b/src/server/documentation/helpers/search-index.js
@@ -87,17 +87,26 @@ async function buildSearchIndex(request, bucket) {
  */
 function removeBrokenWords(text, searchTerm) {
   const lowerSearchTerm = searchTerm.toLowerCase()
-  let line = text.trim()
+  let line = text
 
   if (line.toLowerCase() === lowerSearchTerm) {
     return line
   }
 
-  if (!line.toLowerCase().startsWith(lowerSearchTerm)) {
+  const firstWord = line.substr(0, line.indexOf(' ')).toLowerCase()
+  const lastWord = line.split(' ').splice(-1)[0].toLowerCase()
+
+  if (
+    !line.toLowerCase().startsWith(lowerSearchTerm) &&
+    !firstWord.includes(lowerSearchTerm)
+  ) {
     line = line.replace(/^\S+\s/, '')
   }
 
-  if (!line.toLowerCase().endsWith(lowerSearchTerm)) {
+  if (
+    !line.toLowerCase().endsWith(lowerSearchTerm) &&
+    !lastWord.includes(lowerSearchTerm)
+  ) {
     line = line.replace(/\s\S+$/, '')
   }
 
@@ -176,7 +185,6 @@ async function searchIndex(request, bucket, query) {
                 const sliceStart = Math.max(startPos - surroundingCharacters, 0)
                 const sliceEnd = startPos + length + surroundingCharacters
                 const slice = match.file.slice(sliceStart, sliceEnd)
-
                 const textResult = prepTextResult(slice, query)
 
                 if (!textResult) {


### PR DESCRIPTION
A little bug fix for search

- don't remove first or last words if they contain search query
- tweak the query to also provide partials

## Searching 
> Now searching for "vpn" provides the result for the https://portal.cdp-int.defra.cloud/documentation/how-to/aws-openvpn.md page as expected

### Searching for VPN

<img width="570" alt="Screenshot 2025-03-01 at 08 32 19" src="https://github.com/user-attachments/assets/fa20e901-6d81-48d5-adcc-94fcf9de0999" />


### Clicking through

<img width="1696" alt="Screenshot 2025-03-01 at 08 32 27" src="https://github.com/user-attachments/assets/8d4979a0-7d07-4c3a-91e1-e0c25f4d3589" />


