### PR TITLE
CORE-1134: Fix issues with the highlight functionality

### DIFF
--- a/src/server/documentation/helpers/markdown/build-page-html.test.js
+++ b/src/server/documentation/helpers/markdown/build-page-html.test.js
@@ -97,4 +97,44 @@ describe('#buildPageHtml', () => {
     expect(html).toBe('')
     expect(toc).toBe('')
   })
+
+  test('Should render angle bracket link as expected', async () => {
+    const mockRequest = { query: {} }
+    const markdown = '<https://example.com>'
+    const { html } = await buildPageHtml(mockRequest, markdown)
+
+    const $html = load(html)
+    const $link = $html('a')
+
+    expect($link.prop('outerHTML')).toBe(
+      '<a href="https://example.com" target="_blank" rel="noopener noreferrer">https://example.com</a>'
+    )
+  })
+
+  test('Should render plain link as expected', async () => {
+    const mockRequest = { query: {} }
+    const markdown = 'https://exampleother.com'
+    const { html } = await buildPageHtml(mockRequest, markdown)
+
+    const $html = load(html)
+    const $link = $html('a')
+
+    expect($link.prop('outerHTML')).toBe(
+      '<a href="https://exampleother.com" target="_blank" rel="noopener noreferrer">https://exampleother.com</a>'
+    )
+  })
+
+  test('Should render markdown link as expected', async () => {
+    const mockRequest = { query: {} }
+    const markdown =
+      '[https://example-another.com](https://example-another.com)'
+    const { html } = await buildPageHtml(mockRequest, markdown)
+
+    const $html = load(html)
+    const $link = $html('a')
+
+    expect($link.prop('outerHTML')).toBe(
+      '<a href="https://example-another.com" target="_blank" rel="noopener noreferrer">https://example-another.com</a>'
+    )
+  })
 })


### PR DESCRIPTION
Due to a new `markdown` `major` version and some fundamental changes in escaping html. Issues with rendering the search highlight have knocked angle bracket `<http://example.com>` markdown links. 

This code fixes this issue and continues to support `<http://example.com>` which we use extensively in `cdp-documentation` as well as all other flavours of links - whilst also supporting wrapping search results in `<mark class="app-mark">search result</mark>`


## Current
<img width="3024" height="4768" alt="screencapture-localhost-3000-documentation-how-to-software-standards-md-2025-08-05-16_32_53" src="https://github.com/user-attachments/assets/b4da694c-0f9e-4c1e-9c28-15fb2a022d28" />


## Fixed
<img width="3024" height="4768" alt="screencapture-localhost-3000-documentation-how-to-software-standards-md-2025-08-05-16_32_10" src="https://github.com/user-attachments/assets/d9d276d3-4e43-4b73-b025-a8c45cd554c1" />
