### PR TITLE
Better fix for firefox layout issues

### DIFF
--- a/src/client/stylesheets/pages/_service.scss
+++ b/src/client/stylesheets/pages/_service.scss
@@ -24,9 +24,10 @@
 }
 
 .app-grid-service {
+  flex: 1;
   display: grid;
   gap: govuk-spacing(6);
-  grid-template-columns: repeat(3, auto);
+  grid-template-columns: repeat(3, 1fr);
   grid-auto-rows: minmax(10px, max-content);
   grid-template-areas:
     "details details details"
@@ -36,7 +37,7 @@
 
 
   @include govuk-media-query($from: desktop-massive) {
-    grid-template-columns: repeat(6, auto);
+    grid-template-columns: repeat(6, 1fr);
     grid-auto-rows: minmax(10px, max-content);
     grid-template-areas:
     "details details details published published published"


### PR DESCRIPTION
The flex property is needed on the main section for fraction values in grid columns to be respected