### PR TITLE
Core 1109 fix errors showing in logs

### DIFF
--- a/src/server/common/helpers/redis/redis-client.js
+++ b/src/server/common/helpers/redis/redis-client.js
@@ -16,11 +16,12 @@ function buildRedisClient(redisConfig) {
   const host = redisConfig.host
 
   const client = redisConfig.useSingleInstanceCache
-    ? new IoRedis({ port, host, db, keyPrefix })
+    ? new IoRedis({ port, host, db, keyPrefix, enableReadyCheck: false })
     : new IoRedis.Cluster([{ host, port }], {
         keyPrefix,
         slotsRefreshTimeout: 2000,
         dnsLookup: (address, callback) => callback(null, address),
+        enableReadyCheck: false,
         redisOptions: {
           username: redisConfig.username,
           password: redisConfig.password,

--- a/src/server/common/templates/layouts/minimal-page.njk
+++ b/src/server/common/templates/layouts/minimal-page.njk
@@ -1,5 +1,6 @@
 {# Minimal page template that provides a page without header nav or footer #}
 {% from "service-header/macro.njk" import appServiceHeader with context %}
+{% from "page-heading/macro.njk" import appPageHeading %}
 
 {% extends "govuk/template.njk" %}
 

--- a/src/server/deployments/helpers/pre/provide-deployment.js
+++ b/src/server/deployments/helpers/pre/provide-deployment.js
@@ -9,7 +9,7 @@ const provideDeployment = {
     const deploymentId = request.params?.deploymentId
     const deployment = await fetchDeployment(deploymentId)
 
-    const repository = await fetchRepository(deployment.service).catch(
+    const repository = await fetchRepository(deployment?.service).catch(
       nullify404
     )
     const status = augmentStatus(deployment)

--- a/src/server/test-suites/views/test-results.njk
+++ b/src/server/test-suites/views/test-results.njk
@@ -1,4 +1,5 @@
 {% extends "layouts/page.njk" %}
+
 {% from "warning/macro.njk" import appWarning %}
 
 {% block content %}


### PR DESCRIPTION
Couple of fixes for errors I'm seeing in logs and metrics:

- https://logs.management.cdp-int.defra.cloud/_dashboards/goto/359659dbc6b0e6697909a2d724363ba8?security_tenant=global
- https://metrics.management.cdp-int.defra.cloud/d/cejsk22u6smpse/cdp-portal-frontend-service?orgId=1&refresh=10s

## Of Note

Redis connection events - https://github.com/redis/ioredis/tree/265ea5975a0447be12d7dd5e209256ecb42fc797?tab=readme-ov-file#connection-events