### PR TITLE
Tidy up of auth work

### DIFF
--- a/src/config/nunjucks/context/build-navigation.js
+++ b/src/config/nunjucks/context/build-navigation.js
@@ -1,7 +1,7 @@
 import { scopes } from '../../../server/common/constants/scopes.js'
 
 async function buildNavigation(request) {
-  const authedUser = await request.getUserSession()
+  const userSession = await request.getUserSession()
   const hasPostgresPermission = request.hasScope(scopes.restrictedTechPostgres)
   const hasTestAsTenantPermission = request.hasScope(scopes.testAsTenant)
 
@@ -20,7 +20,7 @@ async function buildNavigation(request) {
   const removeTestAsTenantPath = request.routeLookup('admin/removeTestAsTenant')
   const applyChangelogPath = request.routeLookup('apply-changelog')
 
-  const actions = (authedUser?.isTenant || authedUser?.isAdmin) && [
+  const actions = (userSession?.isTenant || userSession?.isAdmin) && [
     {
       text: 'Deploy Service',
       href: deployServicePath,
@@ -130,7 +130,7 @@ async function buildNavigation(request) {
       ]
     : undefined
 
-  const admin = authedUser?.isAdmin
+  const admin = userSession?.isAdmin
     ? [
         {
           text: 'Admin',

--- a/src/config/nunjucks/context/context.js
+++ b/src/config/nunjucks/context/context.js
@@ -47,9 +47,9 @@ function getAssetPath(asset) {
  * @param {import('@hapi/hapi').Request | null} request
  */
 async function context(request) {
-  const authedUser = await request.getUserSession()
+  const userSession = await request.getUserSession()
   const isInternetExplorer = isIe(request.headers['user-agent'])
-  const announcements = getAnnouncements(authedUser, isInternetExplorer)
+  const announcements = getAnnouncements(userSession, isInternetExplorer)
   const serviceConfig = config.get('service')
 
   return {
@@ -57,16 +57,16 @@ async function context(request) {
     appBaseUrl: config.get('appBaseUrl'),
     appServiceName: serviceConfig.name,
     assetPath: `${assetPath}/assets`,
-    authedUser,
+    userSession,
     blankOption: defaultOption,
     breadcrumbs: [],
     eventName,
     getAssetPath,
     githubOrg: config.get('githubOrg'),
     hasScope: hasScopeDecorator(request),
-    isAdmin: authedUser?.isAdmin ?? false,
-    isAuthenticated: authedUser?.isAuthenticated ?? false,
-    isTenant: authedUser?.isTenant ?? false,
+    isAdmin: userSession?.isAdmin ?? false,
+    isAuthenticated: userSession?.isAuthenticated ?? false,
+    isTenant: userSession?.isTenant ?? false,
     isXhr: isXhr.call(request),
     navigation: await buildNavigation(request),
     noValue,

--- a/src/server/admin/decommissions/controllers/start-decommission.js
+++ b/src/server/admin/decommissions/controllers/start-decommission.js
@@ -9,7 +9,7 @@ const startDecommissionController = {
     id: 'post:admin/decommissions/start'
   },
   handler: async (request, h) => {
-    const authedUser = await request.getUserSession()
+    const userSession = await request.getUserSession()
     const repositoryName = request.payload.repositoryName
 
     const entities = await fetchEntities()
@@ -34,7 +34,7 @@ const startDecommissionController = {
     if (!validationResult.error) {
       try {
         // TODO is anything useful going to be coming back that can be displayed?
-        await decommission(repositoryName, authedUser)
+        await decommission(repositoryName, userSession)
 
         request.yar.flash(sessionNames.notifications, {
           text: 'Decommission requested',
@@ -42,11 +42,11 @@ const startDecommissionController = {
         })
 
         request.audit.sendMessage({
-          event: `Decommission: ${repositoryName} requested by ${authedUser.id}:${authedUser.email}`,
+          event: `Decommission: ${repositoryName} requested by ${userSession?.id}:${userSession?.email}`,
           data: {
             repositoryName
           },
-          user: authedUser
+          user: userSession
         })
 
         return h.redirect(`/admin/decommissions/${repositoryName}`)

--- a/src/server/admin/permissions/controllers/create/permission-details.js
+++ b/src/server/admin/permissions/controllers/create/permission-details.js
@@ -2,13 +2,10 @@ import { sessionNames } from '../../../../common/constants/session-names.js'
 import { createScope } from '../../helpers/fetchers.js'
 import { buildErrorDetails } from '../../../../common/helpers/build-error-details.js'
 import { createPermissionValidation } from '../../helpers/schema/create-permission-validation.js'
-import { provideAuthedUser } from '../../../../common/helpers/auth/pre/provide-authed-user.js'
 
 const createPermissionDetailsController = {
-  options: {
-    pre: [provideAuthedUser]
-  },
   handler: async (request, h) => {
+    const userSession = await request.getUserSession()
     const payload = request?.payload
     const value = payload.value?.trim()
     const kind = Array.isArray(payload.kind)
@@ -54,12 +51,12 @@ const createPermissionDetailsController = {
         })
 
         request.audit.sendMessage({
-          event: `permission: ${value}:${createScopePayload.scope.scopeId} created by ${request.pre.authedUser.id}:${request.pre.authedUser.email}`,
+          event: `permission: ${value}:${createScopePayload.scope.scopeId} created by ${userSession.id}:${userSession.email}`,
           data: {
             value,
             scopeId: createScopePayload.scope.scopeId
           },
-          user: request.pre.authedUser
+          user: userSession
         })
 
         return h.redirect(

--- a/src/server/admin/permissions/controllers/delete/delete-permission.js
+++ b/src/server/admin/permissions/controllers/delete/delete-permission.js
@@ -3,7 +3,6 @@ import Boom from '@hapi/boom'
 
 import { sessionNames } from '../../../../common/constants/session-names.js'
 import { deleteScope } from '../../helpers/fetchers.js'
-import { provideAuthedUser } from '../../../../common/helpers/auth/pre/provide-authed-user.js'
 
 const deletePermissionController = {
   options: {
@@ -12,10 +11,10 @@ const deletePermissionController = {
         scopeId: Joi.objectId().required()
       }),
       failAction: () => Boom.boomify(Boom.badRequest())
-    },
-    pre: [provideAuthedUser]
+    }
   },
   handler: async (request, h) => {
+    const userSession = await request.getUserSession()
     const scopeId = request.params.scopeId
 
     try {
@@ -27,11 +26,11 @@ const deletePermissionController = {
       })
 
       request.audit.sendMessage({
-        event: `permission: ${scopeId} delete by ${request.pre.authedUser.id}:${request.pre.authedUser.email}`,
+        event: `permission: ${scopeId} delete by ${userSession.id}:${userSession.email}`,
         data: {
           scopeId
         },
-        user: request.pre.authedUser
+        user: userSession
       })
 
       return h.redirect('/admin/permissions')

--- a/src/server/admin/permissions/controllers/edit/permission-details.js
+++ b/src/server/admin/permissions/controllers/edit/permission-details.js
@@ -5,7 +5,6 @@ import { sessionNames } from '../../../../common/constants/session-names.js'
 import { buildErrorDetails } from '../../../../common/helpers/build-error-details.js'
 import { editPermissionValidation } from '../../helpers/schema/edit-permission-validation.js'
 import { updateScope } from '../../helpers/fetchers.js'
-import { provideAuthedUser } from '../../../../common/helpers/auth/pre/provide-authed-user.js'
 
 const editPermissionDetailsController = {
   options: {
@@ -14,10 +13,10 @@ const editPermissionDetailsController = {
         scopeId: Joi.objectId().required()
       }),
       failAction: () => Boom.boomify(Boom.notFound())
-    },
-    pre: [provideAuthedUser]
+    }
   },
   handler: async (request, h) => {
+    const userSession = await request.getUserSession()
     const scopeId = request.params.scopeId
     const payload = request?.payload
     const kind = Array.isArray(payload.kind)
@@ -61,11 +60,11 @@ const editPermissionDetailsController = {
         })
 
         request.audit.sendMessage({
-          event: `permission: ${scopeId} edited by ${request.pre.authedUser.id}:${request.pre.authedUser.email}`,
+          event: `permission: ${scopeId} edited by ${userSession.id}:${userSession.email}`,
           data: {
             scopeId
           },
-          user: request.pre.authedUser
+          user: userSession
         })
 
         return h.redirect(`/admin/permissions/${scopeId}`)

--- a/src/server/admin/permissions/controllers/remove/team/remove-permission.js
+++ b/src/server/admin/permissions/controllers/remove/team/remove-permission.js
@@ -3,7 +3,6 @@ import Boom from '@hapi/boom'
 import Joi from '../../../../../common/helpers/extended-joi.js'
 import { sessionNames } from '../../../../../common/constants/session-names.js'
 import { removeScopeFromTeam } from '../../../helpers/fetchers.js'
-import { provideAuthedUser } from '../../../../../common/helpers/auth/pre/provide-authed-user.js'
 import { teamIdValidation } from '@defra/cdp-validation-kit/src/validations.js'
 
 const removePermissionFromTeamController = {
@@ -14,10 +13,10 @@ const removePermissionFromTeamController = {
         scopeId: Joi.objectId().required()
       }),
       failAction: () => Boom.boomify(Boom.badRequest())
-    },
-    pre: [provideAuthedUser]
+    }
   },
   handler: async (request, h) => {
+    const userSession = await request.getUserSession()
     const params = request.params
     const teamId = params.teamId
     const scopeId = params.scopeId
@@ -31,12 +30,12 @@ const removePermissionFromTeamController = {
       })
 
       request.audit.sendMessage({
-        event: `permission: ${scopeId} removed from team: ${teamId} by ${request.pre.authedUser.id}:${request.pre.authedUser.email}`,
+        event: `permission: ${scopeId} removed from team: ${teamId} by ${userSession.id}:${userSession.email}`,
         data: {
           teamId,
           scopeId
         },
-        user: request.pre.authedUser
+        user: userSession
       })
     } catch (error) {
       request.yar.flash(sessionNames.globalValidationFailures, error.message)

--- a/src/server/admin/permissions/controllers/remove/user/remove-permission.js
+++ b/src/server/admin/permissions/controllers/remove/user/remove-permission.js
@@ -3,7 +3,6 @@ import Boom from '@hapi/boom'
 import Joi from '../../../../../common/helpers/extended-joi.js'
 import { sessionNames } from '../../../../../common/constants/session-names.js'
 import { removeScopeFromUser } from '../../../helpers/fetchers.js'
-import { provideAuthedUser } from '../../../../../common/helpers/auth/pre/provide-authed-user.js'
 import { userIdValidation } from '@defra/cdp-validation-kit/src/validations.js'
 
 const removePermissionFromUserController = {
@@ -14,8 +13,7 @@ const removePermissionFromUserController = {
         scopeId: Joi.objectId().required()
       }),
       failAction: () => Boom.boomify(Boom.badRequest())
-    },
-    pre: [provideAuthedUser]
+    }
   },
   handler: async (request, h) => {
     const params = request.params

--- a/src/server/admin/permissions/controllers/remove/user/remove-test-as-tenant-permission.js
+++ b/src/server/admin/permissions/controllers/remove/user/remove-test-as-tenant-permission.js
@@ -1,25 +1,23 @@
+import { scopes } from '../../../../../common/constants/scopes.js'
 import { sessionNames } from '../../../../../common/constants/session-names.js'
 import {
   fetchPermissionsScopeByName,
   removeScopeFromUser
 } from '../../../helpers/fetchers.js'
-import { provideAuthedUser } from '../../../../../common/helpers/auth/pre/provide-authed-user.js'
-import { scopes } from '../../../../../common/constants/scopes.js'
 
 const removeTestAsTenantScopeController = {
   options: {
-    id: 'admin/removeTestAsTenant',
-    pre: [provideAuthedUser]
+    id: 'admin/removeTestAsTenant'
   },
   handler: async (request, h) => {
-    const authedUser = await request.pre.authedUser
+    const userSession = await request.getUserSession()
 
     try {
       const { scope } = await fetchPermissionsScopeByName(
         request,
         scopes.testAsTenant
       )
-      await removeScopeFromUser(request, authedUser.id, scope.scopeId)
+      await removeScopeFromUser(request, userSession?.id, scope.scopeId)
     } catch (error) {
       request.yar.flash(sessionNames.globalValidationFailures, error.message)
     }

--- a/src/server/admin/permissions/helpers/fetchers.js
+++ b/src/server/admin/permissions/helpers/fetchers.js
@@ -103,6 +103,7 @@ async function removeScopeFromTeam(request, teamId, scopeId) {
 }
 
 async function removeScopeFromUser(request, userId, scopeId) {
+  const userSession = await request.getUserSession()
   const endpoint =
     userServiceBackendUrl + `/scopes/admin/${scopeId}/user/remove/${userId}`
 
@@ -116,12 +117,12 @@ async function removeScopeFromUser(request, userId, scopeId) {
   })
 
   request.audit.sendMessage({
-    event: `permission: ${scopeId} removed from user: ${userId} by ${request.pre.authedUser.id}:${request.pre.authedUser.email}`,
+    event: `permission: ${scopeId} removed from user: ${userId} by ${userSession.id}:${userSession.email}`,
     data: {
       userId,
       scopeId
     },
-    user: request.pre.authedUser
+    user: userSession
   })
 
   return payload

--- a/src/server/apply-changelog/controllers/apply.js
+++ b/src/server/apply-changelog/controllers/apply.js
@@ -2,12 +2,11 @@ import Joi from 'joi'
 
 import { config } from '../../../config/config.js'
 import { sessionNames } from '../../common/constants/session-names.js'
-import { provideAuthedUser } from '../../common/helpers/auth/pre/provide-authed-user.js'
 import { provideStepData } from '../../common/helpers/multistep-form/provide-step-data.js'
 
 const applyController = {
   options: {
-    pre: [provideStepData, provideAuthedUser],
+    pre: [provideStepData],
     validate: {
       params: Joi.object({
         multiStepFormId: Joi.string().uuid().required()
@@ -15,6 +14,7 @@ const applyController = {
     }
   },
   handler: async (request, h) => {
+    const userSession = await request.getUserSession()
     const stepData = request.pre.stepData
     const multiStepFormId = request.app.multiStepFormId
     const runApplyChangelogEndpointUrl =
@@ -44,12 +44,12 @@ const applyController = {
       const migrationId = payload?.migrationId
 
       request.audit.sendMessage({
-        event: `database changelog apply requested: ${stepData.serviceName}:${stepData.version} to ${stepData.environment} with config ${request.payload.configVersion} by ${request.pre.authedUser.id}:${request.pre.authedUser.email}`,
+        event: `database changelog apply requested: ${stepData.serviceName}:${stepData.version} to ${stepData.environment} with config ${request.payload.configVersion} by ${userSession.id}:${userSession.email}`,
         data: {
           serviceName: stepData.serviceName,
           environment: stepData.environment
         },
-        user: request.pre.authedUser
+        user: userSession
       })
 
       return h.redirect(

--- a/src/server/apply-changelog/controllers/change-details-form.js
+++ b/src/server/apply-changelog/controllers/change-details-form.js
@@ -33,8 +33,8 @@ const changeDetailsFormController = {
     const latestMigrations = await fetchLatestMigrations(serviceName)
 
     const postgresImageNameOptions = buildOptions(postgresServiceNames ?? [])
-    const authedUser = await request.getUserSession()
-    const environments = getEnvironments(authedUser?.scope)
+    const userSession = await request.getUserSession()
+    const environments = getEnvironments(userSession?.scope)
     const environmentOptions = environments ? buildOptions(environments) : []
 
     const { runningServices, dbChangeOptions, latestDbChanges } =

--- a/src/server/apply-changelog/controllers/change-details.js
+++ b/src/server/apply-changelog/controllers/change-details.js
@@ -18,13 +18,13 @@ const changeDetailsController = {
   },
   handler: async (request, h) => {
     const payload = request?.payload
-    const authedUser = request.auth.credentials
+    const userSession = await request.getUserSession()
     const redirectLocation = payload?.redirectLocation
     const multiStepFormId = request.app.multiStepFormId
 
-    const serviceNames = await fetchServiceNames(authedUser)
+    const serviceNames = await fetchServiceNames(userSession)
     const migrations = await fetchAvailableMigrations(payload?.serviceName)
-    const environments = getEnvironments(authedUser?.scope)
+    const environments = getEnvironments(userSession?.scope)
 
     const validationResult = dbChangeValidation(
       serviceNames,

--- a/src/server/common/components/service-header/template.njk
+++ b/src/server/common/components/service-header/template.njk
@@ -15,10 +15,10 @@
 
     </div>
     <div class="app-service-header__actions">
-      {% if authedUser.displayName %}
+      {% if userSession.displayName %}
         {{ appUserIcon({ classes: "app-icon--minuscule" }) }}
         <span data-testid="app-login-username">
-          {{ authedUser.displayName }}
+          {{ userSession.displayName }}
         </span>
       {% endif %}
 

--- a/src/server/common/helpers/auth/pre/provide-authed-user.js
+++ b/src/server/common/helpers/auth/pre/provide-authed-user.js
@@ -1,6 +1,0 @@
-const provideAuthedUser = {
-  method: async (request) => (await request.getUserSession()) ?? null,
-  assign: 'authedUser'
-}
-
-export { provideAuthedUser }

--- a/src/server/common/helpers/auth/refresh-token.js
+++ b/src/server/common/helpers/auth/refresh-token.js
@@ -23,7 +23,7 @@ export async function refreshTokenIfExpired(refreshToken, request, h) {
 
   if (tokenHasExpired) {
     request.logger.info(
-      `Token for user ${userSession.displayName} has expired, attempting to refresh`
+      `Token for user ${userSession?.displayName} has expired, attempting to refresh`
     )
 
     try {
@@ -33,7 +33,7 @@ export async function refreshTokenIfExpired(refreshToken, request, h) {
     } catch (error) {
       request.logger.debug(
         error,
-        `Token refresh for ${userSession.displayName} failed`
+        `Token refresh for ${userSession?.displayName} failed`
       )
       removeAuthenticatedUser(request)
       request.yar.flash(

--- a/src/server/common/helpers/ext/all-environments-only-for-admin.js
+++ b/src/server/common/helpers/ext/all-environments-only-for-admin.js
@@ -4,12 +4,12 @@ import { scopes } from '../../constants/scopes.js'
 
 const allEnvironmentsOnlyForAdmin = {
   method: async (request, h) => {
-    const authedUser = await request.getUserSession()
+    const userSession = await request.getUserSession()
     const environment = request.params.environment
 
     const adminOnlyEnvs = getEnvironmentsThatNeed([scopes.admin])
 
-    if (!authedUser?.isAdmin && adminOnlyEnvs.includes(environment)) {
+    if (!userSession?.isAdmin && adminOnlyEnvs.includes(environment)) {
       throw Boom.boomify(Boom.unauthorized())
     }
 

--- a/src/server/common/helpers/fetch/authed-fetch-json.js
+++ b/src/server/common/helpers/fetch/authed-fetch-json.js
@@ -35,8 +35,8 @@ async function authedFetchJson(url, token, options = {}) {
 
 function authedFetchJsonDecorator(request) {
   return async (url, options = {}) => {
-    const authedUser = await request.getUserSession()
-    const token = authedUser?.token ?? null
+    const userSession = await request.getUserSession()
+    const token = userSession?.token ?? null
 
     return authedFetchJson(url, token, options).then(
       async ({ res, payload }) => {
@@ -44,8 +44,8 @@ function authedFetchJsonDecorator(request) {
           // Initial request has received a 401 from a call to an API. Refresh token and replay initial request
 
           try {
-            const authedUser = await request.getUserSession()
-            const newToken = authedUser?.token ?? null
+            const refetchedUserSession = await request.getUserSession()
+            const newToken = refetchedUserSession?.token ?? null
 
             // Replay initial request with new token
             return await authedFetchJson(url, newToken, options)

--- a/src/server/common/helpers/fetch/fetch-entities.js
+++ b/src/server/common/helpers/fetch/fetch-entities.js
@@ -45,8 +45,8 @@ function fetchServices(queryParams) {
   })
 }
 
-async function fetchServiceNames(authedUser) {
-  const teamIds = authedUser?.isAdmin ? [] : authedUser.uuidScope
+async function fetchServiceNames(userSession) {
+  const teamIds = userSession?.isAdmin ? [] : userSession.uuidScope
   const services = await fetchServices({ teamIds })
 
   return services.map((service) => service.name)

--- a/src/server/common/helpers/user/get-users-teams.js
+++ b/src/server/common/helpers/user/get-users-teams.js
@@ -7,13 +7,13 @@ import { fetchTeams } from '../../../teams/helpers/fetch/fetch-teams.js'
  * @returns {Promise<[{teamId: string, github: string}]>}
  */
 async function getUsersTeams(request) {
-  const authedUser = await request.getUserSession()
-  const userGroups = authedUser.scope
+  const userSession = await request.getUserSession()
+  const userGroups = userSession?.scope
 
   // TODO we need to consider pagination here in the future
   const { teams } = await fetchTeams(true)
 
-  if (authedUser.isAdmin) {
+  if (userSession?.isAdmin) {
     return teams
   }
 

--- a/src/server/common/helpers/user/user-is-admin.js
+++ b/src/server/common/helpers/user/user-is-admin.js
@@ -1,12 +1,12 @@
-function userIsAdmin(authedUser) {
-  return authedUser.isAdmin
+function userIsAdmin(userSession) {
+  return userSession.isAdmin
 }
 
 function userIsAdminDecorator(request) {
   return async () => {
-    const authedUser = await request.getUserSession()
+    const userSession = await request.getUserSession()
 
-    return authedUser ? userIsAdmin(authedUser) : false
+    return userSession ? userIsAdmin(userSession) : false
   }
 }
 

--- a/src/server/common/helpers/user/user-is-owner.js
+++ b/src/server/common/helpers/user/user-is-owner.js
@@ -3,10 +3,10 @@ import { userIsServiceOwner } from './user-is-service-owner.js'
 function userIsOwnerDecorator(request) {
   /** @param {{ entity }} entity */
   return async (entity) => {
-    const authedUser = await request.getUserSession()
+    const userSession = await request.getUserSession()
     const teams = entity.teams?.map((team) => team.teamId) ?? []
 
-    return userIsServiceOwner(authedUser)(teams)
+    return userIsServiceOwner(userSession)(teams)
   }
 }
 

--- a/src/server/common/helpers/user/user-is-service-owner.js
+++ b/src/server/common/helpers/user/user-is-service-owner.js
@@ -1,14 +1,14 @@
-function userIsServiceOwner(authedUser) {
+function userIsServiceOwner(userSession) {
   return (teams) =>
-    authedUser && teams.some((team) => authedUser?.scope?.includes(team))
+    userSession && teams.some((team) => userSession?.scope?.includes(team))
 }
 
 function userIsServiceOwnerDecorator(request) {
   /** @param {string[]} teamsForTheService */
   return async (teamsForTheService) => {
-    const authedUser = await request.getUserSession()
+    const userSession = await request.getUserSession()
 
-    return userIsServiceOwner(authedUser)(teamsForTheService)
+    return userIsServiceOwner(userSession)(teamsForTheService)
   }
 }
 

--- a/src/server/common/helpers/user/user-is-tenant.js
+++ b/src/server/common/helpers/user/user-is-tenant.js
@@ -1,12 +1,12 @@
-function userIsTenant(authedUser) {
-  return authedUser.isTenant
+function userIsTenant(userSession) {
+  return userSession.isTenant
 }
 
 function userIsTenantDecorator(request) {
   return async () => {
-    const authedUser = await request.getUserSession()
+    const userSession = await request.getUserSession()
 
-    return authedUser ? userIsTenant(authedUser) : false
+    return userSession ? userIsTenant(userSession) : false
   }
 }
 

--- a/src/server/create/journey-test-suite/controllers/create.js
+++ b/src/server/create/journey-test-suite/controllers/create.js
@@ -3,7 +3,6 @@ import { sessionNames } from '../../../common/constants/session-names.js'
 import { provideCreate } from '../../helpers/pre/provide-create.js'
 import { buildErrorDetails } from '../../../common/helpers/build-error-details.js'
 import { testSuiteValidation } from '../../helpers/schema/test-suite-validation.js'
-import { provideAuthedUser } from '../../../common/helpers/auth/pre/provide-authed-user.js'
 import { auditMessageCreated } from '../../../common/helpers/audit/messages/audit-message-created.js'
 import { scopes } from '../../../common/constants/scopes.js'
 
@@ -15,9 +14,10 @@ const testSuiteCreateController = {
         scope: [scopes.admin, '{payload.teamId}']
       }
     },
-    pre: [provideCreate, provideAuthedUser]
+    pre: [provideCreate]
   },
   handler: async (request, h) => {
+    const userSession = await request.getUserSession()
     const create = request.pre?.create
     const repositoryName = create.repositoryName
     const templateTag = create.templateTag
@@ -67,11 +67,7 @@ const testSuiteCreateController = {
         })
 
         request.audit.sendMessage(
-          auditMessageCreated(
-            'Journey Test Suite',
-            repositoryName,
-            request.pre.authedUser
-          )
+          auditMessageCreated('Journey Test Suite', repositoryName, userSession)
         )
 
         return h.redirect(`/test-suites/${payload.repositoryName}`)

--- a/src/server/create/journey-test-suite/controllers/summary.js
+++ b/src/server/create/journey-test-suite/controllers/summary.js
@@ -11,7 +11,7 @@ const testSuiteSummaryController = {
   },
   handler: async (request, h) => {
     const create = request.pre?.create
-    const authedUser = await request.getUserSession()
+    const userSession = await request.getUserSession()
 
     return h.view('create/views/summary', {
       pageTitle: 'Create journey test suite summary',
@@ -22,7 +22,7 @@ const testSuiteSummaryController = {
       summaryRows: summaryTestSuiteRows(
         create,
         'journey-test-suite',
-        authedUser.isAdmin
+        userSession?.isAdmin
       ),
       formButtonText: 'Create',
       create

--- a/src/server/create/microservice/controllers/create.js
+++ b/src/server/create/microservice/controllers/create.js
@@ -4,7 +4,6 @@ import { provideCreate } from '../../helpers/pre/provide-create.js'
 import { buildErrorDetails } from '../../../common/helpers/build-error-details.js'
 import { microserviceValidation } from '../helpers/schema/microservice-validation.js'
 import { setStepComplete } from '../../helpers/form/index.js'
-import { provideAuthedUser } from '../../../common/helpers/auth/pre/provide-authed-user.js'
 import { auditMessageCreated } from '../../../common/helpers/audit/messages/audit-message-created.js'
 import { scopes } from '../../../common/constants/scopes.js'
 import { fetchServiceTemplates } from '../helpers/fetch/fetch-service-templates.js'
@@ -17,9 +16,10 @@ const microserviceCreateController = {
         scope: [scopes.admin, '{payload.teamId}']
       }
     },
-    pre: [provideCreate, provideAuthedUser]
+    pre: [provideCreate]
   },
   handler: async (request, h) => {
+    const userSession = await request.getUserSession()
     const create = request.pre?.create
     const { serviceTemplates } = await fetchServiceTemplates(request)
     const availableServiceTemplateIds = serviceTemplates.map(
@@ -81,7 +81,7 @@ const microserviceCreateController = {
         })
 
         request.audit.sendMessage(
-          auditMessageCreated('Service', repositoryName, request.pre.authedUser)
+          auditMessageCreated('Service', repositoryName, userSession)
         )
 
         return h.redirect(`/services/${payload.repositoryName}`)

--- a/src/server/create/microservice/controllers/summary.js
+++ b/src/server/create/microservice/controllers/summary.js
@@ -11,7 +11,7 @@ const microserviceSummaryController = {
   },
   handler: async (request, h) => {
     const create = request.pre?.create
-    const authedUser = await request.getUserSession()
+    const userSession = await request.getUserSession()
 
     return h.view('create/views/summary', {
       pageTitle: 'Create microservice summary',
@@ -19,7 +19,7 @@ const microserviceSummaryController = {
       headingCaption:
         'Information about the new microservice you are going to create',
       action: '/create/microservice',
-      summaryRows: summaryMicroserviceRows(create, authedUser.isAdmin),
+      summaryRows: summaryMicroserviceRows(create, userSession?.isAdmin),
       formButtonText: 'Create',
       create
     })

--- a/src/server/create/perf-test-suite/controllers/create.js
+++ b/src/server/create/perf-test-suite/controllers/create.js
@@ -4,7 +4,6 @@ import { provideCreate } from '../../helpers/pre/provide-create.js'
 import { buildErrorDetails } from '../../../common/helpers/build-error-details.js'
 import { testSuiteValidation } from '../../helpers/schema/test-suite-validation.js'
 import { setStepComplete } from '../../helpers/form/index.js'
-import { provideAuthedUser } from '../../../common/helpers/auth/pre/provide-authed-user.js'
 import { auditMessageCreated } from '../../../common/helpers/audit/messages/audit-message-created.js'
 import { scopes } from '../../../common/constants/scopes.js'
 
@@ -16,9 +15,10 @@ const perfTestSuiteCreateController = {
         scope: [scopes.admin, '{payload.teamId}']
       }
     },
-    pre: [provideCreate, provideAuthedUser]
+    pre: [provideCreate]
   },
   handler: async (request, h) => {
+    const userSession = await request.getUserSession()
     const create = request.pre?.create
     const repositoryName = create.repositoryName
     const teamId = request.payload?.teamId
@@ -70,11 +70,7 @@ const perfTestSuiteCreateController = {
         })
 
         request.audit.sendMessage(
-          auditMessageCreated(
-            'Perf Test Suite',
-            repositoryName,
-            request.pre.authedUser
-          )
+          auditMessageCreated('Perf Test Suite', repositoryName, userSession)
         )
 
         return h.redirect(`/test-suites/${payload.repositoryName}`)

--- a/src/server/create/perf-test-suite/controllers/summary.js
+++ b/src/server/create/perf-test-suite/controllers/summary.js
@@ -11,7 +11,7 @@ const perfTestSuiteSummaryController = {
   },
   handler: async (request, h) => {
     const create = request.pre?.create
-    const authedUser = await request.getUserSession()
+    const userSession = await request.getUserSession()
 
     return h.view('create/views/summary', {
       pageTitle: 'Create performance test suite summary',
@@ -22,7 +22,7 @@ const perfTestSuiteSummaryController = {
       summaryRows: summaryTestSuiteRows(
         create,
         'perf-test-suite',
-        authedUser.isAdmin
+        userSession?.isAdmin
       ),
       formButtonText: 'Create',
       create

--- a/src/server/create/prototype/controllers/create.js
+++ b/src/server/create/prototype/controllers/create.js
@@ -2,7 +2,6 @@ import { config } from '../../../../config/config.js'
 import { sessionNames } from '../../../common/constants/session-names.js'
 import { provideCreate } from '../../helpers/pre/provide-create.js'
 import { buildErrorDetails } from '../../../common/helpers/build-error-details.js'
-import { provideAuthedUser } from '../../../common/helpers/auth/pre/provide-authed-user.js'
 import { auditMessageCreated } from '../../../common/helpers/audit/messages/audit-message-created.js'
 import { scopes } from '../../../common/constants/scopes.js'
 import { prototypeValidation } from '../schema/prototype-validation.js'
@@ -15,9 +14,10 @@ const prototypeCreateController = {
         scope: [scopes.admin, '{payload.teamId}']
       }
     },
-    pre: [provideCreate, provideAuthedUser]
+    pre: [provideCreate]
   },
   handler: async (request, h) => {
+    const userSession = await request.getUserSession()
     const create = request.pre?.create
     const repositoryName = create.repositoryName
     const templateTag = create.templateTag
@@ -64,11 +64,7 @@ const prototypeCreateController = {
         })
 
         request.audit.sendMessage(
-          auditMessageCreated(
-            'Repository',
-            repositoryName,
-            request.pre.authedUser
-          )
+          auditMessageCreated('Repository', repositoryName, userSession)
         )
 
         return h.redirect(`/services/${payload.repositoryName}`)

--- a/src/server/create/prototype/controllers/summary.js
+++ b/src/server/create/prototype/controllers/summary.js
@@ -11,7 +11,7 @@ const prototypeSummaryController = {
   },
   handler: async (request, h) => {
     const create = request.pre?.create
-    const authedUser = await request.getUserSession()
+    const userSession = await request.getUserSession()
 
     return h.view('create/views/summary', {
       pageTitle: 'Create prototype summary',
@@ -22,7 +22,7 @@ const prototypeSummaryController = {
       summaryRows: summaryPrototypeRows(
         create,
         'prototype',
-        authedUser.isAdmin
+        userSession?.isAdmin
       ),
       formButtonText: 'Create',
       create

--- a/src/server/create/repository/controllers/create.js
+++ b/src/server/create/repository/controllers/create.js
@@ -3,7 +3,6 @@ import { sessionNames } from '../../../common/constants/session-names.js'
 import { provideCreate } from '../../helpers/pre/provide-create.js'
 import { buildErrorDetails } from '../../../common/helpers/build-error-details.js'
 import { repositoryValidation } from '../helpers/schema/repository-validation.js'
-import { provideAuthedUser } from '../../../common/helpers/auth/pre/provide-authed-user.js'
 import { auditMessageCreated } from '../../../common/helpers/audit/messages/audit-message-created.js'
 import { scopes } from '../../../common/constants/scopes.js'
 
@@ -15,9 +14,10 @@ const repositoryCreateController = {
         scope: [scopes.admin, '{payload.teamId}']
       }
     },
-    pre: [provideCreate, provideAuthedUser]
+    pre: [provideCreate]
   },
   handler: async (request, h) => {
+    const userSession = await request.getUserSession()
     const create = request.pre?.create
     const repositoryName = create.repositoryName
     const repositoryVisibility = create.repositoryVisibility
@@ -67,11 +67,7 @@ const repositoryCreateController = {
         })
 
         request.audit.sendMessage(
-          auditMessageCreated(
-            'Repository',
-            repositoryName,
-            request.pre.authedUser
-          )
+          auditMessageCreated('Repository', repositoryName, userSession)
         )
 
         return h.redirect(`/repositories/${repositoryName}/status`)

--- a/src/server/deploy-service/controllers/available-environments.js
+++ b/src/server/deploy-service/controllers/available-environments.js
@@ -9,8 +9,8 @@ const availableEnvironmentsController = {
     if (!request.isXhr()) {
       return Boom.methodNotAllowed('This route is only available via XHR')
     }
-    const authedUser = await request.getUserSession()
-    const userScopes = authedUser?.scope
+    const userSession = await request.getUserSession()
+    const userScopes = userSession?.scope
 
     try {
       const entity = await fetchEntity(request.query?.serviceName).catch(

--- a/src/server/deploy-service/controllers/deploy/details-form.js
+++ b/src/server/deploy-service/controllers/deploy/details-form.js
@@ -30,13 +30,13 @@ const detailsFormController = {
   handler: async (request, h) => {
     const query = request?.query
     const stepData = request.pre.stepData
-    const authedUser = request.auth.credentials
+    const userSession = await request.getUserSession()
 
     const imageName = query?.imageName ?? stepData?.imageName
     const redirectLocation = query?.redirectLocation
     const multiStepFormId = request.app.multiStepFormId
 
-    const serviceNames = await fetchServiceNames(authedUser)
+    const serviceNames = await fetchServiceNames(userSession)
     const latestMigrationsResponse = await fetchLatestMigrations(imageName)
 
     const latestMigrations = latestMigrationsResponse.map((migration) => ({
@@ -47,7 +47,7 @@ const detailsFormController = {
     const entity = await fetchEntity(imageName).catch(nullify404)
     const imageNameOptions = buildOptions(serviceNames)
 
-    const environments = getEnvironments(authedUser?.scope, entity?.type)
+    const environments = getEnvironments(userSession?.scope, entity?.type)
     const environmentOptions = environments.length
       ? buildSuggestions(
           environments.map((environment) => ({

--- a/src/server/deploy-service/controllers/deploy/details.js
+++ b/src/server/deploy-service/controllers/deploy/details.js
@@ -22,13 +22,13 @@ const detailsController = {
   },
   handler: async (request, h) => {
     const payload = request?.payload
-    const authedUser = request.auth.credentials
+    const userSession = await request.getUserSession()
     const redirectLocation = payload?.redirectLocation
     const multiStepFormId = request.app.multiStepFormId
 
-    const serviceNames = await fetchServiceNames(authedUser)
+    const serviceNames = await fetchServiceNames(userSession)
     const availableVersions = await fetchAvailableVersions(payload?.imageName)
-    const environments = getEnvironments(authedUser?.scope)
+    const environments = getEnvironments(userSession?.scope)
 
     const validationResult = serviceValidation(
       serviceNames,

--- a/src/server/deploy-service/controllers/deploy/options-form.js
+++ b/src/server/deploy-service/controllers/deploy/options-form.js
@@ -30,7 +30,7 @@ const optionsFormController = {
     }
   },
   handler: async (request, h) => {
-    const authedUser = await request.getUserSession()
+    const userSession = await request.getUserSession()
     const query = request?.query
     const formDetail = request?.pre?.formDetail
     const multiStepFormId = request.app.multiStepFormId
@@ -43,7 +43,7 @@ const optionsFormController = {
       ...migration,
       statusClassname: provideDatabaseStatusClassname(migration.status)
     }))
-    const environments = getEnvironments(authedUser?.scope)
+    const environments = getEnvironments(userSession?.scope)
 
     return h.view('deploy-service/views/options-form', {
       pageTitle: 'Deploy service options',

--- a/src/server/deployments/controllers/deployments-list.js
+++ b/src/server/deployments/controllers/deployments-list.js
@@ -11,7 +11,6 @@ import { provideFormValues } from '../helpers/ext/provide-form-values.js'
 import { decorateRollouts } from '../transformers/decorate-rollouts.js'
 import { pagination } from '../../common/constants/pagination.js'
 import { fetchDeploymentFilters } from '../helpers/fetch/fetch-deployment-filters.js'
-import { provideAuthedUser } from '../../common/helpers/auth/pre/provide-authed-user.js'
 import { deploymentToEntityRow } from '../transformers/deployment-to-entity-row.js'
 import { fetchDeploymentsWithMigrations } from '../helpers/fetch/fetch-deployments-with-migrations.js'
 import { migrationToEntityRow } from '../transformers/migration-to-entity-row.js'
@@ -66,7 +65,6 @@ async function getFilters() {
 const deploymentsListController = {
   options: {
     id: 'deployments/{environment}',
-    pre: [provideAuthedUser],
     ext: {
       onPreAuth: [allEnvironmentsOnlyForAdmin],
       onPostHandler: [provideFormValues]
@@ -88,8 +86,8 @@ const deploymentsListController = {
     }
   },
   handler: async (request, h) => {
-    const authedUser = request.pre.authedUser
-    const userScopeUUIDs = authedUser?.uuidScope ?? []
+    const userSession = await request.getUserSession()
+    const userScopeUUIDs = userSession?.uuidScope ?? []
 
     const environment = request.params?.environment
     const formattedEnvironment = upperFirst(kebabCase(environment))

--- a/src/server/deployments/helpers/provide-tabs.js
+++ b/src/server/deployments/helpers/provide-tabs.js
@@ -5,7 +5,7 @@ import upperFirst from 'lodash/upperFirst.js'
 const paginationParams = `?page=${pagination.page}&size=${pagination.size}`
 
 async function provideTabs(request, h) {
-  const authedUser = await request.getUserSession()
+  const userSession = await request.getUserSession()
   const response = request.response
 
   if (response.variety === 'view') {
@@ -18,7 +18,7 @@ async function provideTabs(request, h) {
     }
 
     response.source.context.tabDetails.tabs = getEnvironments(
-      authedUser?.scope
+      userSession?.scope
     ).map((env) => ({
       isActive: request.path.startsWith(`/deployments/${env}`),
       url: `/deployments/${env}${paginationParams}`,

--- a/src/server/running-services/controllers/running-service.js
+++ b/src/server/running-services/controllers/running-service.js
@@ -20,8 +20,8 @@ const runningServiceController = {
     const serviceName = request.params.serviceName
 
     const latestMigrations = await fetchLatestMigrations(serviceName)
-    const authedUser = await request.getUserSession()
-    const environments = getEnvironments(authedUser?.scope)
+    const userSession = await request.getUserSession()
+    const environments = getEnvironments(userSession?.scope)
     const { runningServices, teams } =
       await transformRunningService(serviceName)
 

--- a/src/server/running-services/controllers/running-services-list.js
+++ b/src/server/running-services/controllers/running-services-list.js
@@ -1,14 +1,12 @@
 import Joi from 'joi'
 import Boom from '@hapi/boom'
 
-import { provideAuthedUser } from '../../common/helpers/auth/pre/provide-authed-user.js'
-import { buildRunningServicesTableData } from '../helpers/build-running-services-table-data.js'
 import { formatText } from '../../../config/nunjucks/filters/filters.js'
+import { buildRunningServicesTableData } from '../helpers/build-running-services-table-data.js'
 
 const runningServicesListController = {
   options: {
     id: 'running-services',
-    pre: [provideAuthedUser],
     validate: {
       query: Joi.object({
         service: Joi.string().allow(''),

--- a/src/server/running-services/helpers/build-running-services-table-data.js
+++ b/src/server/running-services/helpers/build-running-services-table-data.js
@@ -38,10 +38,11 @@ function getFilters(runningServicesFilters) {
   }
 }
 
-async function buildRunningServicesTableData({ pre, query }) {
-  const authedUser = pre.authedUser
-  const environments = getEnvironments(authedUser?.scope)
-  const userScopeUUIDs = authedUser?.uuidScope ?? []
+async function buildRunningServicesTableData(request) {
+  const query = request.query
+  const userSession = await request.getUserSession()
+  const environments = getEnvironments(userSession?.scope)
+  const userScopeUUIDs = userSession?.uuidScope ?? []
 
   const [deployableServices, runningServicesFilters, runningServices] =
     await Promise.all([

--- a/src/server/running-services/helpers/build-running-services-table-data.test.js
+++ b/src/server/running-services/helpers/build-running-services-table-data.test.js
@@ -22,7 +22,7 @@ describe('#buildRunningServicesTableData', () => {
     )
 
     const result = await buildRunningServicesTableData({
-      pre: { authedUser: { scope: ['admin'], uuidScope: [] } },
+      getUserSession: async () => ({ scope: ['admin'], uuidScope: [] }),
       query: {
         service: 'cdp-portal-frontend',
         status: 'running',
@@ -192,7 +192,7 @@ describe('#buildRunningServicesTableData', () => {
     fetchRunningServices.mockResolvedValue([])
 
     const result = await buildRunningServicesTableData({
-      pre: { authedUser: { scope: [], uuidScope: [] } },
+      getUserSession: async () => ({ scope: [], uuidScope: [] }),
       query: {}
     })
 
@@ -247,7 +247,7 @@ describe('#buildRunningServicesTableData', () => {
 
     await expect(
       buildRunningServicesTableData({
-        pre: { authedUser: { scope: [], uuidScope: [] } },
+        getUserSession: async () => ({ scope: [], uuidScope: [] }),
         query: {}
       })
     ).rejects.toThrow('Fetch failed')

--- a/src/server/services/helpers/provide-service-tabs.js
+++ b/src/server/services/helpers/provide-service-tabs.js
@@ -8,9 +8,9 @@ import { buildTab } from '../../common/patterns/entities/tabs/helpers/build-tab.
  * @returns {Promise<symbol>}
  */
 async function provideServiceTabs(request, h) {
-  const authedUser = await request.getUserSession()
-  const isAdmin = authedUser?.isAdmin
-  const isTenant = authedUser?.isTenant
+  const userSession = await request.getUserSession()
+  const isAdmin = userSession?.isAdmin
+  const isTenant = userSession?.isTenant
   const response = request.response
 
   if (response.variety === 'view') {

--- a/src/server/services/list/controller.js
+++ b/src/server/services/list/controller.js
@@ -1,14 +1,12 @@
 import Joi from 'joi'
 import Boom from '@hapi/boom'
 
-import { provideAuthedUser } from '../../common/helpers/auth/pre/provide-authed-user.js'
 import { buildServicesTableData } from './helpers/build-services-table-data.js'
 import { servicesInfoToDataList } from './transformers/services-info-to-data-list.js'
 
 const servicesListController = {
   options: {
     id: 'services',
-    pre: [provideAuthedUser],
     validate: {
       query: Joi.object({
         service: Joi.string().allow(''),
@@ -20,8 +18,8 @@ const servicesListController = {
     }
   },
   handler: async (request, h) => {
-    const authedUser = request.pre.authedUser
-    const userScopeUUIDs = authedUser?.uuidScope ?? []
+    const userSession = await request.getUserSession()
+    const userScopeUUIDs = userSession?.uuidScope ?? []
     const service = request.query.service
     const teamId = request.query.teamId
 

--- a/src/server/services/service/automations/controllers/auto-deployments.js
+++ b/src/server/services/service/automations/controllers/auto-deployments.js
@@ -5,14 +5,13 @@ import { formatText } from '../../../../../config/nunjucks/filters/filters.js'
 import { buildOptions } from '../../../../common/helpers/options/build-options.js'
 import { getAutoDeployDetails } from '../helpers/fetchers.js'
 import { getEnvironments } from '../../../../common/helpers/environments/get-environments.js'
-import { provideAuthedUser } from '../../../../common/helpers/auth/pre/provide-authed-user.js'
 import { provideNotFoundIfNull } from '../../../../common/helpers/ext/provide-not-found-if-null.js'
 
 const autoDeploymentsController = {
   options: {
     id: 'services/{serviceId}/automations/deployments',
     ext: { onPreAuth: [provideNotFoundIfNull] },
-    pre: [provideAuthedUser],
+
     validate: {
       params: Joi.object({
         serviceId: Joi.string().required()
@@ -21,12 +20,12 @@ const autoDeploymentsController = {
     }
   },
   handler: async (request, h) => {
-    const authedUser = request.pre.authedUser
+    const userSession = await request.getUserSession()
     const serviceId = request.params.serviceId
     const entity = request.app.entity
     const autoDeployDetails = await getAutoDeployDetails(serviceId)
     const environments = getEnvironments(
-      authedUser?.scope,
+      userSession?.scope,
       entity?.type
     ).filter((environment) => environment.toLowerCase() !== 'prod')
     const environmentOptions = buildOptions(

--- a/src/server/services/service/automations/controllers/auto-test-runs.js
+++ b/src/server/services/service/automations/controllers/auto-test-runs.js
@@ -4,7 +4,6 @@ import Boom from '@hapi/boom'
 import { formatText } from '../../../../../config/nunjucks/filters/filters.js'
 import { buildOptions } from '../../../../common/helpers/options/build-options.js'
 import { getEnvironments } from '../../../../common/helpers/environments/get-environments.js'
-import { provideAuthedUser } from '../../../../common/helpers/auth/pre/provide-authed-user.js'
 import { buildAutoTestRunsViewDetails } from '../helpers/build-auto-test-runs-view-details.js'
 import { excludedEnvironments } from '../helpers/constants/excluded-environments.js'
 import { provideNotFoundIfPrototype } from '../../../../common/helpers/ext/provide-not-found-if-prototype.js'
@@ -16,7 +15,6 @@ const autoTestRunsController = {
     ext: {
       onPreAuth: [provideNotFoundIfPrototype, provideNotFoundIfNull]
     },
-    pre: [provideAuthedUser],
     validate: {
       params: Joi.object({
         serviceId: Joi.string().required()
@@ -26,14 +24,14 @@ const autoTestRunsController = {
   },
   handler: async (request, h) => {
     const entity = request.app.entity
-    const authedUser = request.pre.authedUser
+    const userSession = await request.getUserSession()
     const serviceId = request.params.serviceId
     const serviceTeams = entity?.teams
+
     const environments = getEnvironments(
-      authedUser?.scope,
+      userSession?.scope,
       entity?.type
     ).filter((env) => !excludedEnvironments.includes(env.toLowerCase()))
-
     const environmentOptions = buildOptions(
       environments.map((env) => ({ text: formatText(env), value: env })),
       false

--- a/src/server/services/service/automations/controllers/create-auto-test-runs.js
+++ b/src/server/services/service/automations/controllers/create-auto-test-runs.js
@@ -3,7 +3,6 @@ import Joi from 'joi'
 
 import { sessionNames } from '../../../../common/constants/session-names.js'
 import { buildErrorDetails } from '../../../../common/helpers/build-error-details.js'
-import { provideAuthedUser } from '../../../../common/helpers/auth/pre/provide-authed-user.js'
 import { autoTestRunValidation } from '../helpers/schema/auto-test-run-validation.js'
 import { saveAutoTestRunDetails } from '../helpers/fetchers.js'
 import { provideNotFoundIfPrototype } from '../../../../common/helpers/ext/provide-not-found-if-prototype.js'
@@ -15,7 +14,6 @@ const setupAutoTestRunController = {
     ext: {
       onPreAuth: [provideNotFoundIfPrototype, provideNotFoundIfNull]
     },
-    pre: [provideAuthedUser],
     validate: {
       params: Joi.object({
         serviceId: Joi.string().required()
@@ -24,9 +22,9 @@ const setupAutoTestRunController = {
     }
   },
   handler: async (request, h) => {
-    const authedUser = request.pre.authedUser
+    const userSession = await request.getUserSession()
     const payload = request.payload
-    const userScopes = authedUser.scope
+    const userScopes = userSession?.scope
     const serviceId = request.params.serviceId
     const testSuite = payload.testSuite
     const environments = Array.isArray(payload.environments)

--- a/src/server/services/service/automations/controllers/update/update-test-run-form.js
+++ b/src/server/services/service/automations/controllers/update/update-test-run-form.js
@@ -1,17 +1,16 @@
 import Joi from 'joi'
 import Boom from '@hapi/boom'
 
-import {
-  fetchTestRepository,
-  getAutoTestRunDetails
-} from '../../helpers/fetchers.js'
 import { getEnvironments } from '../../../../../common/helpers/environments/get-environments.js'
 import { excludedEnvironments } from '../../helpers/constants/excluded-environments.js'
 import { buildOptions } from '../../../../../common/helpers/options/build-options.js'
 import { formatText } from '../../../../../../config/nunjucks/filters/filters.js'
-import { provideAuthedUser } from '../../../../../common/helpers/auth/pre/provide-authed-user.js'
 import { provideNotFoundIfPrototype } from '../../../../../common/helpers/ext/provide-not-found-if-prototype.js'
 import { provideNotFoundIfNull } from '../../../../../common/helpers/ext/provide-not-found-if-null.js'
+import {
+  fetchTestRepository,
+  getAutoTestRunDetails
+} from '../../helpers/fetchers.js'
 
 const updateTestRunFormController = {
   options: {
@@ -19,7 +18,6 @@ const updateTestRunFormController = {
     ext: {
       onPreAuth: [provideNotFoundIfPrototype, provideNotFoundIfNull]
     },
-    pre: [provideAuthedUser],
     validate: {
       params: Joi.object({
         serviceId: Joi.string().required(),
@@ -29,7 +27,7 @@ const updateTestRunFormController = {
     }
   },
   handler: async (request, h) => {
-    const authedUser = request.pre.authedUser
+    const userSession = await request.getUserSession()
     const serviceId = request.params.serviceId
     const testSuiteId = request.params.testSuiteId
 
@@ -38,7 +36,7 @@ const updateTestRunFormController = {
       fetchTestRepository(testSuiteId)
     ])
 
-    const environments = getEnvironments(authedUser?.scope).filter(
+    const environments = getEnvironments(userSession?.scope).filter(
       (env) => !excludedEnvironments.includes(env.toLowerCase())
     )
     const environmentOptions = buildOptions(

--- a/src/server/services/service/automations/controllers/update/update-test-run.js
+++ b/src/server/services/service/automations/controllers/update/update-test-run.js
@@ -3,7 +3,6 @@ import Boom from '@hapi/boom'
 
 import { sessionNames } from '../../../../../common/constants/session-names.js'
 import { updateAutoTestRun } from '../../helpers/fetchers.js'
-import { provideAuthedUser } from '../../../../../common/helpers/auth/pre/provide-authed-user.js'
 import { autoTestRunValidation } from '../../helpers/schema/auto-test-run-validation.js'
 import { buildErrorDetails } from '../../../../../common/helpers/build-error-details.js'
 import { provideNotFoundIfPrototype } from '../../../../../common/helpers/ext/provide-not-found-if-prototype.js'
@@ -15,7 +14,6 @@ const updateTestRunController = {
     ext: {
       onPreAuth: [provideNotFoundIfPrototype, provideNotFoundIfNull]
     },
-    pre: [provideAuthedUser],
     validate: {
       params: Joi.object({
         serviceId: Joi.string().required(),
@@ -25,9 +23,9 @@ const updateTestRunController = {
     }
   },
   handler: async (request, h) => {
-    const authedUser = request.pre.authedUser
+    const userSession = await request.getUserSession()
     const payload = request.payload
-    const userScopes = authedUser.scope
+    const userScopes = userSession?.scope
     const serviceId = request.params.serviceId
     const testSuiteId = request.params.testSuiteId
     const environments = Array.isArray(payload.environments)

--- a/src/server/services/service/maintenance/controllers/confirm-shutter.js
+++ b/src/server/services/service/maintenance/controllers/confirm-shutter.js
@@ -19,7 +19,7 @@ const confirmShutterController = {
     }
   },
   handler: async (request, h) => {
-    const authedUser = await request.getUserSession()
+    const userSession = await request.getUserSession()
     const serviceId = request.params.serviceId
     const url = request.query.url
     const entity = request.app.entity
@@ -41,7 +41,7 @@ const confirmShutterController = {
       summaryList: shutteringDetailToSummary({
         isFrontend,
         shutteringDetail,
-        authedUser
+        userSession
       }),
       breadcrumbs: [
         {

--- a/src/server/services/service/maintenance/controllers/confirm-undeploy.js
+++ b/src/server/services/service/maintenance/controllers/confirm-undeploy.js
@@ -19,7 +19,7 @@ const confirmUndeployController = {
     }
   },
   handler: async (request, h) => {
-    const authedUser = await request.getUserSession()
+    const userSession = await request.getUserSession()
     const serviceId = request.params.serviceId
     const environment = request.query.environment
     const entity = request.app.entity
@@ -47,7 +47,7 @@ const confirmUndeployController = {
         entity,
         deployedService,
         environment,
-        authedUser,
+        userSession,
         isFrontend
       }),
       breadcrumbs: [

--- a/src/server/services/service/maintenance/helpers/transformers/entity-to-summary.js
+++ b/src/server/services/service/maintenance/helpers/transformers/entity-to-summary.js
@@ -7,7 +7,7 @@ function entityToSummary({
   entity,
   deployedService,
   environment,
-  authedUser,
+  userSession,
   isFrontend
 }) {
   const serviceUrl = `https://${deployedService.service}.${deployedService.environment}.cdp-int.defra.cloud`
@@ -60,7 +60,7 @@ function entityToSummary({
       },
       {
         key: { text: 'Requested By' },
-        value: { text: authedUser?.displayName ?? noValue }
+        value: { text: userSession?.displayName ?? noValue }
       }
     ]
   }

--- a/src/server/services/service/maintenance/helpers/transformers/entity-to-summary.test.js
+++ b/src/server/services/service/maintenance/helpers/transformers/entity-to-summary.test.js
@@ -11,7 +11,7 @@ describe('#entityToSummary', () => {
     version: 'v1.0.0'
   }
   const mockEnvironment = 'Development'
-  const mockAuthedUser = { displayName: 'RoboCop' }
+  const mockuserSession = { displayName: 'RoboCop' }
   const mockServiceUrl = 'https://mock-service.dev.cdp-int.defra.cloud'
 
   test('Should return a summary with all fields populated for a frontend service', () => {
@@ -19,7 +19,7 @@ describe('#entityToSummary', () => {
       entity: mockEntity,
       deployedService: mockDeployedService,
       environment: mockEnvironment,
-      authedUser: mockAuthedUser,
+      userSession: mockuserSession,
       isFrontend: true
     })
 
@@ -52,7 +52,7 @@ describe('#entityToSummary', () => {
       entity: mockEntity,
       deployedService: mockDeployedService,
       environment: mockEnvironment,
-      authedUser: mockAuthedUser,
+      userSession: mockuserSession,
       isFrontend: false
     })
 
@@ -71,7 +71,7 @@ describe('#entityToSummary', () => {
       entity: mockEntity,
       deployedService: { ...mockDeployedService, version: null },
       environment: mockEnvironment,
-      authedUser: mockAuthedUser,
+      userSession: mockuserSession,
       isFrontend: true
     })
 
@@ -90,7 +90,7 @@ describe('#entityToSummary', () => {
       entity: mockEntity,
       deployedService: { service: 'mock-service', environment: 'dev' },
       environment: mockEnvironment,
-      authedUser: { displayName: null },
+      userSession: { displayName: null },
       isFrontend: true
     })
 

--- a/src/server/services/service/maintenance/helpers/transformers/shuttering-detail-to-summary.js
+++ b/src/server/services/service/maintenance/helpers/transformers/shuttering-detail-to-summary.js
@@ -7,7 +7,7 @@ import { renderTag } from '../../../../../common/helpers/view/render-tag.js'
 function shutteringDetailToSummary({
   isFrontend,
   shutteringDetail,
-  authedUser
+  userSession
 }) {
   return {
     classes: 'app-summary-list',
@@ -40,7 +40,7 @@ function shutteringDetailToSummary({
       },
       {
         key: { text: 'Requested By' },
-        value: { text: authedUser?.displayName ?? noValue }
+        value: { text: userSession?.displayName ?? noValue }
       }
     ]
   }

--- a/src/server/services/service/maintenance/helpers/transformers/shuttering-detail-to-summary.test.js
+++ b/src/server/services/service/maintenance/helpers/transformers/shuttering-detail-to-summary.test.js
@@ -11,7 +11,7 @@ describe('#shutteringDetailToSummary', () => {
         environment: 'prod',
         status: shutteringStatus.active
       },
-      authedUser: { displayName: 'B. A. Baracus' }
+      userSession: { displayName: 'B. A. Baracus' }
     })
 
     expect(result.rows).toEqual([
@@ -38,7 +38,7 @@ describe('#shutteringDetailToSummary', () => {
         environment: 'dev',
         status: shutteringStatus.shuttered
       },
-      authedUser: { displayName: 'RoboCop' }
+      userSession: { displayName: 'RoboCop' }
     })
 
     expect(result.rows).toEqual(
@@ -67,7 +67,7 @@ describe('#shutteringDetailToSummary', () => {
         environment: 'management',
         status: shutteringStatus.active
       },
-      authedUser: null
+      userSession: null
     })
 
     expect(result.rows).toEqual(

--- a/src/server/services/service/terminal/controllers/terminal-browser.js
+++ b/src/server/services/service/terminal/controllers/terminal-browser.js
@@ -12,7 +12,8 @@ const terminalBrowserController = {
       failAction: () => Boom.boomify(Boom.notFound())
     }
   },
-  handler: (request, h) => {
+  handler: async (request, h) => {
+    const userSession = await request.getUserSession()
     const params = request.params
     const serviceId = params.serviceId
     const environment = params.environment
@@ -26,7 +27,7 @@ const terminalBrowserController = {
     )
 
     try {
-      canLaunchTerminal(request.auth.credentials?.scope, environment)
+      canLaunchTerminal(userSession?.scope, environment)
     } catch (error) {
       request.yar.flash(sessionNames.globalValidationFailures, error.message)
 
@@ -36,8 +37,8 @@ const terminalBrowserController = {
     request.audit.send({
       event: 'terminal opened',
       user: {
-        id: request.auth?.credentials?.id,
-        name: request.auth?.credentials?.displayName
+        id: userSession?.id,
+        name: userSession?.displayName
       },
       terminal: {
         token,

--- a/src/server/teams/controllers/teams-list.js
+++ b/src/server/teams/controllers/teams-list.js
@@ -1,6 +1,5 @@
 import { fetchTeams } from '../helpers/fetch/fetch-teams.js'
 import { teamToEntityRow } from '../transformers/team-to-entity-row.js'
-import { provideAuthedUser } from '../../common/helpers/auth/pre/provide-authed-user.js'
 
 function belongsToTeam(userScopeUUIDs) {
   return (team) => ({
@@ -22,12 +21,11 @@ function sortByTeam(a, b) {
 
 const teamsListController = {
   options: {
-    id: 'teams',
-    pre: [provideAuthedUser]
+    id: 'teams'
   },
   handler: async (request, h) => {
-    const authedUser = request.pre.authedUser
-    const userScopeUUIDs = authedUser?.uuidScope ?? []
+    const userSession = await request.getUserSession()
+    const userScopeUUIDs = userSession?.uuidScope ?? []
 
     const { teams } = await fetchTeams()
 

--- a/src/server/test-suites/helpers/pre/provide-form-values.js
+++ b/src/server/test-suites/helpers/pre/provide-form-values.js
@@ -35,10 +35,9 @@ const provideFormValues = {
   method: async (request) => {
     const environmentOptions = []
     const runnerProfileOptions = []
+    const userSession = await request.getUserSession()
 
-    const authedUser = await request.getUserSession()
-
-    if (authedUser?.isAuthenticated) {
+    if (userSession?.isAuthenticated) {
       const isAdmin = await request.userIsAdmin()
       const entity = request.app.entity
       const userOwnsTestSuite = await request.userIsOwner(entity)

--- a/src/server/test-suites/list/controller.js
+++ b/src/server/test-suites/list/controller.js
@@ -1,17 +1,15 @@
 import { fetchTestSuites } from '../../common/helpers/fetch/fetch-entities.js'
 import { sortByOwner } from '../../common/helpers/sort/sort-by-owner.js'
 import { entityOwnerDecorator } from '../helpers/decorators/entity-owner-decorator.js'
-import { provideAuthedUser } from '../../common/helpers/auth/pre/provide-authed-user.js'
 import { testSuiteToEntityRow } from '../transformers/test-suite-to-entity-row.js'
 
 const testSuiteListController = {
   options: {
-    id: 'test-suites',
-    pre: [provideAuthedUser]
+    id: 'test-suites'
   },
   handler: async (request, h) => {
-    const authedUser = request.pre.authedUser
-    const userScopeUUIDs = authedUser?.uuidScope ?? []
+    const userSession = await request.getUserSession()
+    const userScopeUUIDs = userSession?.uuidScope ?? []
 
     const [testSuites] = await Promise.all([fetchTestSuites()])
 

--- a/src/server/test-suites/list/controller.test.js
+++ b/src/server/test-suites/list/controller.test.js
@@ -11,6 +11,10 @@ vi.mock('../../common/helpers/auth/pre/provide-authed-user.js')
 describe('testSuiteListController.handler', () => {
   let h
   let request
+  const mockGetUserSession = vi.fn().mockReturnValue({
+    isAuthenticated: true,
+    uuidScope: ['scope-1']
+  })
 
   beforeEach(() => {
     h = {
@@ -18,12 +22,7 @@ describe('testSuiteListController.handler', () => {
     }
 
     request = {
-      pre: {
-        authedUser: {
-          isAuthenticated: true,
-          uuidScope: ['scope-1']
-        }
-      }
+      getUserSession: mockGetUserSession
     }
   })
 
@@ -79,7 +78,10 @@ describe('testSuiteListController.handler', () => {
   })
 
   test('should return an empty view if no test suites are found and user is not authenticated', async () => {
-    request.pre.authedUser.isAuthenticated = false
+    mockGetUserSession.mockReturnValue({
+      isAuthenticated: false,
+      uuidScope: ['scope-1']
+    })
 
     fetchTestSuites.mockResolvedValue([])
     entityOwnerDecorator.mockReturnValue((testSuite) => testSuite) // Mocking decorator to return the same test suite

--- a/src/server/test-suites/test-runs/controllers/test-suite-run.js
+++ b/src/server/test-suites/test-runs/controllers/test-suite-run.js
@@ -3,21 +3,17 @@ import { runTest } from '../../helpers/fetch/run-test.js'
 import { buildErrorDetails } from '../../../common/helpers/build-error-details.js'
 
 import { testSuiteValidation } from '../../helpers/schema/test-suite-validation.js'
-import { provideAuthedUser } from '../../../common/helpers/auth/pre/provide-authed-user.js'
 import { getEnvironments } from '../../../common/helpers/environments/get-environments.js'
 import { fetchTestSuites } from '../../../common/helpers/fetch/fetch-entities.js'
 
 const triggerTestSuiteRunController = {
-  options: {
-    pre: [provideAuthedUser]
-  },
   handler: async (request, h) => {
     const payload = request.payload
     const { imageName, environment, profile } = request.payload
-    const authedUser = await request.getUserSession()
-    const userScopes = authedUser?.scope
+    const userSession = await request.getUserSession()
+    const userScopes = userSession?.scope
 
-    const teamIds = authedUser?.isAdmin ? [] : userScopes
+    const teamIds = userSession?.isAdmin ? [] : userScopes
     const testSuites = await fetchTestSuites({ teamIds })
 
     const testSuiteNames = testSuites.map((testSuite) => testSuite.name)
@@ -45,7 +41,7 @@ const triggerTestSuiteRunController = {
 
         request.audit.send({
           event: 'test run requested',
-          user: { id: authedUser.id, name: authedUser.displayName },
+          user: { id: userSession.id, name: userSession.displayName },
           testRun: {
             imageName,
             environment

--- a/src/server/utilities/controllers/libraries-list-controller.js
+++ b/src/server/utilities/controllers/libraries-list-controller.js
@@ -1,15 +1,11 @@
 import { fetchLibraries } from '../helpers/fetch/fetch-libraries.js'
-import { provideAuthedUser } from '../../common/helpers/auth/pre/provide-authed-user.js'
 import { buildUtilitiesTableData } from '../helpers/build-utilities-table-data.js'
 
 const librariesListController = {
-  options: {
-    pre: [provideAuthedUser]
-  },
   handler: async (request, h) => {
-    const authedUser = request.pre.authedUser
-    const isAuthenticated = authedUser?.isAuthenticated
-    const userScopeUUIDs = authedUser?.uuidScope ?? []
+    const userSession = await request.getUserSession()
+    const isAuthenticated = userSession?.isAuthenticated
+    const userScopeUUIDs = userSession?.uuidScope ?? []
 
     const libraries = await fetchLibraries()
 

--- a/src/server/utilities/controllers/templates-list-controller.js
+++ b/src/server/utilities/controllers/templates-list-controller.js
@@ -1,16 +1,14 @@
 import { fetchTemplates } from '../helpers/fetch/fetch-templates.js'
-import { provideAuthedUser } from '../../common/helpers/auth/pre/provide-authed-user.js'
 import { buildUtilitiesTableData } from '../helpers/build-utilities-table-data.js'
 
 const templatesListController = {
   options: {
-    id: 'utilities/templates',
-    pre: [provideAuthedUser]
+    id: 'utilities/templates'
   },
   handler: async (request, h) => {
-    const authedUser = request.pre.authedUser
-    const isAuthenticated = authedUser?.isAuthenticated
-    const userScopeUUIDs = authedUser?.uuidScope ?? []
+    const userSession = await request.getUserSession()
+    const isAuthenticated = userSession?.isAuthenticated
+    const userScopeUUIDs = userSession?.uuidScope ?? []
 
     const templates = await fetchTemplates()
 


### PR DESCRIPTION
- Remove pre provide-authed-user this is a little too magic
- Update variables to `userSession` rather than `authedUser`
- Switch out `request.auth.credentials` for the preferred fetch from the session `await request.getUserSession()` where everything is at the top level


## Of Note

This opens up this work to the next bit of work which would be to align `const userSession = await request.getUserSession()` return data so its the same as `request.auth.credentials` from `hapi`