### PR TITLE
518967: Terminal links dont need deployments

### DIFF
--- a/src/server/common/helpers/fetch/fetch-tenant-service.js
+++ b/src/server/common/helpers/fetch/fetch-tenant-service.js
@@ -1,0 +1,43 @@
+import { config } from '~/src/config/config.js'
+import { fetchJson } from '~/src/server/common/helpers/fetch/fetch-json.js'
+import { createLogger } from '~/src/server/common/helpers/logging/logger.js'
+
+const logger = createLogger()
+
+/**
+ * @typedef {object} TenantService
+ * @property {string} serviceCode - Service Code
+ * @property {zone} region - CDP Platform Zone
+ */
+
+/**
+ * @typedef {object} TenantServices
+ * @property {TenantService=} dev
+ * @property {TenantService=} test
+ * @property {TenantService=} perf-test
+ * @property {TenantService=} ext-test
+ * @property {TenantService=} prod
+ * @property {TenantService=} management
+ * @property {TenantService=} infra-dev
+ */
+
+/**
+ *
+ * @param {string} serviceName
+ * @returns {Promise<TenantServices|null>}
+ */
+async function fetchTenantService(serviceName) {
+  try {
+    const endpoint =
+      config.get('portalBackendUrl') + `/tenant-services/${serviceName}`
+    const { payload } = await fetchJson(endpoint)
+
+    return payload
+  } catch (error) {
+    // We are catching here because a 404 can be thrown when a tenant service has not been created
+    logger.info(error, 'Tenant Service not found.')
+    return null
+  }
+}
+
+export { fetchTenantService }

--- a/src/server/services/terminal/controllers/terminal.js
+++ b/src/server/services/terminal/controllers/terminal.js
@@ -3,25 +3,20 @@ import Boom from '@hapi/boom'
 
 import { sortByEnv } from '~/src/server/common/helpers/sort/sort-by-env.js'
 import { provideService } from '~/src/server/services/helpers/pre/provide-service.js'
-import { fetchRunningServicesById } from '~/src/server/common/helpers/fetch/fetch-running-services-by-id.js'
 import { terminalEnvironments } from '~/src/server/services/terminal/helpers/can-launch-terminal.js'
+import { fetchTenantService } from '~/src/server/common/helpers/fetch/fetch-tenant-service.js'
 
-async function getTerminalEnvs(service, userScopes) {
-  const teams = service?.teams
+export async function getTerminalEnvs(service, userScopes) {
   const serviceName = service?.serviceName
 
-  if (!teams || !serviceName) {
+  if (!serviceName) {
     return []
   }
 
   const environments = terminalEnvironments(userScopes)
-  const runningServices = (await fetchRunningServicesById(serviceName)) ?? []
+  const tenantService = (await fetchTenantService(serviceName)) ?? {}
 
-  return [
-    ...new Set(
-      runningServices.map((runningService) => runningService.environment)
-    )
-  ]
+  return Object.keys(tenantService)
     .filter((env) => environments.includes(env))
     .sort(sortByEnv)
 }

--- a/src/server/services/terminal/controllers/terminal.test.js
+++ b/src/server/services/terminal/controllers/terminal.test.js
@@ -1,0 +1,55 @@
+import { getTerminalEnvs } from '~/src/server/services/terminal/controllers/terminal.js'
+import { fetchTenantService } from '~/src/server/common/helpers/fetch/fetch-tenant-service.js'
+import { scopes } from '~/src/server/common/constants/scopes.js'
+
+jest.mock('~/src/server/common/helpers/fetch/fetch-tenant-service.js', () => ({
+  fetchTenantService: jest.fn()
+}))
+
+const tenantService = {
+  'perf-test': { serviceCode: 'RSI', zone: 'protected' },
+  'ext-test': { serviceCode: 'RSI', zone: 'protected' },
+  'infra-dev': { serviceCode: 'RSI', zone: 'protected' },
+  test: { serviceCode: 'RSI', zone: 'protected' },
+  dev: { serviceCode: 'RSI', zone: 'protected' },
+  prod: { serviceCode: 'RSI', zone: 'protected' },
+  management: { serviceCode: 'RSI', zone: 'protected' }
+}
+
+describe('#getTerminalEnvs', () => {
+  test('Should show standard envs without prod if tenant exists in those environments', async () => {
+    fetchTenantService.mockResolvedValue(tenantService)
+    const envs = await getTerminalEnvs({ serviceName: 'foo' }, [
+      'dev',
+      'test',
+      'perf-test',
+      'prod'
+    ])
+    expect(envs).toStrictEqual(['dev', 'test', 'perf-test'])
+  })
+
+  test('should only show envs the service exists in', async () => {
+    fetchTenantService.mockResolvedValue({
+      dev: { serviceCode: 'RSI', zone: 'protected' }
+    })
+    const envs = await getTerminalEnvs({ serviceName: 'foo' }, [
+      'dev',
+      'test',
+      'perf-test',
+      'prod'
+    ])
+    expect(envs).toStrictEqual(['dev'])
+  })
+
+  test('Should show prod if they have the break-glass scope', async () => {
+    fetchTenantService.mockResolvedValue(tenantService)
+    const envs = await getTerminalEnvs({ serviceName: 'foo' }, [
+      'dev',
+      'test',
+      'perf-test',
+      'prod',
+      scopes.breakGlass
+    ])
+    expect(envs).toStrictEqual(['dev', 'test', 'perf-test', 'prod'])
+  })
+})


### PR DESCRIPTION
We use tenant-service instead as this is what actually allows it to run.