### PR TITLE
Core 1095 write todo tests

### DIFF
--- a/.vite/setup-files.js
+++ b/.vite/setup-files.js
@@ -35,8 +35,6 @@ beforeAll(async () => {
   })
 })
 
-afterAll(async () => {
-  fetchMock.disableMocks()
-  // TODO: check if this should be afterEach once tests all pass
+afterEach(async () => {
   document.getElementsByTagName('html')[0].innerHTML = ''
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -17548,7 +17548,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.links.scm=https://github.com/DEFRA/cdp-portal-frontend
 sonar.links.issue=https://github.com/DEFRA/cdp-portal-frontend/issues
 
 sonar.sources=src/
-sonar.exclusions=src/**/*.test.js,src/__fixtures__/**/*,test-helpers/**/*,.jest/setup.js,src/**/__file_snapshots__/**/*
+sonar.exclusions=src/**/*.test.js,src/__fixtures__/**/*,test-helpers/**/*,src/**/__file_snapshots__/**/*
 sonar.tests=src/
 sonar.test.inclusions=src/**/*.test.js
 

--- a/src/__fixtures__/admin/cdp-team-without-github.js
+++ b/src/__fixtures__/admin/cdp-team-without-github.js
@@ -10,20 +10,20 @@ const cdpTeamWithoutGithubFixture = {
     alertEmailAddresses: ['alerts@cdp.com'],
     users: [
       {
-        userId: '014ee26b-e738-4bcc-9621-a5289dba7351',
-        name: 'Darth, Vader'
+        displayName: '014ee26b-e738-4bcc-9621-a5289dba7351',
+        id: 'Darth, Vader'
       },
       {
-        userId: '02af05d1-2bbb-4094-a847-b9eddcf0d6bb',
-        name: 'Roger, Rabbit'
+        displayName: '02af05d1-2bbb-4094-a847-b9eddcf0d6bb',
+        id: 'Roger, Rabbit'
       },
       {
-        userId: '0ddadf17-beaf-4aef-a415-ca044dbdd18d',
-        name: 'The Terminator'
+        displayName: '0ddadf17-beaf-4aef-a415-ca044dbdd18d',
+        id: 'The Terminator'
       },
       {
-        userId: '1398fa86-98a2-4ee8-84bb-2468cc71d0ec',
-        name: 'RoboCop'
+        displayName: '1398fa86-98a2-4ee8-84bb-2468cc71d0ec',
+        id: 'RoboCop'
       }
     ]
   }

--- a/src/__fixtures__/admin/cdp-team.js
+++ b/src/__fixtures__/admin/cdp-team.js
@@ -13,12 +13,12 @@ const cdpTeamFixture = {
     alertEnvironments: ['infra-dev', 'management'],
     users: [
       {
-        userId: '0ddadf17-beaf-4aef-a415-ca044dbdd18d',
-        name: 'The Terminator'
+        displayName: '0ddadf17-beaf-4aef-a415-ca044dbdd18d',
+        id: 'The Terminator'
       },
       {
-        userId: '1398fa86-98a2-4ee8-84bb-2468cc71d0ec',
-        name: 'RoboCop'
+        displayName: '1398fa86-98a2-4ee8-84bb-2468cc71d0ec',
+        id: 'RoboCop'
       }
     ]
   }

--- a/src/__fixtures__/admin/cdp-teams.js
+++ b/src/__fixtures__/admin/cdp-teams.js
@@ -11,12 +11,12 @@ const cdpTeamsFixture = {
       github: 'fisheries',
       users: [
         {
-          userId: '01b99595-27b5-4ab0-9807-f104c09d2cd0',
-          name: 'RoboCop'
+          displayName: '01b99595-27b5-4ab0-9807-f104c09d2cd0',
+          id: 'RoboCop'
         },
         {
-          userId: '7a34a7f1-55ca-4e6c-9fc6-56220c4280eb',
-          name: 'Mumm-ra'
+          displayName: '7a34a7f1-55ca-4e6c-9fc6-56220c4280eb',
+          id: 'Mumm-ra'
         }
       ],
       serviceCodes: ['FO'],
@@ -32,8 +32,8 @@ const cdpTeamsFixture = {
       github: 'trees-and-forests',
       users: [
         {
-          userId: '1398fa86-98a2-4ee8-84bb-2468cc71d0ec',
-          name: 'B. A. Baracus'
+          displayName: '1398fa86-98a2-4ee8-84bb-2468cc71d0ec',
+          id: 'B. A. Baracus'
         }
       ],
       serviceCodes: ['TF'],
@@ -49,12 +49,12 @@ const cdpTeamsFixture = {
       github: 'bees',
       users: [
         {
-          userId: '1398fa86-98a2-4ee8-84bb-2468cc71d0ec',
-          name: 'B. A. Baracus'
+          displayName: '1398fa86-98a2-4ee8-84bb-2468cc71d0ec',
+          id: 'B. A. Baracus'
         },
         {
-          userId: '7a34a7f1-55ca-4e6c-9fc6-56220c4280eb',
-          name: 'Mumm-ra'
+          displayName: '7a34a7f1-55ca-4e6c-9fc6-56220c4280eb',
+          id: 'Mumm-ra'
         }
       ],
       serviceCodes: ['BEE'],
@@ -70,8 +70,8 @@ const cdpTeamsFixture = {
       github: 'cdp-platform',
       users: [
         {
-          userId: '1398fa86-98a2-4ee8-84bb-2468cc71d0ec',
-          name: 'B. A. Baracus'
+          displayName: '1398fa86-98a2-4ee8-84bb-2468cc71d0ec',
+          id: 'B. A. Baracus'
         }
       ],
       serviceCodes: ['CDP'],

--- a/src/__fixtures__/admin/cdp-user-session.js
+++ b/src/__fixtures__/admin/cdp-user-session.js
@@ -1,3 +1,4 @@
+// This is a fixture for the CDP user session created in the admin create user multistep form
 const cdpUserSessionFixture = {
   email: 'B.A.Baracus@defradev.onmicrosoft.com',
   userId: '1398fa86-98a2-4ee8-84bb-2468cc71d0ec',

--- a/src/__fixtures__/running-services/filters.js
+++ b/src/__fixtures__/running-services/filters.js
@@ -1,0 +1,30 @@
+// Response from portalBackendApi/running-services/filters
+export const runningServicesFiltersFixture = {
+  filters: {
+    services: ['cdp-portal-frontend', 'cdp-user-service-backend'],
+    statuses: ['pending', 'running', 'undeployed'],
+    users: [
+      {
+        id: '01b99595-27b5-4ab0-9807-f104c09d2cd0',
+        displayName: 'RoboCop'
+      },
+      {
+        id: '7a34a7f1-55ca-4e6c-9fc6-56220c4280eb',
+        displayName: 'Mumm-ra'
+      }
+    ],
+    teams: [
+      {
+        github: 'forms',
+        teamId: '0be2f4a1-3e1c-4675-a8ec-3af6d453b7ca',
+        name: 'Forms'
+      },
+      {
+        github: 'cdp-platform',
+        teamId: 'aabe63e7-87ef-4beb-a596-c810631fc474',
+        name: 'Platform'
+      }
+    ],
+    kinds: null
+  }
+}

--- a/src/__fixtures__/running-services/running-services.js
+++ b/src/__fixtures__/running-services/running-services.js
@@ -7,8 +7,8 @@ const runningServicesFixture = [
     service: 'cdp-portal-frontend',
     version: '0.356.0',
     user: {
-      userId: '1398fa86-98a2-4ee8-84bb-2468cc71d0ec',
-      name: 'RoboCop'
+      id: '01b99595-27b5-4ab0-9807-f104c09d2cd0',
+      displayName: 'RoboCop'
     },
     cpu: '1024',
     memory: '2048',
@@ -42,8 +42,8 @@ const runningServicesFixture = [
     service: 'cdp-user-service-backend',
     version: '0.149.0',
     user: {
-      userId: '1398fa86-98a2-4ee8-84bb-2468cc71d0ec',
-      name: 'RoboCop'
+      id: '01b99595-27b5-4ab0-9807-f104c09d2cd0',
+      displayName: 'RoboCop'
     },
     cpu: '2048',
     memory: '4096',
@@ -77,8 +77,8 @@ const runningServicesFixture = [
     service: 'cdp-self-service-ops',
     version: '0.188.0',
     user: {
-      userId: '0ddadf17-beaf-4aef-a415-ca044dbdd18d',
-      name: 'The Terminator'
+      id: '0ddadf17-beaf-4aef-a415-ca044dbdd18d',
+      displayName: 'The Terminator'
     },
     cpu: '1024',
     memory: '2048',

--- a/src/__fixtures__/team.js
+++ b/src/__fixtures__/team.js
@@ -12,12 +12,12 @@ const teamFixture = {
   alertEmailAddresses: ['alerts@cdp.com'],
   users: [
     {
-      userId: '0ddadf17-beaf-4aef-a415-ca044dbdd18d',
-      name: 'The Terminator'
+      displayName: '0ddadf17-beaf-4aef-a415-ca044dbdd18d',
+      id: 'The Terminator'
     },
     {
-      userId: '1398fa86-98a2-4ee8-84bb-2468cc71d0ec',
-      name: 'RoboCop'
+      displayName: '1398fa86-98a2-4ee8-84bb-2468cc71d0ec',
+      id: 'RoboCop'
     }
   ],
   repositories: [

--- a/src/client/common/helpers/auto-submit.test.js
+++ b/src/client/common/helpers/auto-submit.test.js
@@ -1,4 +1,3 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { xhrRequest } from './xhr.js'
 import { autoSubmit } from './auto-submit.js'
 

--- a/src/client/common/helpers/error-messages.test.js
+++ b/src/client/common/helpers/error-messages.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { errorMessages } from './error-messages.js'
 
 describe('#errorMessages', () => {

--- a/src/client/common/helpers/event-emitter.test.js
+++ b/src/client/common/helpers/event-emitter.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test, vi } from 'vitest'
 import { publish, subscribe, unsubscribe } from './event-emitter.js'
 
 describe('#eventEmitter', () => {

--- a/src/client/common/helpers/fetch/autocomplete/fetch-versions.test.js
+++ b/src/client/common/helpers/fetch/autocomplete/fetch-versions.test.js
@@ -1,5 +1,3 @@
-import { describe, expect, test } from 'vitest'
-
 import { availableVersionsFixture } from '../../../../../__fixtures__/available-versions.js'
 import { fetchVersions } from './fetch-versions.js'
 import {

--- a/src/client/common/helpers/fetch/filters/clear-filters.test.js
+++ b/src/client/common/helpers/fetch/filters/clear-filters.test.js
@@ -1,0 +1,58 @@
+import { clearFilters } from './clear-filters.js'
+
+describe('#clearFilters', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: {
+        ...window.location,
+        search: '?page=2&size=20&filter=name',
+        assign: vi.fn(),
+        replace: vi.fn()
+      }
+    })
+  })
+
+  test('Should remove non-preserved keys from the query string', () => {
+    const event = { preventDefault: vi.fn() }
+
+    clearFilters(event)
+
+    expect(window.location.search).toBe('page=1&size=50')
+  })
+
+  test('Should reset preserved keys to their default values', () => {
+    const event = { preventDefault: vi.fn() }
+
+    clearFilters(event)
+
+    expect(window.location.search).toBe('page=1&size=50')
+  })
+
+  test('Should not modify the query string if it only contains preserved keys', () => {
+    window.location.search = '?page=1&size=10'
+    const event = { preventDefault: vi.fn() }
+
+    clearFilters(event)
+
+    expect(window.location.search).toBe('page=1&size=50')
+  })
+
+  test('Should do nothing if the query string is empty', () => {
+    window.location.search = ''
+    const event = { preventDefault: vi.fn() }
+
+    clearFilters(event)
+
+    expect(window.location.search).toBe('')
+  })
+
+  test('Should call preventDefault on the event', () => {
+    const event = { preventDefault: vi.fn() }
+
+    clearFilters(event)
+
+    expect(event.preventDefault).toHaveBeenCalled()
+  })
+})

--- a/src/client/common/helpers/fetch/select/fetch-memory.test.js
+++ b/src/client/common/helpers/fetch/select/fetch-memory.test.js
@@ -1,5 +1,3 @@
-import { describe, expect, test } from 'vitest'
-
 import { fetchMemory } from './fetch-memory.js'
 import { ecsCpuToMemoryOptionsMapFixture } from '../../../../../__fixtures__/deploy-service/ecs-cpu-to-memory-options-map.js'
 import {

--- a/src/client/common/helpers/init.test.js
+++ b/src/client/common/helpers/init.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { initClass, initModule, initModules } from './init.js'
 
 describe('#init', () => {

--- a/src/client/common/helpers/populate-select-options.test.js
+++ b/src/client/common/helpers/populate-select-options.test.js
@@ -1,4 +1,3 @@
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { waitFor } from '@testing-library/dom'
 
 import { populateSelectOptions } from './populate-select-options.js'

--- a/src/client/common/helpers/protect-form/create-hidden-input.test.js
+++ b/src/client/common/helpers/protect-form/create-hidden-input.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { createHiddenInput } from './create-hidden-input.js'
 
 describe('#createHiddenInput', () => {

--- a/src/client/common/helpers/protect-form/protect-form.test.js
+++ b/src/client/common/helpers/protect-form/protect-form.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { protectForm } from './protect-form.js'
 import { dispatchDomContentLoaded } from '../../../../../test-helpers/dispatch-dom-content-loaded.js'
 

--- a/src/client/common/helpers/protect-form/toggle-protected-inputs.test.js
+++ b/src/client/common/helpers/protect-form/toggle-protected-inputs.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { toggleProtectedInputs } from './toggle-protected-inputs.js'
 
 const getProtectedInputs = (form) =>

--- a/src/config/nunjucks/context/announcements.test.js
+++ b/src/config/nunjucks/context/announcements.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { getAnnouncements } from './announcements.js'
 import { config } from '../../config.js'
 

--- a/src/config/nunjucks/context/build-navigation.test.js
+++ b/src/config/nunjucks/context/build-navigation.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { buildNavigation } from './build-navigation.js'
 import { scopes } from '../../../server/common/constants/scopes.js'
 

--- a/src/config/nunjucks/context/is-ie.test.js
+++ b/src/config/nunjucks/context/is-ie.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { isIe } from './is-ie.js'
 
 describe('#isIe', () => {

--- a/src/config/nunjucks/globals/error-message-helper.test.js
+++ b/src/config/nunjucks/globals/error-message-helper.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { errorMessageHelper } from './error-message-helper.js'
 
 describe('#errorMessage', () => {

--- a/src/server/admin/decommissions/__file_snapshots__/Decommissions-pages-list-view-page-renders-for-logged-in-admin-user-with-feature-toggle-active-(as-o-1.html
+++ b/src/server/admin/decommissions/__file_snapshots__/Decommissions-pages-list-view-page-renders-for-logged-in-admin-user-with-feature-toggle-active-(as-o-1.html
@@ -219,7 +219,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
         <main class="govuk-main-wrapper app-main-wrapper" id="main-content">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav app-split-pane__nav--wide">
+  <div class="app-split-pane__nav app-split-pane__nav--wide"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -274,7 +275,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
       
     <div class="govuk-!-margin-top-2">

--- a/src/server/admin/decommissions/__file_snapshots__/Decommissions-pages-list-view-page-renders-for-logged-in-admin-user-without-feature-toggle-1.html
+++ b/src/server/admin/decommissions/__file_snapshots__/Decommissions-pages-list-view-page-renders-for-logged-in-admin-user-without-feature-toggle-1.html
@@ -219,7 +219,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
         <main class="govuk-main-wrapper app-main-wrapper" id="main-content">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav app-split-pane__nav--wide">
+  <div class="app-split-pane__nav app-split-pane__nav--wide"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -274,7 +275,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
       
     <div class="govuk-!-margin-top-2">

--- a/src/server/admin/decommissions/__file_snapshots__/Decommissions-pages-start-decommission-view-page-renders-regular-view-for-logged-in-admin-user-witho-1.html
+++ b/src/server/admin/decommissions/__file_snapshots__/Decommissions-pages-start-decommission-view-page-renders-regular-view-for-logged-in-admin-user-witho-1.html
@@ -238,7 +238,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
         <main class="govuk-main-wrapper app-main-wrapper" id="main-content">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav app-split-pane__nav--wide">
+  <div class="app-split-pane__nav app-split-pane__nav--wide"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -293,7 +294,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
       
     <div class="govuk-!-margin-top-2">

--- a/src/server/admin/decommissions/decommissions.test.js
+++ b/src/server/admin/decommissions/decommissions.test.js
@@ -1,4 +1,3 @@
-import { expect } from 'vitest'
 import {
   initialiseServer,
   mockAuthAndRenderUrl

--- a/src/server/admin/features/__file_snapshots__/Feature-Toggles-page-list-view-page-renders-for-logged-in-admin-user-1.html
+++ b/src/server/admin/features/__file_snapshots__/Feature-Toggles-page-list-view-page-renders-for-logged-in-admin-user-1.html
@@ -222,7 +222,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
         <main class="govuk-main-wrapper app-main-wrapper" id="main-content">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav app-split-pane__nav--wide">
+  <div class="app-split-pane__nav app-split-pane__nav--wide"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -277,7 +278,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
       
     <div class="govuk-!-margin-top-2">

--- a/src/server/admin/features/features.test.js
+++ b/src/server/admin/features/features.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 import {
   initialiseServer,
   mockAuthAndRenderUrl

--- a/src/server/admin/features/transformers/feature-to-entity-row.test.js
+++ b/src/server/admin/features/transformers/feature-to-entity-row.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { featureToEntityRow } from './feature-to-entity-row.js'
 import { featuresFixture } from '../../../../__fixtures__/features.js'
 

--- a/src/server/admin/helpers/provide-sub-navigation.test.js
+++ b/src/server/admin/helpers/provide-sub-navigation.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { provideSubNavigation } from './provide-sub-navigation.js'
 
 describe('#provideSubNavigation', () => {

--- a/src/server/admin/permissions/views/permission.njk
+++ b/src/server/admin/permissions/views/permission.njk
@@ -52,8 +52,8 @@
           {{ govukSummaryList(summaryList) }}
         {% endcall %}
 
-        {% call appPanel() %}
-          {% if "user" in scope.kind %}
+        {% if "user" in scope.kind %}
+          {% call appPanel() %}
             <h2 class="govuk-heading-m">
               {{ "User" | pluralise(scope.users | length) }} with permission
             </h2>
@@ -68,11 +68,11 @@
                 </a>
               </p>
             {% endif %}
-          {% endif %}
-        {% endcall %}
+          {% endcall %}
+        {% endif %}
 
-        {% call appPanel() %}
-          {% if "team" in scope.kind %}
+        {% if "team" in scope.kind %}
+          {% call appPanel() %}
             <h2 class="govuk-heading-m">
               {{ "Team" | pluralise(scope.teams | length) }} with permission
             </h2>
@@ -87,8 +87,8 @@
                 </a>
               </p>
             {% endif %}
-          {% endif %}
-        {% endcall %}
+          {% endcall %}
+        {% endif %}
       </div>
     </div>
 

--- a/src/server/admin/tags/helpers/schema/tag-validation.test.js
+++ b/src/server/admin/tags/helpers/schema/tag-validation.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { tagValidation } from './tag-validation.js'
 import Joi from 'joi'
 import { validation } from '../../../../common/constants/validation.js'

--- a/src/server/admin/teams/helpers/fetch/add-member-to-team.test.js
+++ b/src/server/admin/teams/helpers/fetch/add-member-to-team.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test, vi } from 'vitest'
 import nock from 'nock'
 
 import { config } from '../../../../../config/config.js'

--- a/src/server/admin/teams/helpers/fetch/remove-member-from-team.test.js
+++ b/src/server/admin/teams/helpers/fetch/remove-member-from-team.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test, vi } from 'vitest'
 import nock from 'nock'
 
 import { config } from '../../../../../config/config.js'

--- a/src/server/admin/teams/transformers/transform-summary-team-rows.test.js
+++ b/src/server/admin/teams/transformers/transform-summary-team-rows.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { cdpTeamSessionFixture } from '../../../../__fixtures__/admin/cdp-team-session.js'
 import { transformSummaryTeamRows } from './transform-summary-team-rows.js'
 

--- a/src/server/admin/teams/transformers/transform-team-to-entity-row.test.js
+++ b/src/server/admin/teams/transformers/transform-team-to-entity-row.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { cdpTeamFixture } from '../../../../__fixtures__/admin/cdp-team.js'
 import { transformTeamToEntityRow } from './transform-team-to-entity-row.js'
 

--- a/src/server/admin/users/transformers/transform-summary-user-rows.test.js
+++ b/src/server/admin/users/transformers/transform-summary-user-rows.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { transformSummaryUserRows } from './transform-summary-user-rows.js'
 import { cdpUserSessionFixture } from '../../../../__fixtures__/admin/cdp-user-session.js'
 

--- a/src/server/admin/users/transformers/transform-user-to-entity-row.test.js
+++ b/src/server/admin/users/transformers/transform-user-to-entity-row.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { cdpUserFixture } from '../../../../__fixtures__/admin/cdp-user.js'
 import { transformUserToEntityRow } from './transform-user-to-entity-row.js'
 

--- a/src/server/apply-changelog/transformers/changelog-apply-rows.test.js
+++ b/src/server/apply-changelog/transformers/changelog-apply-rows.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { changelogApplyRows } from './changelog-apply-rows.js'
 
 describe('#changelogApplyRows', () => {

--- a/src/server/common/components/autocomplete/autocomplete-advanced.test.js
+++ b/src/server/common/components/autocomplete/autocomplete-advanced.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 import { AutocompleteAdvanced } from './autocomplete-advanced.js'
 import { publish } from '../../../../client/common/helpers/event-emitter.js'

--- a/src/server/common/components/autocomplete/autocomplete-advanced.test.js
+++ b/src/server/common/components/autocomplete/autocomplete-advanced.test.js
@@ -11,7 +11,7 @@ describe('#autocomplete-advanced', () => {
   let suggestionsContainer
 
   function setupAdvancedAutoComplete(params) {
-    const $component = renderTestComponent('autocomplete', params)
+    const $component = renderTestComponent('autocomplete', { params })
     const js = $component('[data-testid="app-autocomplete-suggestions"]')
       .first()
       .text()

--- a/src/server/common/components/autocomplete/autocomplete-search.js
+++ b/src/server/common/components/autocomplete/autocomplete-search.js
@@ -40,6 +40,7 @@ class AutocompleteSearch extends Autocomplete {
     }
   }
 
+  // Action to perform when a choice is made by the user
   choiceAction() {
     this.submitForm()
   }

--- a/src/server/common/components/autocomplete/autocomplete-search.test.js
+++ b/src/server/common/components/autocomplete/autocomplete-search.test.js
@@ -39,7 +39,7 @@ function setupAutoComplete({ searchParam, params = {} }) {
     })
   }
 
-  return renderTestComponent('autocomplete', params)
+  return renderTestComponent('autocomplete', { params })
 }
 
 const mockFormSubmit = vi.fn().mockReturnValue(false)

--- a/src/server/common/components/autocomplete/autocomplete-search.test.js
+++ b/src/server/common/components/autocomplete/autocomplete-search.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 import { dispatchDomContentLoaded } from '../../../../../test-helpers/dispatch-dom-content-loaded.js'
 import { enterValue, pressEnter } from '../../../../../test-helpers/keyboard.js'

--- a/src/server/common/components/autocomplete/autocomplete.js
+++ b/src/server/common/components/autocomplete/autocomplete.js
@@ -657,6 +657,7 @@ class Autocomplete {
     })
   }
 
+  // Action to perform when a choice is made by the user click or enter in suggestions, enter or typing in input
   choiceAction() {
     this.dispatchInputEvent()
   }

--- a/src/server/common/components/autocomplete/autocomplete.test.js
+++ b/src/server/common/components/autocomplete/autocomplete.test.js
@@ -36,7 +36,7 @@ function setupAutoComplete({ userSearchParam, params = {} }) {
     })
   }
 
-  return renderTestComponent('autocomplete', params)
+  return renderTestComponent('autocomplete', { params })
 }
 
 /**

--- a/src/server/common/components/autocomplete/autocomplete.test.js
+++ b/src/server/common/components/autocomplete/autocomplete.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { subscribe } from '../../../../client/common/helpers/event-emitter.js'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 import { Autocomplete } from './autocomplete.js'

--- a/src/server/common/components/autocomplete/helpers/build-suggestions.test.js
+++ b/src/server/common/components/autocomplete/helpers/build-suggestions.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { relativeDate } from '../../../helpers/date/relative-date.js'
 import { availableVersionsFixture } from '../../../../../__fixtures__/available-versions.js'
 import { buildSuggestions } from './build-suggestions.js'

--- a/src/server/common/components/autocomplete/template.test.js
+++ b/src/server/common/components/autocomplete/template.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 
 const renderAutoComplete = (params = {}) => {

--- a/src/server/common/components/autocomplete/template.test.js
+++ b/src/server/common/components/autocomplete/template.test.js
@@ -2,32 +2,34 @@ import { renderTestComponent } from '../../../../../test-helpers/component-helpe
 
 const renderAutoComplete = (params = {}) => {
   const $component = renderTestComponent('autocomplete', {
-    label: {
-      text: 'By'
-    },
-    hint: {
-      text: 'Choose a user'
-    },
-    id: 'user',
-    name: 'user',
-    suggestions: [
-      {
-        text: 'RoboCop',
-        value: 'RoboCop',
-        helper: 'User Id: 12454878'
+    params: {
+      label: {
+        text: 'By'
       },
-      {
-        text: 'Roger Rabbit',
-        value: 'Roger Rabbit',
-        helper: 'User Id: 556456465'
+      hint: {
+        text: 'Choose a user'
       },
-      {
-        text: 'Barbie',
-        value: 'Barbie',
-        helper: 'User Id: 67567576'
-      }
-    ],
-    ...params
+      id: 'user',
+      name: 'user',
+      suggestions: [
+        {
+          text: 'RoboCop',
+          value: 'RoboCop',
+          helper: 'User Id: 12454878'
+        },
+        {
+          text: 'Roger Rabbit',
+          value: 'Roger Rabbit',
+          helper: 'User Id: 556456465'
+        },
+        {
+          text: 'Barbie',
+          value: 'Barbie',
+          helper: 'User Id: 67567576'
+        }
+      ],
+      ...params
+    }
   })
 
   const $autocompleteFromGroup = $component(

--- a/src/server/common/components/banner/banner.test.js
+++ b/src/server/common/components/banner/banner.test.js
@@ -8,9 +8,11 @@ describe('#banner', () => {
     vi.useFakeTimers()
 
     const $component = renderTestComponent('banner', {
-      text: 'Total and utter success!',
-      type: 'success',
-      js: 'app-banner'
+      params: {
+        text: 'Total and utter success!',
+        type: 'success',
+        js: 'app-banner'
+      }
     })
 
     // Append banner component to the document

--- a/src/server/common/components/banner/banner.test.js
+++ b/src/server/common/components/banner/banner.test.js
@@ -1,4 +1,3 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 import { banner } from './banner.js'
 

--- a/src/server/common/components/banner/template.test.js
+++ b/src/server/common/components/banner/template.test.js
@@ -6,8 +6,10 @@ describe('Banner Component', () => {
   describe('Success Banner', () => {
     beforeEach(() => {
       $banner = renderTestComponent('banner', {
-        type: 'success',
-        text: 'Well done!'
+        params: {
+          type: 'success',
+          text: 'Well done!'
+        }
       })('[data-testid="app-banner"]').first()
     })
 
@@ -25,8 +27,10 @@ describe('Banner Component', () => {
   describe('Info Banner', () => {
     beforeEach(() => {
       $banner = renderTestComponent('banner', {
-        type: 'info',
-        text: 'Today is Wednesday'
+        params: {
+          type: 'info',
+          text: 'Today is Wednesday'
+        }
       })('[data-testid="app-banner"]').first()
     })
 
@@ -44,8 +48,10 @@ describe('Banner Component', () => {
   describe('Error Banner', () => {
     beforeEach(() => {
       $banner = renderTestComponent('banner', {
-        type: 'error',
-        text: 'Something has gone terribly wrong!'
+        params: {
+          type: 'error',
+          text: 'Something has gone terribly wrong!'
+        }
       })('[data-testid="app-banner"]').first()
     })
 

--- a/src/server/common/components/banner/template.test.js
+++ b/src/server/common/components/banner/template.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 
 describe('Banner Component', () => {

--- a/src/server/common/components/breadcrumbs/template.test.js
+++ b/src/server/common/components/breadcrumbs/template.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 
 describe('Breadcrumbs Component', () => {

--- a/src/server/common/components/breadcrumbs/template.test.js
+++ b/src/server/common/components/breadcrumbs/template.test.js
@@ -5,15 +5,17 @@ describe('Breadcrumbs Component', () => {
 
   beforeEach(() => {
     $breadcrumbs = renderTestComponent('breadcrumbs', {
-      items: [
-        {
-          text: 'Deployments',
-          href: '/deployments'
-        },
-        {
-          text: 'Magic service'
-        }
-      ]
+      params: {
+        items: [
+          {
+            text: 'Deployments',
+            href: '/deployments'
+          },
+          {
+            text: 'Magic service'
+          }
+        ]
+      }
     })('[data-testid="app-breadcrumbs"]').first()
   })
 

--- a/src/server/common/components/button/button.test.js
+++ b/src/server/common/components/button/button.test.js
@@ -1,4 +1,3 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 import { button } from './button.js'
 

--- a/src/server/common/components/button/button.test.js
+++ b/src/server/common/components/button/button.test.js
@@ -12,17 +12,17 @@ const submitForm = (form) => {
 }
 
 describe('#button', () => {
-  let buttonElem
-  let buttonLoaderElem
-  let mockForm
+  let $buttonElem, $buttonLoaderElem, $mockForm
 
   beforeEach(() => {
     vi.useFakeTimers()
 
     const $component = renderTestComponent('button', {
-      text: 'Press me!',
-      loader: {
-        name: 'button-loader'
+      params: {
+        text: 'Press me!',
+        loader: {
+          name: 'button-loader'
+        }
       }
     })
 
@@ -40,9 +40,9 @@ describe('#button', () => {
       buttons.forEach(button)
     }
 
-    buttonElem = document.querySelector('[data-testid="app-button"]')
-    buttonLoaderElem = document.querySelector('[data-testid="app-loader"]')
-    mockForm = document.getElementById('mock-form')
+    $buttonElem = document.querySelector('[data-testid="app-button"]')
+    $buttonLoaderElem = document.querySelector('[data-testid="app-loader"]')
+    $mockForm = document.getElementById('mock-form')
   })
 
   afterEach(() => {
@@ -50,31 +50,31 @@ describe('#button', () => {
   })
 
   test('Should not disable button before specified delay', () => {
-    submitForm(mockForm)
+    submitForm($mockForm)
     vi.advanceTimersByTime(100)
 
-    expect(buttonElem).toBeEnabled()
+    expect($buttonElem).toBeEnabled()
   })
 
   test('Should not add loading class to loader before specified delay', () => {
-    submitForm(mockForm)
+    submitForm($mockForm)
     vi.advanceTimersByTime(100)
 
-    expect(buttonElem).toBeEnabled()
+    expect($buttonElem).toBeEnabled()
   })
 
   test('Should disable button on form submit after specified delay', () => {
-    submitForm(mockForm)
+    submitForm($mockForm)
     vi.advanceTimersByTime(200)
 
-    expect(buttonElem).toHaveAttribute('disabled', 'disabled')
+    expect($buttonElem).toHaveAttribute('disabled', 'disabled')
   })
 
   test('Should add loading class to loader on form submit after specified delay', () => {
-    submitForm(mockForm)
+    submitForm($mockForm)
     vi.advanceTimersByTime(200)
 
-    expect(buttonLoaderElem).toHaveAttribute(
+    expect($buttonLoaderElem).toHaveAttribute(
       'class',
       expect.stringContaining('app-loader--is-loading')
     )

--- a/src/server/common/components/button/template.test.js
+++ b/src/server/common/components/button/template.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 
 describe('Button Component', () => {

--- a/src/server/common/components/button/template.test.js
+++ b/src/server/common/components/button/template.test.js
@@ -6,9 +6,11 @@ describe('Button Component', () => {
 
   beforeEach(() => {
     const $component = renderTestComponent('button', {
-      text: 'Press me!',
-      loader: {
-        name: 'button-loader'
+      params: {
+        text: 'Press me!',
+        loader: {
+          name: 'button-loader'
+        }
       }
     })
 

--- a/src/server/common/components/details/template.test.js
+++ b/src/server/common/components/details/template.test.js
@@ -15,9 +15,11 @@ describe('Details Component', () => {
   describe('Defaults', () => {
     beforeEach(() => {
       $details = renderTestComponent('details', {
-        id: detailsId,
-        summaryText: 'Hello Sunshine',
-        text: 'Wall to wall sunshine coming for the UK in 2025!'
+        params: {
+          id: detailsId,
+          summaryText: 'Hello Sunshine',
+          text: 'Wall to wall sunshine coming for the UK in 2025!'
+        }
       })('[data-testid="app-details"]').first()
     })
 
@@ -39,8 +41,10 @@ describe('Details Component', () => {
   describe('With html content', () => {
     beforeEach(() => {
       $details = renderTestComponent('details', {
-        summaryHtml: 'Hello <strong>Trigger</strong>',
-        html: 'Alright <em>dave?</em>'
+        params: {
+          summaryHtml: 'Hello <strong>Trigger</strong>',
+          html: 'Alright <em>dave?</em>'
+        }
       })('[data-testid="app-details"]').first()
       $summary = $details.find('summary')
       $content = $details.find('[data-testid="app-details-content"]')
@@ -59,11 +63,10 @@ describe('Details Component', () => {
 
   describe('With html caller content', () => {
     beforeEach(() => {
-      $details = renderTestComponent(
-        'details',
-        { summaryHtml: '<h2>Good evening sir</h2>' },
-        `<p>Hello and <strong>Welcome</strong></p>`
-      )('[data-testid="app-details"]').first()
+      $details = renderTestComponent('details', {
+        params: { summaryHtml: '<h2>Good evening sir</h2>' },
+        callBlock: [`<p>Hello and <strong>Welcome</strong></p>`]
+      })('[data-testid="app-details"]').first()
       $summary = $details.find('summary')
       $content = $details.find('[data-testid="app-details-content"]')
     })

--- a/src/server/common/components/details/template.test.js
+++ b/src/server/common/components/details/template.test.js
@@ -1,4 +1,3 @@
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 
 describe('Details Component', () => {

--- a/src/server/common/components/entity-data-list/template.test.js
+++ b/src/server/common/components/entity-data-list/template.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 
 const dataListFixture = [

--- a/src/server/common/components/entity-data-list/template.test.js
+++ b/src/server/common/components/entity-data-list/template.test.js
@@ -38,8 +38,10 @@ describe('Entity Data List Component', () => {
 
   beforeEach(() => {
     const $component = renderTestComponent('entity-data-list', {
-      heading: 'Fruits',
-      items: dataListFixture
+      params: {
+        heading: 'Fruits',
+        items: dataListFixture
+      }
     })
 
     $heading = $component('[data-testid="app-data-list-heading"]').first()

--- a/src/server/common/components/entity-table/template.test.js
+++ b/src/server/common/components/entity-table/template.test.js
@@ -25,18 +25,20 @@ describe('Entity Table Component', () => {
         transformTeamToEntityRow
       )
       $entityTable = renderTestComponent('entity-table', {
-        headers: [
-          { id: 'name', text: 'Name', width: '15' },
-          { id: 'description', text: 'Description', width: '15' },
-          { id: 'github-team', text: 'GitHub Team', width: '15' },
-          { id: 'service-codes', text: 'Service Codes', width: '5' },
-          { id: 'alert-emails', text: 'Alert Emails', width: '20' },
-          { id: 'members', text: 'Members', width: '10' },
-          { id: 'last-updated', text: 'Last Updated', width: '10' },
-          { id: 'created', text: 'Created', width: '10' }
-        ],
-        rows: mockTeamEntityRows,
-        noResult: 'No teams found'
+        params: {
+          headers: [
+            { id: 'name', text: 'Name', width: '15' },
+            { id: 'description', text: 'Description', width: '15' },
+            { id: 'github-team', text: 'GitHub Team', width: '15' },
+            { id: 'service-codes', text: 'Service Codes', width: '5' },
+            { id: 'alert-emails', text: 'Alert Emails', width: '20' },
+            { id: 'members', text: 'Members', width: '10' },
+            { id: 'last-updated', text: 'Last Updated', width: '10' },
+            { id: 'created', text: 'Created', width: '10' }
+          ],
+          rows: mockTeamEntityRows,
+          noResult: 'No teams found'
+        }
       })
     })
 
@@ -104,18 +106,20 @@ describe('Entity Table Component', () => {
   describe('Without entities', () => {
     beforeEach(() => {
       $entityTable = renderTestComponent('entity-table', {
-        headers: [
-          { id: 'name', text: 'Name', width: '15' },
-          { id: 'description', text: 'Description', width: '15' },
-          { id: 'github-team', text: 'GitHub Team', width: '15' },
-          { id: 'service-codes', text: 'Service Codes', width: '5' },
-          { id: 'alert-emails', text: 'Alert Emails', width: '20' },
-          { id: 'members', text: 'Members', width: '10' },
-          { id: 'last-updated', text: 'Last Updated', width: '10' },
-          { id: 'created', text: 'Created', width: '10' }
-        ],
-        rows: [],
-        noResult: 'No teams found'
+        params: {
+          headers: [
+            { id: 'name', text: 'Name', width: '15' },
+            { id: 'description', text: 'Description', width: '15' },
+            { id: 'github-team', text: 'GitHub Team', width: '15' },
+            { id: 'service-codes', text: 'Service Codes', width: '5' },
+            { id: 'alert-emails', text: 'Alert Emails', width: '20' },
+            { id: 'members', text: 'Members', width: '10' },
+            { id: 'last-updated', text: 'Last Updated', width: '10' },
+            { id: 'created', text: 'Created', width: '10' }
+          ],
+          rows: [],
+          noResult: 'No teams found'
+        }
       })
     })
 

--- a/src/server/common/components/entity-table/template.test.js
+++ b/src/server/common/components/entity-table/template.test.js
@@ -1,12 +1,3 @@
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test,
-  vi
-} from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 import { cdpTeamsFixture } from '../../../../__fixtures__/admin/cdp-teams.js'
 import { transformTeamToEntityRow } from '../../../admin/teams/transformers/transform-team-to-entity-row.js'

--- a/src/server/common/components/entity/template.test.js
+++ b/src/server/common/components/entity/template.test.js
@@ -15,10 +15,12 @@ describe('Entity Component', () => {
 
     beforeEach(() => {
       $entity = renderTestComponent('entity', {
-        kind: 'text',
-        value: 'Rod License Service',
-        size: 'large',
-        label: 'Service'
+        params: {
+          kind: 'text',
+          value: 'Rod License Service',
+          size: 'large',
+          label: 'Service'
+        }
       })('[data-testid="app-entity"]').first()
     })
 
@@ -34,10 +36,12 @@ describe('Entity Component', () => {
 
     beforeEach(() => {
       $linkEntity = renderTestComponent('entity', {
-        kind: 'link',
-        value: 'Rod License Service',
-        url: '/deployments/12345678',
-        size: 'large'
+        params: {
+          kind: 'link',
+          value: 'Rod License Service',
+          url: '/deployments/12345678',
+          size: 'large'
+        }
       })('[data-testid="app-entity"]').first()
     })
 
@@ -71,11 +75,13 @@ describe('Entity Component', () => {
 
     beforeEach(() => {
       $linkEntity = renderTestComponent('entity', {
-        kind: 'link',
-        value: 'Cracking service',
-        url: '/services/09876543',
-        size: 'medium',
-        newWindow: true
+        params: {
+          kind: 'link',
+          value: 'Cracking service',
+          url: '/services/09876543',
+          size: 'medium',
+          newWindow: true
+        }
       })('[data-testid="app-entity"]').first()
     })
 
@@ -91,10 +97,12 @@ describe('Entity Component', () => {
 
     beforeEach(() => {
       $tagEntity = renderTestComponent('entity', {
-        kind: 'tag',
-        value: 'Production',
-        classes: 'govuk-tag--blue',
-        size: 'medium'
+        params: {
+          kind: 'tag',
+          value: 'Production',
+          classes: 'govuk-tag--blue',
+          size: 'medium'
+        }
       })('[data-testid="app-entity"]').first()
     })
 
@@ -112,12 +120,14 @@ describe('Entity Component', () => {
 
     beforeEach(() => {
       $tagEntity = renderTestComponent('entity', {
-        kind: 'tag',
-        value: 'Production',
-        classes: 'govuk-tag--blue',
-        size: 'medium',
-        url: 'https://chocolate.com',
-        newWindow: true
+        params: {
+          kind: 'tag',
+          value: 'Production',
+          classes: 'govuk-tag--blue',
+          size: 'medium',
+          url: 'https://chocolate.com',
+          newWindow: true
+        }
       })('[data-testid="app-entity"]').first()
     })
 
@@ -152,9 +162,11 @@ describe('Entity Component', () => {
 
     beforeEach(() => {
       $dateEntity = renderTestComponent('entity', {
-        kind: 'date',
-        value: '2023-04-11T14:40:02.242Z',
-        size: 'large'
+        params: {
+          kind: 'date',
+          value: '2023-04-11T14:40:02.242Z',
+          size: 'large'
+        }
       })('[data-testid="app-entity"]').first()
     })
 
@@ -189,10 +201,12 @@ describe('Entity Component', () => {
 
     beforeEach(() => {
       $dateEntity = renderTestComponent('entity', {
-        kind: 'date',
-        value: '2024-04-11T14:40:02.242Z',
-        size: 'large',
-        withSeconds: true
+        params: {
+          kind: 'date',
+          value: '2024-04-11T14:40:02.242Z',
+          size: 'large',
+          withSeconds: true
+        }
       })('[data-testid="app-entity"]').first()
     })
 
@@ -218,10 +232,12 @@ describe('Entity Component', () => {
 
     beforeEach(() => {
       $textEntity = renderTestComponent('entity', {
-        kind: 'text',
-        value: '0.1.0',
-        size: 'small',
-        title: 'Something wonderful here'
+        params: {
+          kind: 'text',
+          value: '0.1.0',
+          size: 'small',
+          title: 'Something wonderful here'
+        }
       })('[data-testid="app-entity-text"]').first()
     })
 
@@ -239,8 +255,10 @@ describe('Entity Component', () => {
 
     beforeEach(() => {
       $htmlEntity = renderTestComponent('entity', {
-        kind: 'html',
-        value: '<p data-testid="app-entity-html">Green tea rocks</p>'
+        params: {
+          kind: 'html',
+          value: '<p data-testid="app-entity-html">Green tea rocks</p>'
+        }
       })('[data-testid="app-entity-html"]').first()
     })
 
@@ -256,18 +274,20 @@ describe('Entity Component', () => {
 
     beforeEach(() => {
       $listEntity = renderTestComponent('entity', {
-        kind: 'list',
-        value: [
-          {
-            kind: 'date',
-            value: '2023-04-12T17:16:48+00:00'
-          },
-          {
-            kind: 'link',
-            url: '/animal/aabe63e7-87ef-4beb-a596-c810631fc474',
-            value: 'Super animals'
-          }
-        ]
+        params: {
+          kind: 'list',
+          value: [
+            {
+              kind: 'date',
+              value: '2023-04-12T17:16:48+00:00'
+            },
+            {
+              kind: 'link',
+              url: '/animal/aabe63e7-87ef-4beb-a596-c810631fc474',
+              value: 'Super animals'
+            }
+          ]
+        }
       })('[data-testid="app-entity"]').first()
 
       $dateEntity = $listEntity.find('[data-testid="app-time"]')
@@ -296,17 +316,19 @@ describe('Entity Component', () => {
 
     beforeEach(() => {
       $groupEntity = renderTestComponent('entity', {
-        kind: 'group',
-        value: [
-          {
-            kind: 'tag',
-            value: 'Frontend'
-          },
-          {
-            kind: 'tag',
-            value: 'Backend'
-          }
-        ]
+        params: {
+          kind: 'group',
+          value: [
+            {
+              kind: 'tag',
+              value: 'Frontend'
+            },
+            {
+              kind: 'tag',
+              value: 'Backend'
+            }
+          ]
+        }
       })('[data-testid="app-entity"]').first()
 
       $firstTag = $groupEntity.find('[data-testid="govuk-tag"]').first()

--- a/src/server/common/components/entity/template.test.js
+++ b/src/server/common/components/entity/template.test.js
@@ -1,12 +1,3 @@
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test,
-  vi
-} from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 
 describe('Entity Component', () => {

--- a/src/server/common/components/filters/filters.test.js
+++ b/src/server/common/components/filters/filters.test.js
@@ -1,2 +1,171 @@
-import { test } from 'vitest'
-test.todo('#filters')
+import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
+import { filters } from './filters.js'
+import { clearFilters } from '../../../../client/common/helpers/fetch/filters/clear-filters.js'
+
+const mockHistoryPush = vi.fn()
+const mockHistoryReplace = vi.fn()
+
+vi.mock('history', () => ({
+  createBrowserHistory: () => ({
+    push: (url) => mockHistoryPush(url),
+    replace: (url, options) => mockHistoryReplace(url, options)
+  })
+}))
+
+function setupFilters(params = {}) {
+  const $filtersComponent = renderTestComponent('filters', {
+    params,
+    callBlock: [
+      `<input type="text" name="plant-name" data-testid="plant-name" value="" placeholder="Search for a plants name"/>`
+    ]
+  })
+
+  // Append component document
+  document.body.innerHTML = $filtersComponent.html()
+
+  // Mimic initialisation of filters
+  const $filters = Array.from(
+    document.querySelectorAll('[data-js="app-filters"]')
+  )
+  // Init ClientSide JavaScript
+  if ($filters.length) {
+    $filters.forEach(filters)
+  }
+
+  return {
+    $form: document.querySelector('[data-testid="app-filters-form"]'),
+    $legend: document.querySelector('[data-testid="app-filters-legend"]'),
+    $caption: document.querySelector('[data-testid="app-filters-caption"]'),
+    $info: document.querySelector('[data-testid="app-filters-info"]'),
+    $textInput: document.querySelector('[data-testid="plant-name"]'),
+    $hiddenInput: document.querySelector(
+      '[data-testid="app-filters-hidden-input-owner"]'
+    ),
+    $filtersClearAll: document.querySelector(
+      '[data-testid="app-filters-clear-all"]'
+    )
+  }
+}
+
+describe('#filters', () => {
+  const options = {
+    action: '/deployments/search',
+    noJsButton: {
+      text: 'Search'
+    },
+    legend: {
+      text: 'Search'
+    },
+    caption: {
+      text: 'Search and filter deployments'
+    },
+    info: {
+      html: `<p>Use the search box to find plants by name</p>`
+    },
+    clear: {
+      url: '/deployments'
+    },
+    hiddenInputs: {
+      owner: 'scoobie'
+    }
+  }
+
+  let $form,
+    $legend,
+    $caption,
+    $info,
+    $textInput,
+    $hiddenInput,
+    $filtersClearAll
+
+  beforeEach(() => {
+    window.cdp = window.cdp || {}
+    window.cdp.clearFilters = clearFilters
+    vi.useFakeTimers()
+    ;({
+      $form,
+      $legend,
+      $caption,
+      $info,
+      $textInput,
+      $hiddenInput,
+      $filtersClearAll
+    } = setupFilters(options))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('Should have expected form', () => {
+    expect($form).not.toBeNull()
+    expect($form).toHaveAttribute('action', options.action)
+    expect($form).toHaveAttribute('method', 'get')
+  })
+
+  test('Should have expected legend', () => {
+    expect($legend).toBeInTheDocument()
+    expect($legend).toHaveTextContent(options.legend.text)
+  })
+
+  test('Should have expected caption', () => {
+    expect($caption).toBeInTheDocument()
+    expect($caption).toHaveTextContent(options.caption.text)
+  })
+
+  test('Should have expected info', () => {
+    expect($info).toBeInTheDocument()
+    expect($info).toHaveTextContent('Use the search box to find plants by name')
+  })
+
+  test('Should have expected form inputs', () => {
+    expect($textInput).toBeInTheDocument()
+    expect($textInput).toHaveAttribute(
+      'placeholder',
+      'Search for a plants name'
+    )
+
+    expect($hiddenInput).toBeInTheDocument()
+    expect($hiddenInput).toHaveValue(options.hiddenInputs.owner)
+  })
+
+  test('Should have clear all link', () => {
+    expect($filtersClearAll).toBeInTheDocument()
+    expect($filtersClearAll).toHaveAttribute('href', options.clear.url)
+    expect($filtersClearAll).toHaveTextContent('Clear all')
+  })
+
+  test('When typing, should ajax submit form with expected query params', () => {
+    $textInput.focus()
+    $textInput.value = 'frangipani'
+
+    $form.dispatchEvent(new Event('input'))
+
+    // advance to past form debounce
+    vi.advanceTimersByTime(220)
+
+    expect(mockHistoryPush).toHaveBeenCalledWith(
+      '?plant-name=frangipani&owner=scoobie'
+    )
+  })
+
+  test('Clear all should work as expected', () => {
+    expect(window.location.search).toEqual('')
+
+    $textInput.focus()
+    $textInput.value = 'Ribes rubrum'
+
+    $form.dispatchEvent(new Event('input'))
+
+    // advance to past form debounce
+    vi.advanceTimersByTime(220)
+
+    expect(mockHistoryPush).toHaveBeenCalledWith(
+      '?plant-name=Ribes%20rubrum&owner=scoobie'
+    )
+
+    $filtersClearAll.click()
+
+    expect(window.location.search).toEqual('')
+  })
+})

--- a/src/server/common/components/filters/template.njk
+++ b/src/server/common/components/filters/template.njk
@@ -2,19 +2,21 @@
 
 {% set method = params.method | default("get") %}
 
-<form action="{{ params.action }}" method="{{ method }}" class="app-filters-form" data-js="app-filters">
+<form action="{{ params.action }}" method="{{ method }}" class="app-filters-form" data-js="app-filters"
+      data-testid="app-filters-form">
   <fieldset class="govuk-fieldset {%- if params.fieldset.classes %} {{ params.fieldset.classes }}{% endif %}">
     <div class="app-filters__heading">
       <div class="app-filters__header">
-        <legend class="govuk-fieldset__legend {%- if params.legend.classes %} {{ params.legend.classes }}{% endif %}">
+        <legend class="govuk-fieldset__legend {%- if params.legend.classes %} {{ params.legend.classes }}{% endif %}"
+                data-testid="app-filters-legend">
           {{ params.legend.text }}
         </legend>
 
-        <p class="govuk-caption-m govuk-!-margin-bottom-3">
+        <p class="govuk-caption-m govuk-!-margin-bottom-3" data-testid="app-filters-caption">
           {{ params.caption.text }}
         </p>
       </div>
-      <div class="app-filters__info">
+      <div class="app-filters__info" data-testid="app-filters-info">
         {% if params.info.html %}
           {{ params.info.html | safe }}
         {% endif %}
@@ -27,6 +29,7 @@
       <p class="govuk-body-m govuk-!-margin-bottom-0 app-filters__clear-all">
         <a href="{{ params.clear.url }}"
            class="govuk-link govuk-link--text-colour"
+           data-testid="app-filters-clear-all"
            data-clear-all="clearFilters"
            data-js="app-filters-clear-all">
           Clear all
@@ -35,13 +38,14 @@
     </div>
 
     {% for key, value in params.hiddenInputs %}
-      <input type="hidden" name="{{ key }}" value="{{ value }}">
+      <input type="hidden" name="{{ key }}" value="{{ value }}" data-testid="app-filters-hidden-input-{{ key }}">
     {% endfor %}
 
     {{ govukButton({
       classes: "app-button app-button--secondary js-hidden govuk-!-margin-top-2",
       text: params.noJsButton.text,
       attributes: {
+        "data-testid": "app-filters-submit-button",
         "data-js": "app-no-js-submit-button"
       }
     }) }}

--- a/src/server/common/components/footer/template.test.js
+++ b/src/server/common/components/footer/template.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 
 describe('Footer Component', () => {

--- a/src/server/common/components/info/template.test.js
+++ b/src/server/common/components/info/template.test.js
@@ -6,7 +6,9 @@ describe('Info Component', () => {
   describe('With text content', () => {
     beforeEach(() => {
       $info = renderTestComponent('info', {
-        text: 'Something interesting'
+        params: {
+          text: 'Something interesting'
+        }
       })('[data-testid="app-info"]').first()
     })
 
@@ -20,7 +22,9 @@ describe('Info Component', () => {
   describe('With html content', () => {
     beforeEach(() => {
       $info = renderTestComponent('info', {
-        html: '<em>Something fascinating with markup!</em>'
+        params: {
+          html: '<em>Something fascinating with markup!</em>'
+        }
       })('[data-testid="app-info"]').first()
     })
 

--- a/src/server/common/components/info/template.test.js
+++ b/src/server/common/components/info/template.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 
 describe('Info Component', () => {

--- a/src/server/common/components/input-assistant/helpers/is-using-bad-naming-conventions.test.js
+++ b/src/server/common/components/input-assistant/helpers/is-using-bad-naming-conventions.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { isUsingBadNamingConventions } from './is-using-bad-naming-conventions.js'
 
 describe('#isUsingBadNames', () => {

--- a/src/server/common/components/input-assistant/input-assistant.test.js
+++ b/src/server/common/components/input-assistant/input-assistant.test.js
@@ -9,8 +9,10 @@ describe('#inputAssistant', () => {
     vi.useFakeTimers()
 
     const $component = renderTestComponent('input-assistant', {
-      message: "Have a read of 'Naming your microservice best practice'",
-      targetId: 'input-assistant'
+      params: {
+        message: "Have a read of 'Naming your microservice best practice'",
+        targetId: 'input-assistant'
+      }
     })
 
     // Add component with companion input

--- a/src/server/common/components/input-assistant/input-assistant.test.js
+++ b/src/server/common/components/input-assistant/input-assistant.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 import { inputAssistant } from './input-assistant.js'
 

--- a/src/server/common/components/input-assistant/template.test.js
+++ b/src/server/common/components/input-assistant/template.test.js
@@ -5,8 +5,10 @@ describe('Input assistant Component', () => {
 
   beforeEach(() => {
     $inputAssistant = renderTestComponent('input-assistant', {
-      message: "Have a read of 'Naming your microservice best practice'",
-      targetId: 'input-assistant'
+      params: {
+        message: "Have a read of 'Naming your microservice best practice'",
+        targetId: 'input-assistant'
+      }
     })('[data-testid="app-input-assistant"]').first()
   })
 

--- a/src/server/common/components/input-assistant/template.test.js
+++ b/src/server/common/components/input-assistant/template.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 
 describe('Input assistant Component', () => {

--- a/src/server/common/components/loader/template.test.js
+++ b/src/server/common/components/loader/template.test.js
@@ -5,7 +5,9 @@ describe('Loader Component', () => {
 
   beforeEach(() => {
     $buttonLoader = renderTestComponent('loader', {
-      name: 'button-loader'
+      params: {
+        name: 'button-loader'
+      }
     })('[data-testid="app-loader"]').first()
   })
 

--- a/src/server/common/components/loader/template.test.js
+++ b/src/server/common/components/loader/template.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 
 describe('Loader Component', () => {

--- a/src/server/common/components/logs-dashboard-link/template.test.js
+++ b/src/server/common/components/logs-dashboard-link/template.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 
 describe('Logs Dashboard Link Component', () => {

--- a/src/server/common/components/logs-dashboard-link/template.test.js
+++ b/src/server/common/components/logs-dashboard-link/template.test.js
@@ -6,8 +6,10 @@ describe('Logs Dashboard Link Component', () => {
   describe('With default attributes', () => {
     beforeEach(() => {
       const $component = renderTestComponent('logs-dashboard-link', {
-        serviceName: 'cdp-portal-frontend',
-        environment: 'management'
+        params: {
+          serviceName: 'cdp-portal-frontend',
+          environment: 'management'
+        }
       })
 
       logsDashBoardLink = $component(
@@ -31,10 +33,12 @@ describe('Logs Dashboard Link Component', () => {
   describe('With extended attributes', () => {
     beforeEach(() => {
       const $component = renderTestComponent('logs-dashboard-link', {
-        text: 'logs',
-        classes: 'app-link--underline app-link--text-colour',
-        serviceName: 'cdp-portal-frontend',
-        environment: 'management'
+        params: {
+          text: 'logs',
+          classes: 'app-link--underline app-link--text-colour',
+          serviceName: 'cdp-portal-frontend',
+          environment: 'management'
+        }
       })
 
       logsDashBoardLink = $component(

--- a/src/server/common/components/search/search.test.js
+++ b/src/server/common/components/search/search.test.js
@@ -9,14 +9,16 @@ describe('#search', () => {
     Element.prototype.scroll = vi.fn()
 
     const $component = renderTestComponent('search', {
-      label: {
-        text: 'Search me'
-      },
-      hint: {
-        text: 'Search for deployments by name'
-      },
-      id: 'search',
-      name: 'q'
+      params: {
+        label: {
+          text: 'Search me'
+        },
+        hint: {
+          text: 'Search for deployments by name'
+        },
+        id: 'search',
+        name: 'q'
+      }
     })
 
     // Append search component to a form and then add it to the document

--- a/src/server/common/components/search/search.test.js
+++ b/src/server/common/components/search/search.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 import { search } from './search.js'
 

--- a/src/server/common/components/search/template.test.js
+++ b/src/server/common/components/search/template.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 
 describe('Search Component', () => {

--- a/src/server/common/components/search/template.test.js
+++ b/src/server/common/components/search/template.test.js
@@ -5,14 +5,16 @@ describe('Search Component', () => {
 
   beforeEach(() => {
     const $component = renderTestComponent('search', {
-      label: {
-        text: 'Search me'
-      },
-      hint: {
-        text: 'Search for deployments by name'
-      },
-      id: 'search',
-      name: 'q'
+      params: {
+        label: {
+          text: 'Search me'
+        },
+        hint: {
+          text: 'Search for deployments by name'
+        },
+        id: 'search',
+        name: 'q'
+      }
     })
 
     $searchFormGroup = $component('[data-testid="app-search-group"]').first()

--- a/src/server/common/components/secrets-list/helpers/transform-secrets.test.js
+++ b/src/server/common/components/secrets-list/helpers/transform-secrets.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { transformSecrets } from './transform-secrets.js'
 import { serviceSecretsFixture } from '../../../../../__fixtures__/secrets/service-secrets.js'
 

--- a/src/server/common/components/select/template.test.js
+++ b/src/server/common/components/select/template.test.js
@@ -6,11 +6,13 @@ describe('App select with loader Component', () => {
 
   beforeEach(() => {
     const $component = renderTestComponent('select', {
-      attributes: {
-        'data-testid': 'app-select'
-      },
-      loader: {
-        name: 'app-select-loader'
+      params: {
+        attributes: {
+          'data-testid': 'app-select'
+        },
+        loader: {
+          name: 'app-select-loader'
+        }
       }
     })
 

--- a/src/server/common/components/select/template.test.js
+++ b/src/server/common/components/select/template.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 
 describe('App select with loader Component', () => {

--- a/src/server/common/components/service-header/template.test.js
+++ b/src/server/common/components/service-header/template.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 
 describe('Service Header Component', () => {

--- a/src/server/common/components/service-header/template.test.js
+++ b/src/server/common/components/service-header/template.test.js
@@ -5,8 +5,10 @@ describe('Service Header Component', () => {
 
   beforeEach(() => {
     $header = renderTestComponent('service-header', {
-      serviceName: 'Totally MEGA service portal',
-      serviceUrl: '/'
+      params: {
+        serviceName: 'Totally MEGA service portal',
+        serviceUrl: '/'
+      }
     })
   })
 

--- a/src/server/common/components/split-pane/template.njk
+++ b/src/server/common/components/split-pane/template.njk
@@ -1,10 +1,11 @@
 {% set content = params.html | safe if params.html else params.text %}
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav{% if params.isWide %} app-split-pane__nav--wide{% endif %}">
+  <div class="app-split-pane__nav{% if params.isWide %} app-split-pane__nav--wide{% endif %}"
+       data-testid="app-split-pane-nav">
     {% include "split-pane/subnav/subnav.njk" %}
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
       {{ caller() if caller else content }}
     </section>

--- a/src/server/common/components/split-pane/template.test.js
+++ b/src/server/common/components/split-pane/template.test.js
@@ -1,2 +1,66 @@
-import { test } from 'vitest'
-test.todo('Split pane component')
+import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
+
+describe('Split Pane Component', () => {
+  let $splitPane, $splitPaneNav, $splitPaneContent
+
+  beforeEach(() => {
+    const $component = renderTestComponent('split-pane', {
+      params: {
+        isWide: true
+      },
+      callBlock: [`<p>Welcome to the secrets page</p>`],
+      context: {
+        subNavigation: [
+          {
+            isActive: false,
+            url: 'services/cdp-portal-frontend',
+            label: { text: 'About' }
+          },
+          {
+            isActive: true,
+            url: 'services/cdp-portal-frontend/secrets',
+            label: { text: 'Secrets' }
+          }
+        ]
+      }
+    })
+
+    $splitPane = $component('[data-testid="app-split-pane"]')
+    $splitPaneNav = $component('[data-testid="app-split-pane-nav"]').first()
+    $splitPaneContent = $component(
+      '[data-testid="app-split-pane-content"]'
+    ).first()
+  })
+
+  test('Should render with expected class', () => {
+    expect($splitPane.attr('class')).toEqual('app-split-pane')
+  })
+
+  test('Should render with expected nav items', () => {
+    const $firstLi = $splitPaneNav.find('li').eq(0)
+    const $firstAnchor = $firstLi.find('a')
+    const $secondLi = $splitPaneNav.find('li').eq(1)
+    const $secondAnchor = $secondLi.find('a')
+
+    expect($firstLi.attr('class')).toEqual('app-subnav__section-item')
+    expect($firstAnchor.text()).toEqual('About')
+    expect($firstAnchor.attr('href')).toEqual('services/cdp-portal-frontend')
+
+    expect($secondLi.attr('class')).toEqual(
+      'app-subnav__section-item app-subnav__section-item--current'
+    )
+    expect($secondAnchor.text()).toEqual('Secrets')
+    expect($secondAnchor.attr('href')).toEqual(
+      'services/cdp-portal-frontend/secrets'
+    )
+  })
+
+  test('Should render with expected content', () => {
+    expect($splitPaneContent.find('section').attr('class')).toEqual(
+      'app-content'
+    )
+    expect($splitPaneContent.find('p').text()).toEqual(
+      'Welcome to the secrets page'
+    )
+  })
+})

--- a/src/server/common/components/step-navigation/template.njk
+++ b/src/server/common/components/step-navigation/template.njk
@@ -7,18 +7,18 @@
 </style>
 
 <nav class="app-step-navigation-container{% if params.classes %} {{ params.classes }}{% endif %}"
-     aria-label="Multi-step Form">
-  <ul class="app-step-navigation">
+     aria-label="Multi-step Form" data-testid="app-step-navigation__container">
+  <ul class="app-step-navigation" data-testid="app-step-navigation">
     {% for step in params.steps %}
       <li class="app-step-navigation__item{% if step.isCurrent %} app-step-navigation__item--current{% endif %}"
         {% if step.isCurrent %} aria-current="step" {% endif %}
-          aria-labelledby="step-{{ loop.index }}"
-          data-testid="app-step-navigation__item-{{ loop.index }}">
+          aria-labelledby="step-{{ loop.index }}">
 
         {% set stepMarker %}
           <span
             class="app-step-navigation__point{% if step.isCurrent %} app-step-navigation__point--current{% endif %}{% if
-              step.isComplete %} app-step-navigation__point--complete{% endif %}">
+              step.isComplete %} app-step-navigation__point--complete{% endif %}"
+            data-testid="app-step-navigation__marker">
 
             {% if step.isComplete %}
               {{ appCompleteIcon() }}
@@ -26,7 +26,10 @@
               <span class="app-step-navigation__icon" aria-hidden="true">{{ loop.index }}</span>
             {% endif %}
           </span>
-          <p class="app-step-navigation__heading" id="step-{{ loop.index }}">{{ step.text }}</p>
+          <p class="app-step-navigation__heading" id="step-{{ loop.index }}"
+             data-testid="app-step-navigation__text">
+            {{ step.text }}
+          </p>
         {% endset %}
 
         {% if step.url and step.isComplete %}

--- a/src/server/common/components/step-navigation/template.test.js
+++ b/src/server/common/components/step-navigation/template.test.js
@@ -1,2 +1,152 @@
-import { test } from 'vitest'
-test.todo('Step Navigation')
+import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
+
+describe('StepNavigation', () => {
+  let $component, $stepNavigation
+
+  beforeEach(() => {
+    $component = renderTestComponent('step-navigation', {
+      params: {
+        classes: 'app-step-navigation--slim',
+        width: 100,
+        steps: [
+          {
+            text: 'Step 1',
+            isCurrent: false,
+            isComplete: true,
+            url: '/step-1'
+          },
+          { text: 'Step 2', isCurrent: true },
+          { text: 'Step 3', isCurrent: false }
+        ]
+      }
+    })
+    $stepNavigation = $component('[data-testid="app-step-navigation"]')
+  })
+
+  test('Should render with expected css classes', () => {
+    expect(
+      $component('[data-testid="app-step-navigation__container"]').attr('class')
+    ).toEqual('app-step-navigation-container app-step-navigation--slim')
+  })
+
+  test('Should render all steps with correct text and attributes', () => {
+    const $firstLi = $stepNavigation.find('li').eq(0)
+    const $firstAnchor = $firstLi.find('a')
+    const $firstText = $firstLi.find(
+      '[data-testid="app-step-navigation__text"]'
+    )
+    const $firstMarker = $firstLi.find(
+      '[data-testid="app-step-navigation__marker"]'
+    )
+
+    const $secondLi = $stepNavigation.find('li').eq(1)
+    const $secondAnchor = $secondLi.find('a')
+    const $secondText = $secondLi.find(
+      '[data-testid="app-step-navigation__text"]'
+    )
+    const $secondMarker = $secondLi.find(
+      '[data-testid="app-step-navigation__marker"]'
+    )
+
+    const $thirdLi = $stepNavigation.find('li').eq(2)
+    const $thirdAnchor = $thirdLi.find('a')
+    const $thirdText = $thirdLi.find(
+      '[data-testid="app-step-navigation__text"]'
+    )
+    const $thirdMarker = $thirdLi.find(
+      '[data-testid="app-step-navigation__marker"]'
+    )
+
+    expect($firstLi.attr('class')).toEqual('app-step-navigation__item')
+    expect($firstLi.attr('aria-current')).toBeUndefined()
+    expect($firstAnchor.attr('href')).toEqual('/step-1')
+    expect($firstText.text()).toContain('Step 1')
+    expect($firstMarker.attr('class')).toEqual(
+      'app-step-navigation__point app-step-navigation__point--complete'
+    )
+
+    expect($secondLi.attr('class')).toEqual(
+      'app-step-navigation__item app-step-navigation__item--current'
+    )
+    expect($secondLi.attr('aria-current')).toEqual('step')
+    expect($secondAnchor).toHaveLength(0) // No link for current step
+    expect($secondText.text()).toContain('Step 2')
+    expect($secondMarker.attr('class')).toEqual(
+      'app-step-navigation__point app-step-navigation__point--current'
+    )
+
+    expect($thirdLi.attr('class')).toEqual('app-step-navigation__item')
+    expect($thirdLi.attr('aria-current')).toBeUndefined()
+    expect($thirdAnchor).toHaveLength(0) // No link for yet to be reached step
+    expect($thirdText.text()).toContain('Step 3')
+    expect($thirdMarker.attr('class')).toEqual('app-step-navigation__point')
+  })
+
+  test('Should apply correct styles and text for current step', () => {
+    const $secondLi = $stepNavigation.find('li').eq(1)
+    const $secondAnchor = $secondLi.find('a')
+    const $secondText = $secondLi.find(
+      '[data-testid="app-step-navigation__text"]'
+    )
+    const $secondMarker = $secondLi.find(
+      '[data-testid="app-step-navigation__marker"]'
+    )
+
+    expect($secondLi.attr('class')).toEqual(
+      'app-step-navigation__item app-step-navigation__item--current'
+    )
+    expect($secondLi.attr('aria-current')).toEqual('step')
+    expect($secondAnchor).toHaveLength(0) // No link for current step
+    expect($secondText.text()).toContain('Step 2')
+    expect($secondMarker.attr('class')).toEqual(
+      'app-step-navigation__point app-step-navigation__point--current'
+    )
+  })
+
+  test('Should apply correct styles and text for completed step', () => {
+    const $firstLi = $stepNavigation.find('li').eq(0)
+    const $firstAnchor = $firstLi.find('a')
+    const $firstText = $firstLi.find(
+      '[data-testid="app-step-navigation__text"]'
+    )
+    const $firstMarker = $firstLi.find(
+      '[data-testid="app-step-navigation__marker"]'
+    )
+
+    expect($firstLi.attr('class')).toEqual('app-step-navigation__item')
+    expect($firstLi.attr('aria-current')).toBeUndefined()
+    expect($firstAnchor.attr('href')).toEqual('/step-1')
+    expect($firstText.text()).toContain('Step 1')
+    expect($firstMarker.attr('class')).toEqual(
+      'app-step-navigation__point app-step-navigation__point--complete'
+    )
+  })
+
+  test('Should apply correct styles and text for incomplete step', () => {
+    const $thirdLi = $stepNavigation.find('li').eq(2)
+    const $thirdAnchor = $thirdLi.find('a')
+    const $thirdText = $thirdLi.find(
+      '[data-testid="app-step-navigation__text"]'
+    )
+    const $thirdMarker = $thirdLi.find(
+      '[data-testid="app-step-navigation__marker"]'
+    )
+
+    expect($thirdLi.attr('class')).toEqual('app-step-navigation__item')
+    expect($thirdLi.attr('aria-current')).toBeUndefined()
+    expect($thirdAnchor).toHaveLength(0) // No link for current step
+    expect($thirdText.text()).toContain('Step 3')
+    expect($thirdMarker.attr('class')).toEqual('app-step-navigation__point')
+  })
+
+  test('Should not render a link for incomplete or current steps', () => {
+    const $secondLi = $stepNavigation.find('li').eq(1)
+    const $secondAnchor = $secondLi.find('a')
+
+    const $thirdLi = $stepNavigation.find('li').eq(2)
+    const $thirdAnchor = $thirdLi.find('a')
+
+    expect($secondAnchor).toHaveLength(0) // No link for current step
+    expect($thirdAnchor).toHaveLength(0) // No link for yet to be reached step
+  })
+})

--- a/src/server/common/components/tabs/tabs.test.js
+++ b/src/server/common/components/tabs/tabs.test.js
@@ -1,2 +1,121 @@
-import { test } from 'vitest'
-test.todo('#tabs')
+import { tabs } from './tabs.js'
+import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
+import { dispatchDomContentLoaded } from '../../../../../test-helpers/dispatch-dom-content-loaded.js'
+import { history } from '../../../../client/common/helpers/history.js'
+
+function setupTabsComponent(options = {}) {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: {
+      ...window.location,
+      search: options?.search ?? '',
+      assign: vi.fn(),
+      replace: vi.fn()
+    }
+  })
+
+  const $tabs = renderTestComponent('tabs', {
+    params: {
+      tabs: [
+        { isActive: true, url: '/tab-one', label: 'One' },
+        { isActive: false, url: '/tab-two', label: 'Two' },
+        { isActive: false, url: '/tab-three', label: 'Three' }
+      ]
+    }
+  })
+
+  // Add tabs to the document
+  document.body.innerHTML = $tabs.html()
+
+  // Init ClientSide JavaScript
+  const tabsElements = Array.from(
+    document.querySelectorAll('[data-js="app-tabs"]')
+  )
+
+  if (tabsElements.length) {
+    tabsElements.forEach(tabs)
+  }
+
+  const $firstTabLink = document.querySelector(
+    '[data-testid="app-tabs-list-item__anchor-one"]'
+  )
+  const $secondTabLink = document.querySelector(
+    '[data-testid="app-tabs-list-item__anchor-two"]'
+  )
+  const $thirdTabLink = document.querySelector(
+    '[data-testid="app-tabs-list-item__anchor-three"]'
+  )
+
+  return {
+    $firstTabLink,
+    $secondTabLink,
+    $thirdTabLink
+  }
+}
+
+describe('#tabs', () => {
+  let $firstTabLink, $secondTabLink, $thirdTabLink
+
+  describe('On page load', () => {
+    test('With query params tab hrefs should have expected appended params', () => {
+      ;({ $firstTabLink, $secondTabLink, $thirdTabLink } = setupTabsComponent({
+        search: '?page=1&size=50&service=cdp-portal-frontend&user=RoboCop'
+      }))
+
+      dispatchDomContentLoaded()
+
+      expect($firstTabLink.getAttribute('href')).toBe(
+        'http://localhost:3000/tab-one?page=1&size=50&service=cdp-portal-frontend&user=RoboCop'
+      )
+      expect($secondTabLink.getAttribute('href')).toBe(
+        'http://localhost:3000/tab-two?page=1&size=50&service=cdp-portal-frontend&user=RoboCop'
+      )
+      expect($thirdTabLink.getAttribute('href')).toBe(
+        'http://localhost:3000/tab-three?page=1&size=50&service=cdp-portal-frontend&user=RoboCop'
+      )
+    })
+
+    test('Without query params tab hrefs should have expected appended params', () => {
+      ;({ $firstTabLink, $secondTabLink, $thirdTabLink } = setupTabsComponent({
+        search: '?service=cdp-portal-frontend&user=RoboCop'
+      }))
+
+      dispatchDomContentLoaded()
+
+      expect($firstTabLink.getAttribute('href')).toBe(
+        'http://localhost:3000/tab-one?service=cdp-portal-frontend&user=RoboCop'
+      )
+      expect($secondTabLink.getAttribute('href')).toBe(
+        'http://localhost:3000/tab-two?service=cdp-portal-frontend&user=RoboCop'
+      )
+      expect($thirdTabLink.getAttribute('href')).toBe(
+        'http://localhost:3000/tab-three?service=cdp-portal-frontend&user=RoboCop'
+      )
+    })
+  })
+
+  describe('On url change', () => {
+    beforeEach(() => {
+      ;({ $firstTabLink, $secondTabLink, $thirdTabLink } = setupTabsComponent({
+        search: '?page=4&size=40&service=cdp-portal-backend&user=Mumm-ra'
+      }))
+    })
+
+    test('Should carry params onto tab href as expected', () => {
+      history.push(
+        '/tab-two?page=4&size=40&service=cdp-portal-backend&user=Mumm-ra'
+      )
+
+      expect($firstTabLink.getAttribute('href')).toBe(
+        'http://localhost:3000/tab-one?page=4&size=40&service=cdp-portal-backend&user=Mumm-ra'
+      )
+      expect($secondTabLink.getAttribute('href')).toBe(
+        'http://localhost:3000/tab-two?page=4&size=40&service=cdp-portal-backend&user=Mumm-ra'
+      )
+      expect($thirdTabLink.getAttribute('href')).toBe(
+        'http://localhost:3000/tab-three?page=4&size=40&service=cdp-portal-backend&user=Mumm-ra'
+      )
+    })
+  })
+})

--- a/src/server/common/components/tabs/template.njk
+++ b/src/server/common/components/tabs/template.njk
@@ -22,7 +22,8 @@
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-{{ tabId }}"
-             aria-selected="{{ tab.isActive }}">
+             aria-selected="{{ tab.isActive }}"
+             data-testid="app-tabs-list-item__anchor-{{ tabId }}">
             {{ tab.label }}
           </a>
         </li>

--- a/src/server/common/components/tabs/template.test.js
+++ b/src/server/common/components/tabs/template.test.js
@@ -8,17 +8,16 @@ describe('Tabs Component', () => {
 
   describe('With child content', () => {
     beforeEach(() => {
-      $tabs = renderTestComponent(
-        'tabs',
-        {
+      $tabs = renderTestComponent('tabs', {
+        params: {
           tabs: [
             { isActive: true, url: '/tab-one', label: 'One' },
             { isActive: false, url: '/tab-two', label: 'Two' },
             { isActive: false, url: '/tab-three', label: 'Three' }
           ]
         },
-        '<p>Example Tab child html</p>'
-      )
+        callBlock: ['<p>Example Tab page html</p>']
+      })
 
       $tabsList = $tabs('[data-testid="app-tabs-list"]')
     })
@@ -54,23 +53,25 @@ describe('Tabs Component', () => {
     test('Should render expected tab panel content', () => {
       const $tabPanel = $tabs('[data-testid="app-tabs-panel"]')
 
-      expect($tabPanel.html().trim()).toBe('<p>Example Tab child html</p>')
+      expect($tabPanel.html().trim()).toBe('<p>Example Tab page html</p>')
     })
   })
 
   describe('With panel text content', () => {
     beforeEach(() => {
       $tabs = renderTestComponent('tabs', {
-        tabs: [
-          {
-            isActive: true,
-            url: '/tab-one',
-            label: 'One',
-            panel: { text: 'Example Tab text content' }
-          },
-          { isActive: false, url: '/tab-two', label: 'Two' },
-          { isActive: false, url: '/tab-three', label: 'Three' }
-        ]
+        params: {
+          tabs: [
+            {
+              isActive: true,
+              url: '/tab-one',
+              label: 'One',
+              panel: { text: 'Example Tab text content' }
+            },
+            { isActive: false, url: '/tab-two', label: 'Two' },
+            { isActive: false, url: '/tab-three', label: 'Three' }
+          ]
+        }
       })
     })
 
@@ -84,16 +85,18 @@ describe('Tabs Component', () => {
   describe('With panel html content', () => {
     beforeEach(() => {
       $tabs = renderTestComponent('tabs', {
-        tabs: [
-          {
-            isActive: true,
-            url: '/tab-one',
-            label: 'One',
-            panel: { html: 'Example Tab html content' }
-          },
-          { isActive: false, url: '/tab-two', label: 'Two' },
-          { isActive: false, url: '/tab-three', label: 'Three' }
-        ]
+        params: {
+          tabs: [
+            {
+              isActive: true,
+              url: '/tab-one',
+              label: 'One',
+              panel: { html: 'Example Tab html content' }
+            },
+            { isActive: false, url: '/tab-two', label: 'Two' },
+            { isActive: false, url: '/tab-three', label: 'Three' }
+          ]
+        }
       })
     })
 
@@ -106,9 +109,8 @@ describe('Tabs Component', () => {
 
   describe('When tabs are turned off', () => {
     beforeEach(() => {
-      $tabs = renderTestComponent(
-        'tabs',
-        {
+      $tabs = renderTestComponent('tabs', {
+        params: {
           displayTabs: false,
           tabs: [
             { isActive: true, url: '/tab-one', label: 'One' },
@@ -116,8 +118,8 @@ describe('Tabs Component', () => {
             { isActive: false, url: '/tab-three', label: 'Three' }
           ]
         },
-        '<p>Example Tab child html</p>'
-      )
+        callBlock: ['<p>Example Tab page html</p>']
+      })
 
       $tabsList = $tabs('[data-testid="app-tabs-list"]')
     })
@@ -135,7 +137,7 @@ describe('Tabs Component', () => {
     test('Should render expected tab panel content', () => {
       const $tabPanel = $tabs('[data-testid="app-tabs-panel"]')
 
-      expect($tabPanel.html().trim()).toBe('<p>Example Tab child html</p>')
+      expect($tabPanel.html().trim()).toBe('<p>Example Tab page html</p>')
     })
   })
 })

--- a/src/server/common/components/tabs/template.test.js
+++ b/src/server/common/components/tabs/template.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 
 describe('Tabs Component', () => {

--- a/src/server/common/components/tag/template.test.js
+++ b/src/server/common/components/tag/template.test.js
@@ -8,15 +8,17 @@ describe('Tag Component', () => {
   describe('On render', () => {
     beforeEach(() => {
       $component = renderTestComponent('tag', {
-        text: 'Not today',
-        classes: 'additional-class',
-        attributes: {
-          'data-testid': 'app-tag'
-        },
-        url: 'https://apples.com',
-        newWindow: true,
-        link: {
-          classes: 'app-link--without-underline'
+        params: {
+          text: 'Not today',
+          classes: 'additional-class',
+          attributes: {
+            'data-testid': 'app-tag'
+          },
+          url: 'https://apples.com',
+          newWindow: true,
+          link: {
+            classes: 'app-link--without-underline'
+          }
         }
       })
 

--- a/src/server/common/components/tag/template.test.js
+++ b/src/server/common/components/tag/template.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 
 describe('Tag Component', () => {

--- a/src/server/common/components/time/template.test.js
+++ b/src/server/common/components/time/template.test.js
@@ -14,7 +14,9 @@ describe('Time Component', () => {
 
   beforeEach(() => {
     $time = renderTestComponent('time', {
-      datetime: '2023-04-11T16:11:31.722Z'
+      params: {
+        datetime: '2023-04-11T16:11:31.722Z'
+      }
     })
   })
 

--- a/src/server/common/components/time/template.test.js
+++ b/src/server/common/components/time/template.test.js
@@ -1,12 +1,3 @@
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test,
-  vi
-} from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 
 describe('Time Component', () => {

--- a/src/server/common/components/warning/template.test.js
+++ b/src/server/common/components/warning/template.test.js
@@ -6,7 +6,9 @@ describe('Info Component', () => {
   describe('With text content', () => {
     beforeEach(() => {
       $info = renderTestComponent('info', {
-        text: 'Something interesting'
+        params: {
+          text: 'Something interesting'
+        }
       })('[data-testid="app-info"]').first()
     })
 
@@ -20,7 +22,9 @@ describe('Info Component', () => {
   describe('With html content', () => {
     beforeEach(() => {
       $info = renderTestComponent('info', {
-        html: '<em>Something fascinating with markup!</em>'
+        params: {
+          html: '<em>Something fascinating with markup!</em>'
+        }
       })('[data-testid="app-info"]').first()
     })
 

--- a/src/server/common/components/warning/template.test.js
+++ b/src/server/common/components/warning/template.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 
 describe('Info Component', () => {

--- a/src/server/common/components/xhr-subscriber/xhr-subscriber.test.js
+++ b/src/server/common/components/xhr-subscriber/xhr-subscriber.test.js
@@ -1,5 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
-
 import { xhrRequest } from '../../../../client/common/helpers/xhr.js'
 import { renderTestComponent } from '../../../../../test-helpers/component-helpers.js'
 import { xhrSubscriber } from './xhr-subscriber.js'

--- a/src/server/common/components/xhr-subscriber/xhr-subscriber.test.js
+++ b/src/server/common/components/xhr-subscriber/xhr-subscriber.test.js
@@ -14,9 +14,11 @@ describe('#xhrSubscriber', () => {
 
   beforeEach(() => {
     const $component = renderTestComponent('xhr-subscriber', {
-      id: 'mock-subscriber',
-      subscribeTo: mockEventName,
-      xhrUrl: mockXhrUrl
+      params: {
+        id: 'mock-subscriber',
+        subscribeTo: mockEventName,
+        xhrUrl: mockXhrUrl
+      }
     })
 
     // Append xhrSubscriber component to the document

--- a/src/server/common/helpers/audit/audit-message.test.js
+++ b/src/server/common/helpers/audit/audit-message.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { auditMessage } from './audit-message.js'
 
 describe('#auditMessage', () => {

--- a/src/server/common/helpers/auth/auth-scope.test.js
+++ b/src/server/common/helpers/auth/auth-scope.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { authScope } from './auth-scope.js'
 
 describe('#authScope', () => {

--- a/src/server/common/helpers/auth/cognito.test.js
+++ b/src/server/common/helpers/auth/cognito.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import jwt from '@hapi/jwt'
 import { tokenHasExpired } from './cognito.js'
 

--- a/src/server/common/helpers/auth/refresh-token.test.js
+++ b/src/server/common/helpers/auth/refresh-token.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, it, vi } from 'vitest'
 import { refreshTokenIfExpired } from './refresh-token.js'
 import pino from 'pino'
 import { add, sub } from 'date-fns'

--- a/src/server/common/helpers/auth/user-session.test.js
+++ b/src/server/common/helpers/auth/user-session.test.js
@@ -1,12 +1,3 @@
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test,
-  vi
-} from 'vitest'
 import jwt from '@hapi/jwt'
 import nock from 'nock'
 

--- a/src/server/common/helpers/build-error-details.test.js
+++ b/src/server/common/helpers/build-error-details.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { buildErrorDetails } from './build-error-details.js'
 import { joiValidationErrorDetailsFixture } from '../../../__fixtures__/joi-validation-error-details.js'
 

--- a/src/server/common/helpers/build-pagination.test.js
+++ b/src/server/common/helpers/build-pagination.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { buildPagination } from './build-pagination.js'
 
 describe('#buildPagination', () => {

--- a/src/server/common/helpers/date/format-date.test.js
+++ b/src/server/common/helpers/date/format-date.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 import { formatDate } from './format-date.js'
 
 describe('#formatDate', () => {

--- a/src/server/common/helpers/date/relative-date.test.js
+++ b/src/server/common/helpers/date/relative-date.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 import { relativeDate } from './relative-date.js'
 
 describe('#relativeDate', () => {

--- a/src/server/common/helpers/environments/get-environments.test.js
+++ b/src/server/common/helpers/environments/get-environments.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { getEnvironments, getEnvironmentsThatNeed } from './get-environments.js'
 import { scopes } from '../../constants/scopes.js'
 

--- a/src/server/common/helpers/errors/status-code-message.test.js
+++ b/src/server/common/helpers/errors/status-code-message.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { statusCodeMessage } from './status-code-message.js'
 
 describe('#statusCodeMessage', () => {

--- a/src/server/common/helpers/ext/all-environments-only-for-admin.test.js
+++ b/src/server/common/helpers/ext/all-environments-only-for-admin.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test, vi } from 'vitest'
 import { allEnvironmentsOnlyForAdmin } from './all-environments-only-for-admin.js'
 import {
   getError,

--- a/src/server/common/helpers/fetch/fetch-deploy-service-options.test.js
+++ b/src/server/common/helpers/fetch/fetch-deploy-service-options.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import nock from 'nock'
 
 import { config } from '../../../../config/config.js'

--- a/src/server/common/helpers/fetch/fetch-deployable-image-names.test.js
+++ b/src/server/common/helpers/fetch/fetch-deployable-image-names.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test, vi } from 'vitest'
 import nock from 'nock'
 
 import { config } from '../../../../config/config.js'

--- a/src/server/common/helpers/fetch/fetch-latest-deployment-settings.test.js
+++ b/src/server/common/helpers/fetch/fetch-latest-deployment-settings.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import nock from 'nock'
 
 import { config } from '../../../../config/config.js'

--- a/src/server/common/helpers/fetch/fetcher.test.js
+++ b/src/server/common/helpers/fetch/fetcher.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import nock from 'nock'
 
 import { config } from '../../../../config/config.js'

--- a/src/server/common/helpers/form/calculate-step-width.test.js
+++ b/src/server/common/helpers/form/calculate-step-width.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { calculateStepWidth } from './calculate-step-width.js'
 
 describe('#calculateStepWidth', () => {

--- a/src/server/common/helpers/form/provide-form-context-values.test.js
+++ b/src/server/common/helpers/form/provide-form-context-values.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { provideFormContextValues } from './provide-form-context-values.js'
 
 const buildMockRequest = ({

--- a/src/server/common/helpers/multistep-form/provide-form-context-values.test.js
+++ b/src/server/common/helpers/multistep-form/provide-form-context-values.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { provideFormContextValues } from './provide-form-context-values.js'
 
 const buildMockRequest = ({

--- a/src/server/common/helpers/nullify-404.test.js
+++ b/src/server/common/helpers/nullify-404.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { nullify404 } from './nullify-404.js'
 import {
   getErrorSync,

--- a/src/server/common/helpers/nunjucks/render-component.js
+++ b/src/server/common/helpers/nunjucks/render-component.js
@@ -3,13 +3,13 @@ import upperFirst from 'lodash/upperFirst.js'
 
 import { nunjucksEnvironment } from '../../../../config/nunjucks/index.js'
 
-function renderString(name, params, macroPath, caller = []) {
+function renderString(name, params, macroPath, callBlock = []) {
   const macroName = `app${upperFirst(camelCase(name))}`
   const macroParams = JSON.stringify(params, null, 2)
   let macroString = `{%- from "${macroPath}" import ${macroName} -%}`
 
-  if (caller.length) {
-    macroString += `{% call ${macroName}(${macroParams}) %} ${caller.join(' ')} {% endcall %}`
+  if (Array.isArray(callBlock) && callBlock.length > 0) {
+    macroString += `{% call ${macroName}(${macroParams}) %} ${callBlock.join(' ')} {% endcall %}`
   } else {
     macroString += `{{- ${macroName}(${macroParams}) -}}`
   }
@@ -21,13 +21,13 @@ function renderString(name, params, macroPath, caller = []) {
  * Render component outside of .njk files
  * @param {string} name - component name
  * @param {object} [params] - component params
- * @param {Array} [caller] - caller array
+ * @param {Array} [callBlock] - caller array
  * @returns {string}
  */
-function renderComponent(name, params = {}, caller = []) {
+function renderComponent(name, params = {}, callBlock = []) {
   const macroPath = `${name}/macro.njk`
 
-  return renderString(name, params, macroPath, caller)
+  return renderString(name, params, macroPath, callBlock)
 }
 
 function renderIcon(name, params = {}) {

--- a/src/server/common/helpers/options/build-options.test.js
+++ b/src/server/common/helpers/options/build-options.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { buildOptions } from './build-options.js'
 
 describe('#buildOptions', () => {

--- a/src/server/common/helpers/options/options-with-message.test.js
+++ b/src/server/common/helpers/options/options-with-message.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { optionsWithMessage } from './options-with-message.js'
 
 describe('#optionsWithMessage', () => {

--- a/src/server/common/helpers/pluralise.test.js
+++ b/src/server/common/helpers/pluralise.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { pluralise } from './pluralise.js'
 
 describe('#pluralise', () => {

--- a/src/server/common/helpers/proxy/setup-proxy.test.js
+++ b/src/server/common/helpers/proxy/setup-proxy.test.js
@@ -1,4 +1,3 @@
-import { afterEach, describe, expect, test } from 'vitest'
 import { config } from '../../../../config/config.js'
 import { setupProxy } from './setup-proxy.js'
 import { getGlobalDispatcher, ProxyAgent } from 'undici'

--- a/src/server/common/helpers/remove-nil.test.js
+++ b/src/server/common/helpers/remove-nil.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { removeNil } from './remove-nil.js'
 
 describe('#removeNil', () => {

--- a/src/server/common/helpers/remove-url-parts.test.js
+++ b/src/server/common/helpers/remove-url-parts.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { removeUrlParts } from './remove-url-parts.js'
 
 describe('#removeUrlParts', () => {

--- a/src/server/common/helpers/route-lookup/route-lookup.test.js
+++ b/src/server/common/helpers/route-lookup/route-lookup.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { routeLookup } from './index.js'
 import {
   getErrorSync,

--- a/src/server/common/helpers/sanitisation/sanitise-user.test.js
+++ b/src/server/common/helpers/sanitisation/sanitise-user.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { sanitiseUser } from './sanitise-user.js'
 import { noValue } from '../../constants/no-value.js'
 

--- a/src/server/common/helpers/sanitize.test.js
+++ b/src/server/common/helpers/sanitize.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { sanitize } from './sanitize.js'
 
 describe('#sanitize', () => {

--- a/src/server/common/helpers/secure-context/get-trust-store-certs.test.js
+++ b/src/server/common/helpers/secure-context/get-trust-store-certs.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { getTrustStoreCerts } from './get-trust-store-certs.js'
 
 describe('#getTrustStoreCerts', () => {

--- a/src/server/common/helpers/sort/sort-by-env.test.js
+++ b/src/server/common/helpers/sort/sort-by-env.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { sortByEnv } from './sort-by-env.js'
 
 describe('#sortByEnv', () => {

--- a/src/server/common/helpers/sort/sort-by-name.test.js
+++ b/src/server/common/helpers/sort/sort-by-name.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { sortByName } from './sort-by-name.js'
 import { deploymentsFixture } from '../../../../__fixtures__/deployments/deployments.js'
 

--- a/src/server/common/helpers/sort/sort-by-owner.test.js
+++ b/src/server/common/helpers/sort/sort-by-owner.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { sortByOwner } from './sort-by-owner.js'
 import { librariesFixture } from '../../../../__fixtures__/libraries.js'
 import { entityServicesFixture } from '../../../../__fixtures__/services/entities.js'

--- a/src/server/common/helpers/sort/sort-by.test.js
+++ b/src/server/common/helpers/sort/sort-by.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { sortBy } from './sort-by.js'
 import { deploymentsFixture } from '../../../../__fixtures__/deployments/deployments.js'
 

--- a/src/server/common/helpers/starts-with-vowel.test.js
+++ b/src/server/common/helpers/starts-with-vowel.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { startsWithVowel } from './starts-with-vowel.js'
 
 describe('#startsWithVowel', () => {

--- a/src/server/common/helpers/status-tag-class-map.test.js
+++ b/src/server/common/helpers/status-tag-class-map.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { statusTagClassMap } from './status-tag-class-map.js'
 import { creationStatuses } from '../constants/creation-statuses.js'
 

--- a/src/server/common/helpers/url/url-helpers.test.js
+++ b/src/server/common/helpers/url/url-helpers.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test, vi } from 'vitest'
 import { asExternalUrl, redirectWithRefresh } from './url-helpers.js'
 
 describe('asExternalUrl', () => {

--- a/src/server/common/helpers/user/get-users-teams.test.js
+++ b/src/server/common/helpers/user/get-users-teams.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test, vi } from 'vitest'
 import nock from 'nock'
 
 import { config } from '../../../../config/config.js'

--- a/src/server/common/helpers/user/user-is-admin.test.js
+++ b/src/server/common/helpers/user/user-is-admin.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { userIsAdmin } from './user-is-admin.js'
 
 describe('#userIsAdmin', () => {

--- a/src/server/common/helpers/user/user-is-service-owner.test.js
+++ b/src/server/common/helpers/user/user-is-service-owner.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
 import {
   userIsServiceOwner,
   userIsServiceOwnerDecorator

--- a/src/server/common/helpers/user/user-is-tenant.test.js
+++ b/src/server/common/helpers/user/user-is-tenant.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { userIsTenant } from './user-is-tenant.js'
 
 describe('#userIsTenant', () => {

--- a/src/server/common/helpers/validate-entity-is-a-service.test.js
+++ b/src/server/common/helpers/validate-entity-is-a-service.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { validateEntityIsAService } from './validate-entity-is-a-service.js'
 import Boom from '@hapi/boom'
 

--- a/src/server/common/helpers/validate-entity-is-a-test-suite.test.js
+++ b/src/server/common/helpers/validate-entity-is-a-test-suite.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { validateEntityIsATestSuite } from './validate-entity-is-a-test-suite.js'
 import Boom from '@hapi/boom'
 

--- a/src/server/common/helpers/view/build-link.test.js
+++ b/src/server/common/helpers/view/build-link.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { load } from 'cheerio'
 import { buildLink } from './build-link.js'
 

--- a/src/server/common/helpers/view/build-list.test.js
+++ b/src/server/common/helpers/view/build-list.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { buildList } from './build-list.js'
 
 describe('#buildList', () => {

--- a/src/server/common/helpers/view/render-tag.test.js
+++ b/src/server/common/helpers/view/render-tag.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { renderTag } from './render-tag.js'
 
 function setupComponent(params = {}) {

--- a/src/server/common/patterns/entities/tabs/proxy/helpers/find-proxy-rules.test.js
+++ b/src/server/common/patterns/entities/tabs/proxy/helpers/find-proxy-rules.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { fetchProxyRules } from '../../../../../../services/helpers/fetch/fetch-proxy-rules.js'
 import { findAllProxyRules } from './find-proxy-rules.js'
 

--- a/src/server/common/patterns/entities/tabs/proxy/transformers/transform-proxy-rules.test.js
+++ b/src/server/common/patterns/entities/tabs/proxy/transformers/transform-proxy-rules.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { transformProxyRules } from './transform-proxy-rules.js'
 
 describe('#transformProxyRules', () => {

--- a/src/server/common/patterns/entities/tabs/secrets/schema/secret-payload-validation.test.js
+++ b/src/server/common/patterns/entities/tabs/secrets/schema/secret-payload-validation.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import Joi from 'joi'
 
 import { secretPayloadValidation } from './secret-payload-validation.js'

--- a/src/server/common/patterns/entities/tabs/secrets/transformers/all-environment-secrets.test.js
+++ b/src/server/common/patterns/entities/tabs/secrets/transformers/all-environment-secrets.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { allEnvironmentSecrets } from './all-environment-secrets.js'
 import { allEnvironmentSecretsFixture } from '../../../../../../../__fixtures__/secrets/all-environment-secrets.js'
 import { getEnvironments } from '../../../../../helpers/environments/get-environments.js'

--- a/src/server/common/patterns/entities/tabs/secrets/transformers/environment-secrets.test.js
+++ b/src/server/common/patterns/entities/tabs/secrets/transformers/environment-secrets.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { environmentSecrets } from './environment-secrets.js'
 import { serviceSecretsWithPendingFixture } from '../../../../../../../__fixtures__/secrets/service-secrets.js'
 

--- a/src/server/common/transformers/with-environments.test.js
+++ b/src/server/common/transformers/with-environments.test.js
@@ -1,5 +1,4 @@
-import { describe, expect, test } from 'vitest'
-import { runningServicesFixture } from '../../../__fixtures__/running-services.js'
+import { runningServicesFixture } from '../../../__fixtures__/running-services/running-services.js'
 import { withEnvironments } from './with-environments.js'
 
 describe('#withEnvironments', () => {

--- a/src/server/create/helpers/validator/check-name-availability.test.js
+++ b/src/server/create/helpers/validator/check-name-availability.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
 import nock from 'nock'
 
 import { config } from '../../../../config/config.js'

--- a/src/server/create/microservice/helpers/schema/microservice-validation.test.js
+++ b/src/server/create/microservice/helpers/schema/microservice-validation.test.js
@@ -1,5 +1,3 @@
-import { describe, expect, test } from 'vitest'
-
 import { microserviceValidation } from './microservice-validation.js'
 import { checkNameAvailability } from '../../../helpers/validator/check-name-availability.js'
 

--- a/src/server/deploy-service/helpers/build-help-text.test.js
+++ b/src/server/deploy-service/helpers/build-help-text.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { buildHelpText } from './build-help-text.js'
 import { deployServiceOptionsFixture } from '../../../__fixtures__/deploy-service/deploy-service-options.js'
 

--- a/src/server/deploy-service/helpers/cpu-to-vcpu.test.js
+++ b/src/server/deploy-service/helpers/cpu-to-vcpu.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { cpuToVCpu } from './cpu-to-vcpu.js'
 
 describe('#cpuToVCpu', () => {

--- a/src/server/deploy-service/helpers/fetch/fetch-available-versions.test.js
+++ b/src/server/deploy-service/helpers/fetch/fetch-available-versions.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import nock from 'nock'
 
 import { config } from '../../../../config/config.js'

--- a/src/server/deploy-service/helpers/pre/provide-form-values.test.js
+++ b/src/server/deploy-service/helpers/pre/provide-form-values.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import nock from 'nock'
 
 import { config } from '../../../../config/config.js'

--- a/src/server/deploy-service/transformers/deployment-rows.test.js
+++ b/src/server/deploy-service/transformers/deployment-rows.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { deploymentSessionFixture } from '../../../__fixtures__/deploy-service/deployment-session.js'
 import { deploymentRows } from './deployment-rows.js'
 import { cpuOptionsFixture } from '../../../__fixtures__/deploy-service/cpu-options.js'

--- a/src/server/deployments/helpers/augment-status.test.js
+++ b/src/server/deployments/helpers/augment-status.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { augmentStatus } from './augment-status.js'
 
 describe('#augmentStatus', () => {

--- a/src/server/deployments/helpers/build-database-logs-link.test.js
+++ b/src/server/deployments/helpers/build-database-logs-link.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 import { buildDatabaseLogsLink } from './build-database-logs-link.js'
 
 describe('#buildDatabaseLogsLink', () => {

--- a/src/server/deployments/helpers/database-update-favicon-state.test.js
+++ b/src/server/deployments/helpers/database-update-favicon-state.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { faviconState } from '../../common/constants/favicon-state.js'
 import { databaseStatus } from '../constants/database-status.js'
 import { databaseUpdateFaviconState } from './database-update-favicon-state.js'

--- a/src/server/deployments/helpers/deployment-favicon-state.test.js
+++ b/src/server/deployments/helpers/deployment-favicon-state.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { faviconState } from '../../common/constants/favicon-state.js'
 import { deploymentStatus } from '../../common/constants/deployment.js'
 import { deploymentFaviconState } from './deployment-favicon-state.js'

--- a/src/server/deployments/helpers/fetch/fetch-deployment.test.js
+++ b/src/server/deployments/helpers/fetch/fetch-deployment.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import nock from 'nock'
 
 import { config } from '../../../../config/config.js'

--- a/src/server/deployments/helpers/pre/provide-deployment.test.js
+++ b/src/server/deployments/helpers/pre/provide-deployment.test.js
@@ -1,4 +1,3 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { provideDeployment } from './provide-deployment.js'
 import { fetchDeployment } from '../fetch/fetch-deployment.js'
 import { deploymentInProgressFixture } from '../../../../__fixtures__/deployments/deployment-in-progress.js'

--- a/src/server/deployments/helpers/provide-deployment-status-classname.test.js
+++ b/src/server/deployments/helpers/provide-deployment-status-classname.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { provideDeploymentStatusClassname } from './provide-deployment-status-classname.js'
 
 describe('#getDeploymentStatusClassname', () => {

--- a/src/server/deployments/helpers/provide-ecs-deployment-status.test.js
+++ b/src/server/deployments/helpers/provide-ecs-deployment-status.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { provideEcsDeploymentStatus } from './provide-ecs-deployment-status.js'
 import { deploymentStatus } from '../../common/constants/deployment.js'
 

--- a/src/server/deployments/helpers/provide-tabs.test.js
+++ b/src/server/deployments/helpers/provide-tabs.test.js
@@ -1,4 +1,3 @@
-import { afterEach, describe, expect, test, vi } from 'vitest'
 import { provideTabs } from './provide-tabs.js'
 import { scopes } from '../../common/constants/scopes.js'
 

--- a/src/server/deployments/transformers/decorate-rollouts.test.js
+++ b/src/server/deployments/transformers/decorate-rollouts.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { decorateRollouts } from './decorate-rollouts.js'
 import { deploymentsWithMigrationsFixture } from '../../../__fixtures__/deployments/deployments-with-migrations.js'
 import { entityServicesFixture } from '../../../__fixtures__/services/entities.js'

--- a/src/server/deployments/transformers/deployment-to-entity-row.js
+++ b/src/server/deployments/transformers/deployment-to-entity-row.js
@@ -89,7 +89,7 @@ function deploymentToEntityRow(deployment) {
       {
         headers: 'team',
         entity: {
-          kind: 'group',
+          kind: 'list',
           value: teams?.length ? teams : null
         }
       },

--- a/src/server/deployments/transformers/deployment-to-entity-row.test.js
+++ b/src/server/deployments/transformers/deployment-to-entity-row.test.js
@@ -65,7 +65,7 @@ describe('#deploymentToEntityRow', () => {
           },
           {
             entity: {
-              kind: 'group',
+              kind: 'list',
               value: [
                 {
                   kind: 'link',
@@ -135,7 +135,7 @@ describe('#deploymentToEntityRow', () => {
           },
           {
             entity: {
-              kind: 'group',
+              kind: 'list',
               value: [
                 {
                   kind: 'link',
@@ -205,7 +205,7 @@ describe('#deploymentToEntityRow', () => {
           },
           {
             entity: {
-              kind: 'group',
+              kind: 'list',
               value: [
                 {
                   kind: 'link',
@@ -275,7 +275,7 @@ describe('#deploymentToEntityRow', () => {
           },
           {
             entity: {
-              kind: 'group',
+              kind: 'list',
               value: [
                 {
                   kind: 'link',
@@ -345,7 +345,7 @@ describe('#deploymentToEntityRow', () => {
           },
           {
             entity: {
-              kind: 'group',
+              kind: 'list',
               value: [
                 {
                   kind: 'link',

--- a/src/server/deployments/transformers/deployment-to-entity-row.test.js
+++ b/src/server/deployments/transformers/deployment-to-entity-row.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { decorateRollouts } from './decorate-rollouts.js'
 import { deploymentToEntityRow } from './deployment-to-entity-row.js'
 import { deploymentsWithMigrationsFixture } from '../../../__fixtures__/deployments/deployments-with-migrations.js'

--- a/src/server/deployments/transformers/migration-to-entity-row.js
+++ b/src/server/deployments/transformers/migration-to-entity-row.js
@@ -86,7 +86,7 @@ function migrationToEntityRow(migration) {
       {
         headers: 'team',
         entity: {
-          kind: 'group',
+          kind: 'list',
           value: teams?.length ? teams : null
         }
       },

--- a/src/server/deployments/views/__file_snapshots__/Deployments-list-page-renders-for-logged-in-admin-user-1.html
+++ b/src/server/deployments/views/__file_snapshots__/Deployments-list-page-renders-for-logged-in-admin-user-1.html
@@ -249,19 +249,21 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 
-<form action="/deployments/dev" method="get" class="app-filters-form" data-js="app-filters">
+<form action="/deployments/dev" method="get" class="app-filters-form" data-js="app-filters"
+      data-testid="app-filters-form">
   <fieldset class="govuk-fieldset">
     <div class="app-filters__heading">
       <div class="app-filters__header">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l govuk-!-margin-bottom-2">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l govuk-!-margin-bottom-2"
+                data-testid="app-filters-legend">
           Search
         </legend>
 
-        <p class="govuk-caption-m govuk-!-margin-bottom-3">
+        <p class="govuk-caption-m govuk-!-margin-bottom-3" data-testid="app-filters-caption">
           Search and filter microservice deployments and database updates
         </p>
       </div>
-      <div class="app-filters__info">
+      <div class="app-filters__info" data-testid="app-filters-info">
       </div>
     </div>
 
@@ -818,6 +820,7 @@ selected="selected">
       <p class="govuk-body-m govuk-!-margin-bottom-0 app-filters__clear-all">
         <a href="/deployments/dev"
            class="govuk-link govuk-link--text-colour"
+           data-testid="app-filters-clear-all"
            data-clear-all="clearFilters"
            data-js="app-filters-clear-all">
           Clear all
@@ -825,10 +828,10 @@ selected="selected">
       </p>
     </div>
 
-      <input type="hidden" name="page" value="1">
-      <input type="hidden" name="size" value="50">
+      <input type="hidden" name="page" value="1" data-testid="app-filters-hidden-input-page">
+      <input type="hidden" name="size" value="50" data-testid="app-filters-hidden-input-size">
 
-    <button type="submit" class="govuk-button app-button app-button--secondary js-hidden govuk-!-margin-top-2" data-module="govuk-button" data-js="app-no-js-submit-button">
+    <button type="submit" class="govuk-button app-button app-button--secondary js-hidden govuk-!-margin-top-2" data-module="govuk-button" data-testid="app-filters-submit-button" data-js="app-no-js-submit-button">
   Search
 </button>
   </fieldset>
@@ -850,7 +853,8 @@ selected="selected">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-infra-dev"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-infra-dev">
             Infra-dev
           </a>
         </li>
@@ -866,7 +870,8 @@ selected="selected">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-management"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-management">
             Management
           </a>
         </li>
@@ -882,7 +887,8 @@ selected="selected">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-dev"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-dev">
             Dev
           </a>
         </li>
@@ -898,7 +904,8 @@ selected="selected">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-test"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-test">
             Test
           </a>
         </li>
@@ -914,7 +921,8 @@ selected="selected">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-perf-test"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-perf-test">
             Perf-test
           </a>
         </li>
@@ -930,7 +938,8 @@ selected="selected">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-prod"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-prod">
             Prod
           </a>
         </li>
@@ -1184,10 +1193,10 @@ width="20%"        >
 
 
 
-      <span class="app-entity__group">
-          
+        <ul class="app-entity__list">
+            
 
-<div class="app-entity" data-testid="app-entity">
+<li class="app-entity__list-item" data-testid="app-entity">
 
 
 
@@ -1198,10 +1207,10 @@ width="20%"        >
 
 
 
-</div>
+</li>
 
 
-      </span>
+        </ul>
 
 
 </div>
@@ -1414,10 +1423,10 @@ width="20%"        >
 
 
 
-      <span class="app-entity__group">
-          
+        <ul class="app-entity__list">
+            
 
-<div class="app-entity" data-testid="app-entity">
+<li class="app-entity__list-item" data-testid="app-entity">
 
 
 
@@ -1428,10 +1437,10 @@ width="20%"        >
 
 
 
-</div>
+</li>
 
 
-      </span>
+        </ul>
 
 
 </div>
@@ -1643,10 +1652,10 @@ width="20%"        >
 
 
 
-      <span class="app-entity__group">
-          
+        <ul class="app-entity__list">
+            
 
-<div class="app-entity" data-testid="app-entity">
+<li class="app-entity__list-item" data-testid="app-entity">
 
 
 
@@ -1657,10 +1666,10 @@ width="20%"        >
 
 
 
-</div>
+</li>
 
 
-      </span>
+        </ul>
 
 
 </div>
@@ -1858,10 +1867,10 @@ width="20%"        >
 
 
 
-      <span class="app-entity__group">
-          
+        <ul class="app-entity__list">
+            
 
-<div class="app-entity" data-testid="app-entity">
+<li class="app-entity__list-item" data-testid="app-entity">
 
 
 
@@ -1872,10 +1881,10 @@ width="20%"        >
 
 
 
-</div>
+</li>
 
 
-      </span>
+        </ul>
 
 
 </div>
@@ -2087,10 +2096,10 @@ width="20%"        >
 
 
 
-      <span class="app-entity__group">
-          
+        <ul class="app-entity__list">
+            
 
-<div class="app-entity" data-testid="app-entity">
+<li class="app-entity__list-item" data-testid="app-entity">
 
 
 
@@ -2101,10 +2110,10 @@ width="20%"        >
 
 
 
-</div>
+</li>
 
 
-      </span>
+        </ul>
 
 
 </div>

--- a/src/server/deployments/views/__file_snapshots__/Deployments-list-page-renders-for-logged-out-users-1.html
+++ b/src/server/deployments/views/__file_snapshots__/Deployments-list-page-renders-for-logged-out-users-1.html
@@ -198,19 +198,21 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 
-<form action="/deployments/dev" method="get" class="app-filters-form" data-js="app-filters">
+<form action="/deployments/dev" method="get" class="app-filters-form" data-js="app-filters"
+      data-testid="app-filters-form">
   <fieldset class="govuk-fieldset">
     <div class="app-filters__heading">
       <div class="app-filters__header">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l govuk-!-margin-bottom-2">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l govuk-!-margin-bottom-2"
+                data-testid="app-filters-legend">
           Search
         </legend>
 
-        <p class="govuk-caption-m govuk-!-margin-bottom-3">
+        <p class="govuk-caption-m govuk-!-margin-bottom-3" data-testid="app-filters-caption">
           Search and filter microservice deployments and database updates
         </p>
       </div>
-      <div class="app-filters__info">
+      <div class="app-filters__info" data-testid="app-filters-info">
       </div>
     </div>
 
@@ -767,6 +769,7 @@ selected="selected">
       <p class="govuk-body-m govuk-!-margin-bottom-0 app-filters__clear-all">
         <a href="/deployments/dev"
            class="govuk-link govuk-link--text-colour"
+           data-testid="app-filters-clear-all"
            data-clear-all="clearFilters"
            data-js="app-filters-clear-all">
           Clear all
@@ -774,10 +777,10 @@ selected="selected">
       </p>
     </div>
 
-      <input type="hidden" name="page" value="1">
-      <input type="hidden" name="size" value="50">
+      <input type="hidden" name="page" value="1" data-testid="app-filters-hidden-input-page">
+      <input type="hidden" name="size" value="50" data-testid="app-filters-hidden-input-size">
 
-    <button type="submit" class="govuk-button app-button app-button--secondary js-hidden govuk-!-margin-top-2" data-module="govuk-button" data-js="app-no-js-submit-button">
+    <button type="submit" class="govuk-button app-button app-button--secondary js-hidden govuk-!-margin-top-2" data-module="govuk-button" data-testid="app-filters-submit-button" data-js="app-no-js-submit-button">
   Search
 </button>
   </fieldset>
@@ -799,7 +802,8 @@ selected="selected">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-dev"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-dev">
             Dev
           </a>
         </li>
@@ -815,7 +819,8 @@ selected="selected">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-test"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-test">
             Test
           </a>
         </li>
@@ -831,7 +836,8 @@ selected="selected">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-perf-test"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-perf-test">
             Perf-test
           </a>
         </li>
@@ -847,7 +853,8 @@ selected="selected">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-prod"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-prod">
             Prod
           </a>
         </li>
@@ -1087,10 +1094,10 @@ width="20%"        >
 
 
 
-      <span class="app-entity__group">
-          
+        <ul class="app-entity__list">
+            
 
-<div class="app-entity" data-testid="app-entity">
+<li class="app-entity__list-item" data-testid="app-entity">
 
 
 
@@ -1101,10 +1108,10 @@ width="20%"        >
 
 
 
-</div>
+</li>
 
 
-      </span>
+        </ul>
 
 
 </div>
@@ -1303,10 +1310,10 @@ width="20%"        >
 
 
 
-      <span class="app-entity__group">
-          
+        <ul class="app-entity__list">
+            
 
-<div class="app-entity" data-testid="app-entity">
+<li class="app-entity__list-item" data-testid="app-entity">
 
 
 
@@ -1317,10 +1324,10 @@ width="20%"        >
 
 
 
-</div>
+</li>
 
 
-      </span>
+        </ul>
 
 
 </div>
@@ -1518,10 +1525,10 @@ width="20%"        >
 
 
 
-      <span class="app-entity__group">
-          
+        <ul class="app-entity__list">
+            
 
-<div class="app-entity" data-testid="app-entity">
+<li class="app-entity__list-item" data-testid="app-entity">
 
 
 
@@ -1532,10 +1539,10 @@ width="20%"        >
 
 
 
-</div>
+</li>
 
 
-      </span>
+        </ul>
 
 
 </div>
@@ -1733,10 +1740,10 @@ width="20%"        >
 
 
 
-      <span class="app-entity__group">
-          
+        <ul class="app-entity__list">
+            
 
-<div class="app-entity" data-testid="app-entity">
+<li class="app-entity__list-item" data-testid="app-entity">
 
 
 
@@ -1747,10 +1754,10 @@ width="20%"        >
 
 
 
-</div>
+</li>
 
 
-      </span>
+        </ul>
 
 
 </div>
@@ -1948,10 +1955,10 @@ width="20%"        >
 
 
 
-      <span class="app-entity__group">
-          
+        <ul class="app-entity__list">
+            
 
-<div class="app-entity" data-testid="app-entity">
+<li class="app-entity__list-item" data-testid="app-entity">
 
 
 
@@ -1962,10 +1969,10 @@ width="20%"        >
 
 
 
-</div>
+</li>
 
 
-      </span>
+        </ul>
 
 
 </div>

--- a/src/server/deployments/views/database-update.test.js
+++ b/src/server/deployments/views/database-update.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 import {
   initialiseServer,
   mockAuthAndRenderUrl

--- a/src/server/deployments/views/deployment.test.js
+++ b/src/server/deployments/views/deployment.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 import {
   initialiseServer,
   mockAuthAndRenderUrl

--- a/src/server/deployments/views/list.test.js
+++ b/src/server/deployments/views/list.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 import {
   initialiseServer,
   mockAuthAndRenderUrl

--- a/src/server/documentation/controllers/search-handler.test.js
+++ b/src/server/documentation/controllers/search-handler.test.js
@@ -1,4 +1,3 @@
-import { beforeAll, describe, expect, test } from 'vitest'
 import Hapi from '@hapi/hapi'
 import Boom from '@hapi/boom'
 

--- a/src/server/documentation/helpers/docs-breadcrumbs.test.js
+++ b/src/server/documentation/helpers/docs-breadcrumbs.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { docsBreadcrumbs } from './docs-breadcrumbs.js'
 
 describe('#docsBreadcrumbs', () => {

--- a/src/server/documentation/helpers/documentation-structure.test.js
+++ b/src/server/documentation/helpers/documentation-structure.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test, vi } from 'vitest'
 import { fetchS3File } from './s3-file-handler.js'
 import { documentationStructure } from './documentation-structure.js'
 

--- a/src/server/documentation/helpers/extensions/heading.test.js
+++ b/src/server/documentation/helpers/extensions/heading.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { Marked } from 'marked'
 import { load } from 'cheerio'
 

--- a/src/server/documentation/helpers/extensions/link.test.js
+++ b/src/server/documentation/helpers/extensions/link.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { Marked } from 'marked'
 import { load } from 'cheerio'
 

--- a/src/server/documentation/helpers/extensions/nav-link.test.js
+++ b/src/server/documentation/helpers/extensions/nav-link.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { Marked } from 'marked'
 import { load } from 'cheerio'
 

--- a/src/server/documentation/helpers/markdown/build-docs-nav.test.js
+++ b/src/server/documentation/helpers/markdown/build-docs-nav.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { buildDocsNav } from './build-docs-nav.js'
 import { fetchMarkdown } from '../s3-file-handler.js'
 

--- a/src/server/documentation/helpers/markdown/build-page-html.test.js
+++ b/src/server/documentation/helpers/markdown/build-page-html.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { load } from 'cheerio'
 
 import { buildPageHtml } from './build-page-html.js'

--- a/src/server/documentation/helpers/search-index.test.js
+++ b/src/server/documentation/helpers/search-index.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeEach, describe, expect, test, vi } from 'vitest'
 import lunr from 'lunr'
 
 import { searchIndex } from './search-index.js'

--- a/src/server/health/controller.test.js
+++ b/src/server/health/controller.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 import { createServer } from '../index.js'
 import { statusCodes } from '../common/constants/status-codes.js'
 

--- a/src/server/helpers/provide-sub-navigation.test.js
+++ b/src/server/helpers/provide-sub-navigation.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { provideSubNav } from './provide-sub-navigation.js'
 import { scopes } from '../common/constants/scopes.js'
 import { pluralise } from '../common/helpers/pluralise.js'

--- a/src/server/repositories/status.test.js
+++ b/src/server/repositories/status.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 import {
   initialiseServer,
   mockAuthAndRenderUrl,

--- a/src/server/running-services/helpers/build-running-services-table-data.test.js
+++ b/src/server/running-services/helpers/build-running-services-table-data.test.js
@@ -1,2 +1,255 @@
-import { test } from 'vitest'
-test.todo('#buildTableData')
+import { fetchRunningServices } from './fetch/fetch-running-services.js'
+import { fetchServices } from '../../common/helpers/fetch/fetch-entities.js'
+import { entityServicesFixture } from '../../../__fixtures__/services/entities.js'
+import { buildRunningServicesTableData } from './build-running-services-table-data.js'
+import { fetchRunningServicesFilters } from './fetch/fetch-running-services-filters.js'
+import { runningServicesFiltersFixture } from '../../../__fixtures__/running-services/filters.js'
+import { runningServicesFixture } from '../../../__fixtures__/running-services/running-services.js'
+
+vi.mock('./fetch/fetch-running-services-filters.js')
+vi.mock('./fetch/fetch-running-services.js')
+vi.mock('../../common/helpers/fetch/fetch-entities.js')
+
+describe('#buildRunningServicesTableData', () => {
+  test('returns expected table data with valid inputs', async () => {
+    fetchServices.mockResolvedValue(entityServicesFixture)
+    fetchRunningServicesFilters.mockResolvedValue(runningServicesFiltersFixture)
+    // Mimic server side filtering
+    fetchRunningServices.mockResolvedValue(
+      runningServicesFixture.filter(
+        ({ service }) => service === 'cdp-portal-frontend'
+      )
+    )
+
+    const result = await buildRunningServicesTableData({
+      pre: { authedUser: { scope: ['admin'], uuidScope: [] } },
+      query: {
+        service: 'cdp-portal-frontend',
+        status: 'running',
+        team: 'Platform',
+        user: 'RoboCop'
+      }
+    })
+
+    expect(result).toEqual({
+      environments: [
+        'infra-dev',
+        'management',
+        'dev',
+        'test',
+        'perf-test',
+        'prod'
+      ],
+      rows: [
+        {
+          cells: [
+            {
+              headers: 'owner',
+              isCentered: true,
+              classes: 'app-entity-table__cell--owned',
+              entity: {
+                kind: 'html',
+                value: ''
+              }
+            },
+            {
+              headers: 'service',
+              entity: {
+                kind: 'link',
+                value: 'cdp-portal-frontend',
+                url: '/running-services/cdp-portal-frontend'
+              }
+            },
+            {
+              headers: 'team',
+              entity: {
+                kind: 'group',
+                value: [
+                  {
+                    kind: 'link',
+                    value: 'Platform',
+                    url: '/teams/aabe63e7-87ef-4beb-a596-c810631fc474'
+                  }
+                ]
+              }
+            },
+            {
+              headers: 'infra-dev',
+              isSlim: true,
+              entity: {
+                kind: 'html',
+                value: expect.stringContaining('Deployed')
+              }
+            },
+            {
+              headers: 'management',
+              isSlim: true,
+              html: '<div class="app-running-service-entity--empty"></div>'
+            },
+            {
+              headers: 'dev',
+              isSlim: true,
+              html: '<div class="app-running-service-entity--empty"></div>'
+            },
+            {
+              headers: 'test',
+              isSlim: true,
+              html: '<div class="app-running-service-entity--empty"></div>'
+            },
+            {
+              headers: 'perf-test',
+              isSlim: true,
+              html: '<div class="app-running-service-entity--empty"></div>'
+            },
+            {
+              headers: 'prod',
+              isSlim: true,
+              html: '<div class="app-running-service-entity--empty"></div>'
+            }
+          ]
+        }
+      ],
+      serviceFilters: [
+        {
+          text: ' - - select - - ',
+          disabled: true,
+          attributes: {
+            selected: true
+          }
+        },
+        {
+          value: 'cdp-portal-frontend',
+          text: 'cdp-portal-frontend'
+        },
+        {
+          value: 'cdp-user-service-backend',
+          text: 'cdp-user-service-backend'
+        }
+      ],
+      userFilters: [
+        {
+          text: ' - - select - - ',
+          disabled: true,
+          attributes: {
+            selected: true
+          }
+        },
+        {
+          value: '01b99595-27b5-4ab0-9807-f104c09d2cd0',
+          text: 'RoboCop'
+        },
+        {
+          value: '7a34a7f1-55ca-4e6c-9fc6-56220c4280eb',
+          text: 'Mumm-ra'
+        }
+      ],
+      statusFilters: [
+        {
+          text: ' - - select - - ',
+          disabled: true,
+          attributes: {
+            selected: true
+          }
+        },
+        {
+          value: 'pending',
+          text: 'Pending'
+        },
+        {
+          value: 'running',
+          text: 'Running'
+        },
+        {
+          value: 'undeployed',
+          text: 'Undeployed'
+        }
+      ],
+      teamFilters: [
+        {
+          text: ' - - select - - ',
+          disabled: true,
+          attributes: {
+            selected: true
+          }
+        },
+        {
+          value: '0be2f4a1-3e1c-4675-a8ec-3af6d453b7ca',
+          text: 'Forms'
+        },
+        {
+          value: 'aabe63e7-87ef-4beb-a596-c810631fc474',
+          text: 'Platform'
+        }
+      ]
+    })
+  })
+
+  test('Should handle empty filters gracefully', async () => {
+    fetchServices.mockResolvedValue([])
+    fetchRunningServicesFilters.mockResolvedValue({
+      filters: { services: [], users: [], statuses: [], teams: [] }
+    })
+    fetchRunningServices.mockResolvedValue([])
+
+    const result = await buildRunningServicesTableData({
+      pre: { authedUser: { scope: [], uuidScope: [] } },
+      query: {}
+    })
+
+    expect(result).toEqual({
+      environments: ['dev', 'test', 'perf-test', 'prod'],
+      rows: [],
+      serviceFilters: [
+        {
+          text: ' - - select - - ',
+          disabled: true,
+          attributes: {
+            selected: true
+          }
+        }
+      ],
+      userFilters: [
+        {
+          text: ' - - select - - ',
+          disabled: true,
+          attributes: {
+            selected: true
+          }
+        }
+      ],
+      statusFilters: [
+        {
+          text: ' - - select - - ',
+          disabled: true,
+          attributes: {
+            selected: true
+          }
+        }
+      ],
+      teamFilters: [
+        {
+          text: ' - - select - - ',
+          disabled: true,
+          attributes: {
+            selected: true
+          }
+        }
+      ]
+    })
+  })
+
+  test('Should throw an error if fetchRunningServices fails', async () => {
+    fetchServices.mockResolvedValue([])
+    fetchRunningServicesFilters.mockResolvedValue({
+      filters: { services: [], users: [], statuses: [], teams: [] }
+    })
+    fetchRunningServices.mockRejectedValue(new Error('Fetch failed'))
+
+    await expect(
+      buildRunningServicesTableData({
+        pre: { authedUser: { scope: [], uuidScope: [] } },
+        query: {}
+      })
+    ).rejects.toThrow('Fetch failed')
+  })
+})

--- a/src/server/running-services/helpers/provide-deployment-status-classname.test.js
+++ b/src/server/running-services/helpers/provide-deployment-status-classname.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { provideDeploymentStatusClassname } from './provide-deployment-status-classname.js'
 
 describe('#getDeploymentStatusClassname', () => {

--- a/src/server/running-services/helpers/transformers/running-service-to-entity-row.test.js
+++ b/src/server/running-services/helpers/transformers/running-service-to-entity-row.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { environments } from '../../../../config/environments.js'
-import { runningServicesFixture } from '../../../../__fixtures__/running-services.js'
+import { runningServicesFixture } from '../../../../__fixtures__/running-services/running-services.js'
 import { transformRunningServices } from './running-services.js'
 import { runningServiceToEntityRow } from './running-service-to-entity-row.js'
 import { entityServicesFixture } from '../../../../__fixtures__/services/entities.js'

--- a/src/server/running-services/helpers/transformers/running-service-to-entity-row.test.js
+++ b/src/server/running-services/helpers/transformers/running-service-to-entity-row.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { environments } from '../../../../config/environments.js'
 import { runningServicesFixture } from '../../../../__fixtures__/running-services/running-services.js'
 import { transformRunningServices } from './running-services.js'

--- a/src/server/running-services/helpers/transformers/running-services.test.js
+++ b/src/server/running-services/helpers/transformers/running-services.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { transformRunningServices } from './running-services.js'
 import { runningServicesFixture } from '../../../../__fixtures__/running-services/running-services.js'
 import { entityServicesFixture } from '../../../../__fixtures__/services/entities.js'

--- a/src/server/running-services/helpers/transformers/running-services.test.js
+++ b/src/server/running-services/helpers/transformers/running-services.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { transformRunningServices } from './running-services.js'
-import { runningServicesFixture } from '../../../../__fixtures__/running-services.js'
+import { runningServicesFixture } from '../../../../__fixtures__/running-services/running-services.js'
 import { entityServicesFixture } from '../../../../__fixtures__/services/entities.js'
 
 describe('transformRunningServices', () => {
@@ -51,8 +51,8 @@ describe('transformRunningServices', () => {
             unstable: false,
             updated: '2024-05-10T14:49:42Z',
             user: {
-              name: 'RoboCop',
-              userId: '1398fa86-98a2-4ee8-84bb-2468cc71d0ec'
+              displayName: 'RoboCop',
+              id: '01b99595-27b5-4ab0-9807-f104c09d2cd0'
             },
             version: '0.356.0'
           }
@@ -99,8 +99,8 @@ describe('transformRunningServices', () => {
             unstable: false,
             updated: '2024-04-25T10:27:58Z',
             user: {
-              name: 'The Terminator',
-              userId: '0ddadf17-beaf-4aef-a415-ca044dbdd18d'
+              displayName: 'The Terminator',
+              id: '0ddadf17-beaf-4aef-a415-ca044dbdd18d'
             },
             version: '0.188.0'
           }
@@ -142,8 +142,8 @@ describe('transformRunningServices', () => {
             unstable: false,
             updated: '2024-05-10T14:54:15Z',
             user: {
-              name: 'RoboCop',
-              userId: '1398fa86-98a2-4ee8-84bb-2468cc71d0ec'
+              displayName: 'RoboCop',
+              id: '01b99595-27b5-4ab0-9807-f104c09d2cd0'
             },
             version: '0.149.0'
           }

--- a/src/server/services/helpers/add-service-owner-scope.test.js
+++ b/src/server/services/helpers/add-service-owner-scope.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { addServiceOwnerScope } from './add-service-owner-scope.js'
 import { userIsOwnerDecorator } from '../../common/helpers/user/user-is-owner.js'
 

--- a/src/server/services/helpers/provide-service-tabs.test.js
+++ b/src/server/services/helpers/provide-service-tabs.test.js
@@ -1,4 +1,3 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { hasScopeDecorator } from '../../common/helpers/decorators/has-scope.js'
 import { provideServiceTabs } from './provide-service-tabs.js'
 

--- a/src/server/services/helpers/schema/service-params-validation.test.js
+++ b/src/server/services/helpers/schema/service-params-validation.test.js
@@ -1,5 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
-
 import { serviceParamsValidation } from './service-params-validation.js'
 
 describe('#serviceParamsValidation', () => {

--- a/src/server/services/list/helpers/build-services-table-data.test.js
+++ b/src/server/services/list/helpers/build-services-table-data.test.js
@@ -1,4 +1,3 @@
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import nock from 'nock'
 
 import { config } from '../../../../config/config.js'

--- a/src/server/services/list/transformers/entity-to-entity-row.test.js
+++ b/src/server/services/list/transformers/entity-to-entity-row.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { entityToEntityRow } from './entity-to-entity-row.js'
 import { entityServicesFixture } from '../../../../__fixtures__/services/entities.js'
 

--- a/src/server/services/service/about/__file_snapshots__/Services-About-postgres-service-page-logged-in-admin-user-restrictedTechPostgres-permission-1.html
+++ b/src/server/services/service/about/__file_snapshots__/Services-About-postgres-service-page-logged-in-admin-user-restrictedTechPostgres-permission-1.html
@@ -301,7 +301,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -317,7 +318,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -333,7 +335,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -349,7 +352,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -365,7 +369,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -381,7 +386,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -397,7 +403,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>

--- a/src/server/services/service/about/__file_snapshots__/Services-About-postgres-service-page-logged-in-tenant-user-1.html
+++ b/src/server/services/service/about/__file_snapshots__/Services-About-postgres-service-page-logged-in-tenant-user-1.html
@@ -275,7 +275,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -291,7 +292,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -307,7 +309,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>

--- a/src/server/services/service/about/__file_snapshots__/Services-About-postgres-service-page-logged-in-tenant-user-restrictedTechPostgres-permission-1.html
+++ b/src/server/services/service/about/__file_snapshots__/Services-About-postgres-service-page-logged-in-tenant-user-restrictedTechPostgres-permission-1.html
@@ -287,7 +287,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -303,7 +304,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -319,7 +321,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>

--- a/src/server/services/service/about/__file_snapshots__/Services-About-prototype-service-page-logged-in-admin-user-restrictedTechPostgres-permission-1.html
+++ b/src/server/services/service/about/__file_snapshots__/Services-About-prototype-service-page-logged-in-admin-user-restrictedTechPostgres-permission-1.html
@@ -289,7 +289,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -305,7 +306,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -321,7 +323,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -337,7 +340,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -353,7 +357,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -369,7 +374,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -385,7 +391,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>

--- a/src/server/services/service/about/__file_snapshots__/Services-About-prototype-service-page-logged-in-tenant-user-1.html
+++ b/src/server/services/service/about/__file_snapshots__/Services-About-prototype-service-page-logged-in-tenant-user-1.html
@@ -275,7 +275,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -291,7 +292,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -307,7 +309,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>

--- a/src/server/services/service/about/__file_snapshots__/Services-About-prototype-service-page-logged-in-tenant-user-restrictedTechPostgres-permission-1.html
+++ b/src/server/services/service/about/__file_snapshots__/Services-About-prototype-service-page-logged-in-tenant-user-restrictedTechPostgres-permission-1.html
@@ -275,7 +275,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -291,7 +292,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -307,7 +309,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>

--- a/src/server/services/service/about/__file_snapshots__/Services-About-service-page-logged-in-admin-user-1.html
+++ b/src/server/services/service/about/__file_snapshots__/Services-About-service-page-logged-in-admin-user-1.html
@@ -289,7 +289,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -305,7 +306,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -321,7 +323,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -337,7 +340,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -353,7 +357,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -369,7 +374,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -385,7 +391,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>

--- a/src/server/services/service/about/__file_snapshots__/Services-About-service-page-logged-in-tenant-user-1.html
+++ b/src/server/services/service/about/__file_snapshots__/Services-About-service-page-logged-in-tenant-user-1.html
@@ -275,7 +275,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -291,7 +292,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -307,7 +309,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>

--- a/src/server/services/service/about/__file_snapshots__/Services-About-service-page-logged-in-tenant-user-service-owner-1.html
+++ b/src/server/services/service/about/__file_snapshots__/Services-About-service-page-logged-in-tenant-user-service-owner-1.html
@@ -278,7 +278,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -294,7 +295,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -310,7 +312,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -326,7 +329,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -342,7 +346,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -358,7 +363,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -374,7 +380,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>

--- a/src/server/services/service/about/about.test.js
+++ b/src/server/services/service/about/about.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 import {
   initialiseServer,
   mockAuthAndRenderUrl,

--- a/src/server/services/service/about/transformers/api-gateways.test.js
+++ b/src/server/services/service/about/transformers/api-gateways.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
 import nock from 'nock'
 
 import { config } from '../../../../../config/config.js'

--- a/src/server/services/service/about/transformers/service-to-summary.test.js
+++ b/src/server/services/service/about/transformers/service-to-summary.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 import { repositoryFixture } from '../../../../../__fixtures__/repository.js'
 import { transformServiceToSummary } from './service-to-summary.js'
 import { entityServicesFixture } from '../../../../../__fixtures__/services/entities.js'

--- a/src/server/services/service/about/transformers/vanity-urls.test.js
+++ b/src/server/services/service/about/transformers/vanity-urls.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
 import nock from 'nock'
 
 import { config } from '../../../../../config/config.js'

--- a/src/server/services/service/automations/__file_snapshots__/Service-Automations-page-deployments-view-page-renders-for-logged-in-admin-user-1.html
+++ b/src/server/services/service/automations/__file_snapshots__/Service-Automations-page-deployments-view-page-renders-for-logged-in-admin-user-1.html
@@ -297,7 +297,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -313,7 +314,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -329,7 +331,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -345,7 +348,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -361,7 +365,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -377,7 +382,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -393,7 +399,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>
@@ -407,7 +414,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
           <section class="govuk-!-margin-top-6">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -430,7 +438,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
             <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third-from-desktop">

--- a/src/server/services/service/automations/__file_snapshots__/Service-Automations-page-deployments-view-page-renders-for-logged-in-service-owner-tenant-1.html
+++ b/src/server/services/service/automations/__file_snapshots__/Service-Automations-page-deployments-view-page-renders-for-logged-in-service-owner-tenant-1.html
@@ -286,7 +286,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -302,7 +303,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -318,7 +320,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -334,7 +337,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -350,7 +354,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -366,7 +371,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -382,7 +388,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>
@@ -396,7 +403,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
           <section class="govuk-!-margin-top-6">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -419,7 +427,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
             <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third-from-desktop">

--- a/src/server/services/service/automations/__file_snapshots__/Service-Automations-page-test-runs-view-page-renders-for-logged-in-admin-user-1.html
+++ b/src/server/services/service/automations/__file_snapshots__/Service-Automations-page-test-runs-view-page-renders-for-logged-in-admin-user-1.html
@@ -297,7 +297,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -313,7 +314,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -329,7 +331,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -345,7 +348,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -361,7 +365,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -377,7 +382,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -393,7 +399,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>
@@ -407,7 +414,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
           <section class="govuk-!-margin-top-6">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -430,7 +438,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
             <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop-huge">

--- a/src/server/services/service/automations/__file_snapshots__/Service-Automations-page-test-runs-view-page-renders-for-logged-in-service-owner-tenant-1.html
+++ b/src/server/services/service/automations/__file_snapshots__/Service-Automations-page-test-runs-view-page-renders-for-logged-in-service-owner-tenant-1.html
@@ -286,7 +286,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -302,7 +303,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -318,7 +320,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -334,7 +337,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -350,7 +354,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -366,7 +371,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -382,7 +388,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>
@@ -396,7 +403,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
           <section class="govuk-!-margin-top-6">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -419,7 +427,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
             <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop-huge">

--- a/src/server/services/service/automations/automations.test.js
+++ b/src/server/services/service/automations/automations.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 import {
   initialiseServer,
   mockAuthAndRenderUrl,

--- a/src/server/services/service/automations/views/__file_snapshots__/Service-automation-tab-Never-deployed-1.html
+++ b/src/server/services/service/automations/views/__file_snapshots__/Service-automation-tab-Never-deployed-1.html
@@ -134,37 +134,39 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
         <li class="app-tabs__list-item app-tabs__list-item--selected"
-            data-testid="app-tabs-list-item- app-tabs-list-item--selected">
+            data-testid="app-tabs-list-item-automation app-tabs-list-item--selected">
 
 
-          <a id="tab-"
+          <a id="tab-automation"
              class="app-tabs__tab"
              href="services/cdp-portal-backend/automation"
              data-js="app-tab"
              role="tab"
-             aria-controls="tab-panel-"
-             aria-selected="true">
-            
+             aria-controls="tab-panel-automation"
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-automation">
+            Automation
           </a>
         </li>
     </ul>
 
-      <section id="tab-panel-"
+      <section id="tab-panel-automation"
                class="app-tabs__panel"
                role="tabpanel"
-               aria-labelledby="tab-"
+               aria-labelledby="tab-automation"
                data-testid="app-tabs-panel">
           <section class="govuk-!-margin-top-6">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
             <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third-from-desktop">

--- a/src/server/services/service/automations/views/__file_snapshots__/Service-automation-tab-Previously-deployed-1.html
+++ b/src/server/services/service/automations/views/__file_snapshots__/Service-automation-tab-Previously-deployed-1.html
@@ -134,37 +134,39 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
         <li class="app-tabs__list-item app-tabs__list-item--selected"
-            data-testid="app-tabs-list-item- app-tabs-list-item--selected">
+            data-testid="app-tabs-list-item-automation app-tabs-list-item--selected">
 
 
-          <a id="tab-"
+          <a id="tab-automation"
              class="app-tabs__tab"
              href="services/cdp-portal-backend/automation"
              data-js="app-tab"
              role="tab"
-             aria-controls="tab-panel-"
-             aria-selected="true">
-            
+             aria-controls="tab-panel-automation"
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-automation">
+            Automation
           </a>
         </li>
     </ul>
 
-      <section id="tab-panel-"
+      <section id="tab-panel-automation"
                class="app-tabs__panel"
                role="tabpanel"
-               aria-labelledby="tab-"
+               aria-labelledby="tab-automation"
                data-testid="app-tabs-panel">
           <section class="govuk-!-margin-top-6">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
             <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third-from-desktop">

--- a/src/server/services/service/automations/views/__file_snapshots__/Service-automation-tab-With-auto-deploy-turned-on-1.html
+++ b/src/server/services/service/automations/views/__file_snapshots__/Service-automation-tab-With-auto-deploy-turned-on-1.html
@@ -134,37 +134,39 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
         <li class="app-tabs__list-item app-tabs__list-item--selected"
-            data-testid="app-tabs-list-item- app-tabs-list-item--selected">
+            data-testid="app-tabs-list-item-automation app-tabs-list-item--selected">
 
 
-          <a id="tab-"
+          <a id="tab-automation"
              class="app-tabs__tab"
              href="services/cdp-portal-backend/automation"
              data-js="app-tab"
              role="tab"
-             aria-controls="tab-panel-"
-             aria-selected="true">
-            
+             aria-controls="tab-panel-automation"
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-automation">
+            Automation
           </a>
         </li>
     </ul>
 
-      <section id="tab-panel-"
+      <section id="tab-panel-automation"
                class="app-tabs__panel"
                role="tabpanel"
-               aria-labelledby="tab-"
+               aria-labelledby="tab-automation"
                data-testid="app-tabs-panel">
           <section class="govuk-!-margin-top-6">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
             <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third-from-desktop">

--- a/src/server/services/service/automations/views/auto-deployments.test.js
+++ b/src/server/services/service/automations/views/auto-deployments.test.js
@@ -15,7 +15,8 @@ function buildServiceAutomationContext({
       tabs: [
         {
           isActive: true,
-          url: `services/${serviceId}/automation`
+          url: `services/${serviceId}/automation`,
+          label: 'Automation'
         }
       ]
     },

--- a/src/server/services/service/automations/views/auto-deployments.test.js
+++ b/src/server/services/service/automations/views/auto-deployments.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 import { renderPage } from '../../../../../../test-helpers/component-helpers.js'
 import { buildOptions } from '../../../../common/helpers/options/build-options.js'
 import { entityServicesFixture } from '../../../../../__fixtures__/services/entities.js'

--- a/src/server/services/service/buckets/__file_snapshots__/Service-Buckets-page-all-envs-view-page-renders-for-logged-in-admin-user-1.html
+++ b/src/server/services/service/buckets/__file_snapshots__/Service-Buckets-page-all-envs-view-page-renders-for-logged-in-admin-user-1.html
@@ -293,7 +293,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -309,7 +310,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -325,7 +327,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -341,7 +344,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -357,7 +361,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -373,7 +378,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -389,7 +395,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>
@@ -406,7 +413,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -469,7 +477,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
                 <section>
             <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Buckets</h2>

--- a/src/server/services/service/buckets/__file_snapshots__/Service-Buckets-page-all-envs-view-page-renders-for-logged-in-service-owner-tenant-1.html
+++ b/src/server/services/service/buckets/__file_snapshots__/Service-Buckets-page-all-envs-view-page-renders-for-logged-in-service-owner-tenant-1.html
@@ -282,7 +282,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -298,7 +299,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -314,7 +316,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -330,7 +333,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -346,7 +350,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -362,7 +367,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -378,7 +384,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>
@@ -395,7 +402,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -442,7 +450,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
                 <section>
             <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Buckets</h2>

--- a/src/server/services/service/buckets/__file_snapshots__/Service-Buckets-page-all-envs-view-page-renders-for-logged-in-tenant-who-doesnt-own-service-1.html
+++ b/src/server/services/service/buckets/__file_snapshots__/Service-Buckets-page-all-envs-view-page-renders-for-logged-in-tenant-who-doesnt-own-service-1.html
@@ -279,7 +279,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -295,7 +296,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -311,7 +313,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -328,7 +331,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -375,7 +379,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
                 <section>
             <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Buckets</h2>

--- a/src/server/services/service/buckets/__file_snapshots__/Service-Buckets-page-single-envs-view-page-renders-for-logged-in-admin-user-1.html
+++ b/src/server/services/service/buckets/__file_snapshots__/Service-Buckets-page-single-envs-view-page-renders-for-logged-in-admin-user-1.html
@@ -297,7 +297,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -313,7 +314,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -329,7 +331,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -345,7 +348,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -361,7 +365,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -377,7 +382,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -393,7 +399,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>
@@ -407,7 +414,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
           <section class="govuk-!-margin-top-6">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -470,7 +478,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
             <div class="govuk-grid-row">
         <section class="govuk-grid-column-two-thirds-from-desktop-big">

--- a/src/server/services/service/buckets/__file_snapshots__/Service-Buckets-page-single-envs-view-page-renders-for-logged-in-service-owner-tenant-1.html
+++ b/src/server/services/service/buckets/__file_snapshots__/Service-Buckets-page-single-envs-view-page-renders-for-logged-in-service-owner-tenant-1.html
@@ -286,7 +286,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -302,7 +303,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -318,7 +320,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -334,7 +337,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -350,7 +354,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -366,7 +371,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -382,7 +388,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>
@@ -396,7 +403,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
           <section class="govuk-!-margin-top-6">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -443,7 +451,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
             <div class="govuk-grid-row">
         <section class="govuk-grid-column-two-thirds-from-desktop-big">

--- a/src/server/services/service/buckets/__file_snapshots__/Service-Buckets-page-single-envs-view-page-renders-for-logged-in-tenant-who-doesnt-own-service-1.html
+++ b/src/server/services/service/buckets/__file_snapshots__/Service-Buckets-page-single-envs-view-page-renders-for-logged-in-tenant-who-doesnt-own-service-1.html
@@ -283,7 +283,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -299,7 +300,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -315,7 +317,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -329,7 +332,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
           <section class="govuk-!-margin-top-6">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -376,7 +380,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
             <div class="govuk-grid-row">
         <section class="govuk-grid-column-two-thirds-from-desktop-big">

--- a/src/server/services/service/buckets/buckets.test.js
+++ b/src/server/services/service/buckets/buckets.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 import {
   initialiseServer,
   mockAuthAndRenderUrl,

--- a/src/server/services/service/buckets/transformers/all-environment-buckets.test.js
+++ b/src/server/services/service/buckets/transformers/all-environment-buckets.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { allEnvironmentBuckets } from './all-environment-buckets.js'
 import { allEnvironmentBucketsFixture } from '../../../../../__fixtures__/buckets/all-environment-buckets.js'
 import { getEnvironments } from '../../../../common/helpers/environments/get-environments.js'

--- a/src/server/services/service/buckets/transformers/environment-buckets.test.js
+++ b/src/server/services/service/buckets/transformers/environment-buckets.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { environmentBuckets } from './environment-buckets.js'
 import { bucketsWithPendingFixture } from '../../../../../__fixtures__/buckets/buckets.js'
 

--- a/src/server/services/service/maintenance/__file_snapshots__/Services-Maintenance-service-page-logged-in-admin-user-1.html
+++ b/src/server/services/service/maintenance/__file_snapshots__/Services-Maintenance-service-page-logged-in-admin-user-1.html
@@ -293,7 +293,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -309,7 +310,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -325,7 +327,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -341,7 +344,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -357,7 +361,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -373,7 +378,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -389,7 +395,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>

--- a/src/server/services/service/maintenance/__file_snapshots__/Services-Maintenance-service-page-logged-in-tenant-user-service-owner-with-scope-1.html
+++ b/src/server/services/service/maintenance/__file_snapshots__/Services-Maintenance-service-page-logged-in-tenant-user-service-owner-with-scope-1.html
@@ -282,7 +282,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -298,7 +299,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -314,7 +316,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -330,7 +333,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -346,7 +350,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -362,7 +367,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -378,7 +384,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>

--- a/src/server/services/service/maintenance/helpers/transformers/entity-to-summary.test.js
+++ b/src/server/services/service/maintenance/helpers/transformers/entity-to-summary.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { noValue } from '../../../../../common/constants/no-value.js'
 import { entityToSummary } from './entity-to-summary.js'
 

--- a/src/server/services/service/maintenance/helpers/transformers/shuttering-detail-to-summary.test.js
+++ b/src/server/services/service/maintenance/helpers/transformers/shuttering-detail-to-summary.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { noValue } from '../../../../../common/constants/no-value.js'
 import { shutteringDetailToSummary } from './shuttering-detail-to-summary.js'
 import { shutteringStatus } from '../../../../../common/constants/shuttering.js'

--- a/src/server/services/service/maintenance/maintenance.test.js
+++ b/src/server/services/service/maintenance/maintenance.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 import {
   initialiseServer,
   mockAuthAndRenderUrl,

--- a/src/server/services/service/proxy/__file_snapshots__/Service-Proxy-page-all-envs-view-page-renders-for-logged-in-admin-user-1.html
+++ b/src/server/services/service/proxy/__file_snapshots__/Service-Proxy-page-all-envs-view-page-renders-for-logged-in-admin-user-1.html
@@ -293,7 +293,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -309,7 +310,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -325,7 +327,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -341,7 +344,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -357,7 +361,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -373,7 +378,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -389,7 +395,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>
@@ -406,7 +413,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -469,7 +477,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
                 <section>
             <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Proxy</h2>

--- a/src/server/services/service/proxy/__file_snapshots__/Service-Proxy-page-all-envs-view-page-renders-for-logged-in-service-owner-tenant-1.html
+++ b/src/server/services/service/proxy/__file_snapshots__/Service-Proxy-page-all-envs-view-page-renders-for-logged-in-service-owner-tenant-1.html
@@ -282,7 +282,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -298,7 +299,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -314,7 +316,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -330,7 +333,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -346,7 +350,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -362,7 +367,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -378,7 +384,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>
@@ -395,7 +402,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -442,7 +450,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
                 <section>
             <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Proxy</h2>

--- a/src/server/services/service/proxy/__file_snapshots__/Service-Proxy-page-all-envs-view-page-renders-for-logged-in-tenant-1.html
+++ b/src/server/services/service/proxy/__file_snapshots__/Service-Proxy-page-all-envs-view-page-renders-for-logged-in-tenant-1.html
@@ -279,7 +279,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -295,7 +296,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -311,7 +313,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -328,7 +331,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -375,7 +379,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
                 <section>
             <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Proxy</h2>

--- a/src/server/services/service/proxy/__file_snapshots__/Service-Proxy-page-single-envs-view-page-renders-for-logged-in-admin-user-1.html
+++ b/src/server/services/service/proxy/__file_snapshots__/Service-Proxy-page-single-envs-view-page-renders-for-logged-in-admin-user-1.html
@@ -297,7 +297,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -313,7 +314,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -329,7 +331,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -345,7 +348,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -361,7 +365,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -377,7 +382,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -393,7 +399,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>
@@ -407,7 +414,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
           <section class="govuk-!-margin-top-6">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -470,7 +478,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
             <div class="govuk-grid-row">
         <section class="govuk-grid-column-two-thirds-from-desktop-big">

--- a/src/server/services/service/proxy/__file_snapshots__/Service-Proxy-page-single-envs-view-page-renders-for-logged-in-service-owner-tenant-1.html
+++ b/src/server/services/service/proxy/__file_snapshots__/Service-Proxy-page-single-envs-view-page-renders-for-logged-in-service-owner-tenant-1.html
@@ -286,7 +286,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -302,7 +303,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -318,7 +320,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -334,7 +337,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -350,7 +354,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -366,7 +371,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -382,7 +388,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>
@@ -396,7 +403,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
           <section class="govuk-!-margin-top-6">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -443,7 +451,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
             <div class="govuk-grid-row">
         <section class="govuk-grid-column-two-thirds-from-desktop-big">

--- a/src/server/services/service/proxy/__file_snapshots__/Service-Proxy-page-single-envs-view-page-renders-for-logged-in-tenant-1.html
+++ b/src/server/services/service/proxy/__file_snapshots__/Service-Proxy-page-single-envs-view-page-renders-for-logged-in-tenant-1.html
@@ -283,7 +283,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -299,7 +300,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -315,7 +317,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -329,7 +332,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
           <section class="govuk-!-margin-top-6">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -376,7 +380,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
             <div class="govuk-grid-row">
         <section class="govuk-grid-column-two-thirds-from-desktop-big">

--- a/src/server/services/service/proxy/proxy.test.js
+++ b/src/server/services/service/proxy/proxy.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 import { fetchProxyRules } from '../../helpers/fetch/fetch-proxy-rules.js'
 import {
   initialiseServer,

--- a/src/server/services/service/secrets/__file_snapshots__/Service-Secrets-page-all-envs-view-page-renders-for-logged-in-admin-user-1.html
+++ b/src/server/services/service/secrets/__file_snapshots__/Service-Secrets-page-all-envs-view-page-renders-for-logged-in-admin-user-1.html
@@ -293,7 +293,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -309,7 +310,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -325,7 +327,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -341,7 +344,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -357,7 +361,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -373,7 +378,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -389,7 +395,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>
@@ -406,7 +413,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -469,7 +477,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
                 <section>
             <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Secrets</h2>

--- a/src/server/services/service/secrets/__file_snapshots__/Service-Secrets-page-all-envs-view-page-renders-for-logged-in-service-owner-tenant-1.html
+++ b/src/server/services/service/secrets/__file_snapshots__/Service-Secrets-page-all-envs-view-page-renders-for-logged-in-service-owner-tenant-1.html
@@ -282,7 +282,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -298,7 +299,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -314,7 +316,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -330,7 +333,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -346,7 +350,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -362,7 +367,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -378,7 +384,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>
@@ -395,7 +402,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -442,7 +450,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
                 <section>
             <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Secrets</h2>

--- a/src/server/services/service/secrets/__file_snapshots__/Service-Secrets-page-single-envs-view-page-renders-for-logged-in-admin-user-1.html
+++ b/src/server/services/service/secrets/__file_snapshots__/Service-Secrets-page-single-envs-view-page-renders-for-logged-in-admin-user-1.html
@@ -297,7 +297,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -313,7 +314,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -329,7 +331,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -345,7 +348,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -361,7 +365,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -377,7 +382,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -393,7 +399,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>
@@ -407,7 +414,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
           <section class="govuk-!-margin-top-6">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -470,7 +478,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
             <div class="govuk-grid-row">
         <section class="govuk-grid-column-two-thirds-from-desktop-big">

--- a/src/server/services/service/secrets/__file_snapshots__/Service-Secrets-page-single-envs-view-page-renders-for-logged-in-service-owner-tenant-1.html
+++ b/src/server/services/service/secrets/__file_snapshots__/Service-Secrets-page-single-envs-view-page-renders-for-logged-in-service-owner-tenant-1.html
@@ -286,7 +286,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -302,7 +303,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -318,7 +320,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -334,7 +337,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -350,7 +354,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -366,7 +371,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -382,7 +388,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>
@@ -396,7 +403,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
           <section class="govuk-!-margin-top-6">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -443,7 +451,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
             <div class="govuk-grid-row">
         <section class="govuk-grid-column-two-thirds-from-desktop-big">

--- a/src/server/services/service/secrets/routes.js
+++ b/src/server/services/service/secrets/routes.js
@@ -24,7 +24,6 @@ const serviceSecrets = {
             sandbox: 'plugin'
           }
         },
-        // TODO can these postHandlers be combined?
         {
           type: 'onPostHandler',
           method: provideServiceTabs,

--- a/src/server/services/service/secrets/secrets.test.js
+++ b/src/server/services/service/secrets/secrets.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 import {
   initialiseServer,
   mockAuthAndRenderUrl,

--- a/src/server/services/service/status/status.test.js
+++ b/src/server/services/service/status/status.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 import {
   initialiseServer,
   mockAuthAndRenderUrl,

--- a/src/server/services/service/terminal/__file_snapshots__/Service-Terminal-page-page-renders-for-logged-in-admin-user-1.html
+++ b/src/server/services/service/terminal/__file_snapshots__/Service-Terminal-page-page-renders-for-logged-in-admin-user-1.html
@@ -293,7 +293,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -309,7 +310,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -325,7 +327,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -341,7 +344,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -357,7 +361,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -373,7 +378,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -389,7 +395,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>

--- a/src/server/services/service/terminal/__file_snapshots__/Service-Terminal-page-page-renders-for-logged-in-service-owner-tenant-1.html
+++ b/src/server/services/service/terminal/__file_snapshots__/Service-Terminal-page-page-renders-for-logged-in-service-owner-tenant-1.html
@@ -282,7 +282,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -298,7 +299,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-automations"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-automations">
             Automations
           </a>
         </li>
@@ -314,7 +316,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-buckets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-buckets">
             Buckets
           </a>
         </li>
@@ -330,7 +333,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-maintenance"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
             Maintenance
           </a>
         </li>
@@ -346,7 +350,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -362,7 +367,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -378,7 +384,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-terminal"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-terminal">
             Terminal
           </a>
         </li>

--- a/src/server/services/service/terminal/helpers/can-launch-terminal.test.js
+++ b/src/server/services/service/terminal/helpers/can-launch-terminal.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { canLaunchTerminal } from './can-launch-terminal.js'
 import { scopes } from '../../../../common/constants/scopes.js'
 

--- a/src/server/services/service/terminal/helpers/schema/launch-terminal-params-validation.test.js
+++ b/src/server/services/service/terminal/helpers/schema/launch-terminal-params-validation.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { launchTerminalParamsValidation } from './launch-terminal-params-validation.js'
 import { scopes } from '../../../../../common/constants/scopes.js'
 

--- a/src/server/services/service/terminal/helpers/schema/terminal-browser-params-validation.test.js
+++ b/src/server/services/service/terminal/helpers/schema/terminal-browser-params-validation.test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, test } from 'vitest'
 import { terminalBrowserParamsValidation } from './terminal-browser-params-validation.js'
 import { scopes } from '../../../../../common/constants/scopes.js'
 

--- a/src/server/services/service/terminal/terminal.test.js
+++ b/src/server/services/service/terminal/terminal.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 import {
   initialiseServer,
   mockAuthAndRenderUrl,

--- a/src/server/teams/transformers/team-to-entity-row.test.js
+++ b/src/server/teams/transformers/team-to-entity-row.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { teamToEntityRow } from './team-to-entity-row.js'
 import { cdpTeamFixture } from '../../../__fixtures__/admin/cdp-team.js'
 import { cdpTeamWithoutGithubFixture } from '../../../__fixtures__/admin/cdp-team-without-github.js'

--- a/src/server/test-suites/helpers/build-logs-link.test.js
+++ b/src/server/test-suites/helpers/build-logs-link.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 import { buildLogsLink } from './build-logs-link.js'
 
 describe('#buildLogsLink', () => {

--- a/src/server/test-suites/helpers/pre/provide-form-values.test.js
+++ b/src/server/test-suites/helpers/pre/provide-form-values.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test, vi } from 'vitest'
 import { provideFormValues } from './provide-form-values.js'
 
 describe('#provideFormValues', () => {

--- a/src/server/test-suites/helpers/provide-test-run-status-classname.test.js
+++ b/src/server/test-suites/helpers/provide-test-run-status-classname.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { provideTestRunStatusClassname } from './provide-test-run-status-classname.js'
 
 describe('#provideTestRunStatusClassname', () => {

--- a/src/server/test-suites/helpers/provide-test-suite-tabs.test.js
+++ b/src/server/test-suites/helpers/provide-test-suite-tabs.test.js
@@ -1,4 +1,3 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { provideTestSuiteTabs } from './provide-test-suite-tabs.js'
 
 const mockRouteLookup = vi.fn()

--- a/src/server/test-suites/helpers/should-poll.test.js
+++ b/src/server/test-suites/helpers/should-poll.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { shouldPoll } from './should-poll.js'
 import { taskStatus } from '../constants/test-run-status.js'
 

--- a/src/server/test-suites/list/controller.test.js
+++ b/src/server/test-suites/list/controller.test.js
@@ -1,4 +1,3 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { fetchTestSuites } from '../../common/helpers/fetch/fetch-entities.js'
 import { testSuiteListController } from './controller.js'
 import { entityOwnerDecorator } from '../helpers/decorators/entity-owner-decorator.js'

--- a/src/server/test-suites/test-suite/about/__file_snapshots__/About-Test-Suite-page-page-renders-for-logged-in-admin-user-1.html
+++ b/src/server/test-suites/test-suite/about/__file_snapshots__/About-Test-Suite-page-page-renders-for-logged-in-admin-user-1.html
@@ -260,7 +260,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -276,7 +277,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -292,7 +294,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>

--- a/src/server/test-suites/test-suite/about/__file_snapshots__/About-Test-Suite-page-page-renders-for-logged-in-service-owner-tenant-1.html
+++ b/src/server/test-suites/test-suite/about/__file_snapshots__/About-Test-Suite-page-page-renders-for-logged-in-service-owner-tenant-1.html
@@ -246,7 +246,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -262,7 +263,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -278,7 +280,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>

--- a/src/server/test-suites/test-suite/about/__file_snapshots__/About-Test-Suite-page-page-renders-for-logged-in-tenant-1.html
+++ b/src/server/test-suites/test-suite/about/__file_snapshots__/About-Test-Suite-page-page-renders-for-logged-in-tenant-1.html
@@ -246,7 +246,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -262,7 +263,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>

--- a/src/server/test-suites/test-suite/about/about.test.js
+++ b/src/server/test-suites/test-suite/about/about.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 import {
   initialiseServer,
   mockAuthAndRenderUrl,

--- a/src/server/test-suites/test-suite/proxy/__file_snapshots__/Proxy-Test-Suite-page-all-envs-view-page-renders-for-logged-in-admin-user-1.html
+++ b/src/server/test-suites/test-suite/proxy/__file_snapshots__/Proxy-Test-Suite-page-all-envs-view-page-renders-for-logged-in-admin-user-1.html
@@ -264,7 +264,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -280,7 +281,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -296,7 +298,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -313,7 +316,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -376,7 +380,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
                 <section>
             <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Proxy</h2>

--- a/src/server/test-suites/test-suite/proxy/__file_snapshots__/Proxy-Test-Suite-page-all-envs-view-page-renders-for-logged-in-service-owner-tenant-1.html
+++ b/src/server/test-suites/test-suite/proxy/__file_snapshots__/Proxy-Test-Suite-page-all-envs-view-page-renders-for-logged-in-service-owner-tenant-1.html
@@ -250,7 +250,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -266,7 +267,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -282,7 +284,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -299,7 +302,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -346,7 +350,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
                 <section>
             <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Proxy</h2>

--- a/src/server/test-suites/test-suite/proxy/__file_snapshots__/Proxy-Test-Suite-page-all-envs-view-page-renders-for-logged-in-tenant-1.html
+++ b/src/server/test-suites/test-suite/proxy/__file_snapshots__/Proxy-Test-Suite-page-all-envs-view-page-renders-for-logged-in-tenant-1.html
@@ -250,7 +250,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -266,7 +267,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -283,7 +285,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -330,7 +333,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
                 <section>
             <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Proxy</h2>

--- a/src/server/test-suites/test-suite/proxy/__file_snapshots__/Proxy-Test-Suite-page-single-envs-view-page-renders-for-logged-in-admin-user-1.html
+++ b/src/server/test-suites/test-suite/proxy/__file_snapshots__/Proxy-Test-Suite-page-single-envs-view-page-renders-for-logged-in-admin-user-1.html
@@ -268,7 +268,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -284,7 +285,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -300,7 +302,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -314,7 +317,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
           <section class="govuk-!-margin-top-6">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -377,7 +381,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
             <div class="govuk-grid-row">
         <section class="govuk-grid-column-two-thirds-from-desktop-big">

--- a/src/server/test-suites/test-suite/proxy/__file_snapshots__/Proxy-Test-Suite-page-single-envs-view-page-renders-for-logged-in-service-owner-tenant-1.html
+++ b/src/server/test-suites/test-suite/proxy/__file_snapshots__/Proxy-Test-Suite-page-single-envs-view-page-renders-for-logged-in-service-owner-tenant-1.html
@@ -254,7 +254,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -270,7 +271,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -286,7 +288,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -300,7 +303,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
           <section class="govuk-!-margin-top-6">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -347,7 +351,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
             <div class="govuk-grid-row">
         <section class="govuk-grid-column-two-thirds-from-desktop-big">

--- a/src/server/test-suites/test-suite/proxy/__file_snapshots__/Proxy-Test-Suite-page-single-envs-view-page-renders-for-logged-in-tenant-1.html
+++ b/src/server/test-suites/test-suite/proxy/__file_snapshots__/Proxy-Test-Suite-page-single-envs-view-page-renders-for-logged-in-tenant-1.html
@@ -254,7 +254,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -270,7 +271,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -284,7 +286,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
           <section class="govuk-!-margin-top-6">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -331,7 +334,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
             <div class="govuk-grid-row">
         <section class="govuk-grid-column-two-thirds-from-desktop-big">

--- a/src/server/test-suites/test-suite/proxy/proxy.test.js
+++ b/src/server/test-suites/test-suite/proxy/proxy.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 import { fetchProxyRules } from '../../../services/helpers/fetch/fetch-proxy-rules.js'
 import {
   initialiseServer,

--- a/src/server/test-suites/test-suite/secrets/__file_snapshots__/Secrets-Test-Suite-page-all-envs-view-page-renders-for-logged-in-admin-user-1.html
+++ b/src/server/test-suites/test-suite/secrets/__file_snapshots__/Secrets-Test-Suite-page-all-envs-view-page-renders-for-logged-in-admin-user-1.html
@@ -264,7 +264,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -280,7 +281,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -296,7 +298,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -313,7 +316,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -376,7 +380,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
                 <section>
             <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Secrets</h2>

--- a/src/server/test-suites/test-suite/secrets/__file_snapshots__/Secrets-Test-Suite-page-all-envs-view-page-renders-for-logged-in-service-owner-tenant-1.html
+++ b/src/server/test-suites/test-suite/secrets/__file_snapshots__/Secrets-Test-Suite-page-all-envs-view-page-renders-for-logged-in-service-owner-tenant-1.html
@@ -250,7 +250,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -266,7 +267,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -282,7 +284,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -299,7 +302,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -346,7 +350,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
                 <section>
             <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Secrets</h2>

--- a/src/server/test-suites/test-suite/secrets/__file_snapshots__/Secrets-Test-Suite-page-single-envs-view-page-renders-for-logged-in-admin-user-1.html
+++ b/src/server/test-suites/test-suite/secrets/__file_snapshots__/Secrets-Test-Suite-page-single-envs-view-page-renders-for-logged-in-admin-user-1.html
@@ -268,7 +268,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -284,7 +285,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -300,7 +302,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -314,7 +317,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
           <section class="govuk-!-margin-top-6">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -377,7 +381,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
             <div class="govuk-grid-row">
         <section class="govuk-grid-column-two-thirds-from-desktop-big">

--- a/src/server/test-suites/test-suite/secrets/__file_snapshots__/Secrets-Test-Suite-page-single-envs-view-page-renders-for-logged-in-service-owner-tenant-1.html
+++ b/src/server/test-suites/test-suite/secrets/__file_snapshots__/Secrets-Test-Suite-page-single-envs-view-page-renders-for-logged-in-service-owner-tenant-1.html
@@ -254,7 +254,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-about"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
             About
           </a>
         </li>
@@ -270,7 +271,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-proxy"
-             aria-selected="false">
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
             Proxy
           </a>
         </li>
@@ -286,7 +288,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
              data-js="app-tab"
              role="tab"
              aria-controls="tab-panel-secrets"
-             aria-selected="true">
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-secrets">
             Secrets
           </a>
         </li>
@@ -300,7 +303,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
           <section class="govuk-!-margin-top-6">
 
 <div class="app-split-pane" data-testid="app-split-pane">
-  <div class="app-split-pane__nav">
+  <div class="app-split-pane__nav"
+       data-testid="app-split-pane-nav">
 <nav class="app-subnav" aria-labelledby="app-subnav-heading" data-testid="app-subnav">
   <h2 class="govuk-visually-hidden" id="app-subnav-heading">Pages in this section</h2>
   <ul class="app-subnav__section">
@@ -347,7 +351,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
   </ul>
 </nav>
   </div>
-  <div class="app-split-pane__content">
+  <div class="app-split-pane__content" data-testid="app-split-pane-content">
     <section class="app-content">
             <div class="govuk-grid-row">
         <section class="govuk-grid-column-two-thirds-from-desktop-big">

--- a/src/server/test-suites/test-suite/secrets/secrets.test.js
+++ b/src/server/test-suites/test-suite/secrets/secrets.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 import {
   initialiseServer,
   mockAuthAndRenderUrl,

--- a/src/server/test-suites/test-suite/status/status.test.js
+++ b/src/server/test-suites/test-suite/status/status.test.js
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 import {
   initialiseServer,
   mockAuthAndRenderUrl,

--- a/src/server/test-suites/transformers/test-suite-run-results.test.js
+++ b/src/server/test-suites/transformers/test-suite-run-results.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { testSuiteRunResults } from './test-suite-run-results.js'
 import { testSuiteRunsFixture } from '../../../__fixtures__/test-suite-runs.js'
 

--- a/src/server/test-suites/transformers/test-suite-to-entity-row.test.js
+++ b/src/server/test-suites/transformers/test-suite-to-entity-row.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { entityTestSuiteFixture } from '../../../__fixtures__/test-suite.js'
 import { testSuiteToEntityRow } from './test-suite-to-entity-row.js'
 

--- a/src/server/test-suites/transformers/test-suite-to-summary.test.js
+++ b/src/server/test-suites/transformers/test-suite-to-summary.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { repositoryTestSuiteFixture } from '../../../__fixtures__/repository.js'
 import { transformTestSuiteToSummary } from './test-suite-to-summary.js'
 import { entityTestSuiteFixture } from '../../../__fixtures__/test-suite.js'

--- a/src/server/utilities/transformers/utility-to-entity-row.test.js
+++ b/src/server/utilities/transformers/utility-to-entity-row.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { utilityToEntityRow } from './utility-to-entity-row.js'
 import { templatesFixture } from '../../../__fixtures__/templates.js'
 

--- a/test-helpers/component-helpers.js
+++ b/test-helpers/component-helpers.js
@@ -35,19 +35,23 @@ Object.keys(testGlobals).forEach((global) => {
   nunjucksTestEnv.addGlobal(global, testGlobals[global])
 })
 
-function renderTestComponent(name, params, callBlock) {
+function renderTestComponent(name, options = {}) {
+  const params = options?.params ?? {}
+  const callBlock = options?.callBlock ?? []
+  const context = options?.context ?? {}
+
   const macroPath = `${name}/macro.njk`
   const macroName = `app${upperFirst(camelCase(name.replace('icons', '')))}`
   const macroParams = JSON.stringify(params, null, 2)
-  let macroString = `{%- from "${macroPath}" import ${macroName} -%}`
+  let macroString = `{%- from "${macroPath}" import ${macroName} with context -%}`
 
-  if (callBlock) {
-    macroString += `{%- call ${macroName}(${macroParams}) -%}${callBlock}{%- endcall -%}`
+  if (Array.isArray(callBlock) && callBlock.length > 0) {
+    macroString += `{%- call ${macroName}(${macroParams}) -%}${callBlock.join(' ')}{%- endcall -%}`
   } else {
     macroString += `{{- ${macroName}(${macroParams}) -}}`
   }
 
-  return cheerio.load(nunjucksTestEnv.renderString(macroString))
+  return cheerio.load(nunjucksTestEnv.renderString(macroString, context))
 }
 
 function renderPage(viewPath, context) {

--- a/test-helpers/component-helpers.js
+++ b/test-helpers/component-helpers.js
@@ -23,7 +23,8 @@ const nunjucksTestEnv = nunjucks.configure(
   {
     trimBlocks: true,
     lstripBlocks: true,
-    watch: false
+    watch: false,
+    noCache: true
   }
 )
 


### PR DESCRIPTION
Lots of bits and bobs but mostly:
- writing the 5 `todo` tests that have been hanging around for a while
- fixing how teams display in the deployments table
- remove vitest explicit imports, these are not needed now eslint has the globals set up
- update `renderTestComponent` args to also support passing `context`
- added lots of testing hooks which triggered visual test updates
- remove some dead `jest` work
- avoid empty `appPanel` components in the `admin > permissions` section

More details in the commits