### PR TITLE
Fix mark issue search

### DIFF
--- a/src/server/common/components/documentation/template.njk
+++ b/src/server/common/components/documentation/template.njk
@@ -5,21 +5,20 @@
     </div>
 
     <div class="app-documentation__body">
-      <div class="app-section app-section--wide">
-        <div class="app-documentation__markdown">
-          {{ params.content | safe }}
-        </div>
-
-        <p class="app-documentation__generated-from">
-          <em>
-            This documentation has been auto-generated from <a class="app-link"
-                                                               href="https://github.com/DEFRA/cdp-documentation"
-                                                               target="_blank"
-                                                               rel="noopener noreferrer">cdp-documentation</a>
-          </em>
-        </p>
+      <div class="app-documentation__markdown">
+        {{ params.content | safe }}
       </div>
+
+      <p class="app-documentation__generated-from">
+        <em>
+          This documentation has been auto-generated from <a class="app-link"
+                                                             href="https://github.com/DEFRA/cdp-documentation"
+                                                             target="_blank"
+                                                             rel="noopener noreferrer">cdp-documentation</a>
+        </em>
+      </p>
     </div>
+
 
     <div class="app-documentation__toc-sidebar">
       {% if params.toc %}

--- a/src/server/documentation/helpers/markdown/build-page-html.test.js
+++ b/src/server/documentation/helpers/markdown/build-page-html.test.js
@@ -36,6 +36,25 @@ describe('#buildPageHtml', () => {
     )
   })
 
+  test('Should not add search term highlight on excluded elements', async () => {
+    const searchTerm = 'fetch'
+    const mockRequest = { query: { q: searchTerm } }
+    const markdown =
+      '# Fetch\n\n `inline fetch example` \n ```and this is a fetch code example``` \n [fetch](/fetch-in-url)'
+    const { html } = await buildPageHtml(mockRequest, markdown)
+
+    const $html = load(html)
+
+    expect($html('h1').prop('id')).toBe('fetch')
+    expect($html('h1 a').prop('href')).toBe('#fetch')
+    expect($html('h1 a').html()).toBe('<mark class="app-mark">Fetch</mark>')
+
+    expect($html('p code:first').text()).toBe('inline fetch example')
+    expect($html('p code:last').text()).toBe('and this is a fetch code example')
+    expect($html('p a').prop('href')).toBe('/fetch-in-url')
+    expect($html('p a').html()).toBe('<mark class="app-mark">fetch</mark>')
+  })
+
   test('Should generate expected table of contents', async () => {
     const markdown = '# Heading 1\n\n## Heading 2\n\n### Heading 3'
     const { toc } = await buildPageHtml(searchTerm, markdown)


### PR DESCRIPTION
## Screenshot

Searching for `fetch` now only adds `<mark>` elements in the correct places. **Not** in:
- `code` blocks
- inline `code`
- `heading` ids
- `link` hrefs



![screencapture-localhost-3000-documentation-how-to-proxy-md-2025-03-18-17_50_07](https://github.com/user-attachments/assets/f9ea83f8-7906-4fd0-a0bf-6c2fda900cce)
