### PR TITLE
CORE-1322: A few tweaks around permission audit

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.links.scm=https://github.com/DEFRA/cdp-portal-frontend
 sonar.links.issue=https://github.com/DEFRA/cdp-portal-frontend/issues
 
 sonar.sources=src/
-sonar.exclusions=src/**/*.test.js,src/__fixtures__/**/*,test-helpers/**/*,src/**/__file_snapshots__/**/*
+sonar.exclusions=src/**/*.test.js,src/__fixtures__/**/*,test-helpers/**/*,.vite,src/**/__file_snapshots__/**/*
 sonar.tests=src/
 sonar.test.inclusions=src/**/*.test.js
 

--- a/src/server/admin/audit/__file_snapshots__/Audit-page-list-view-page-renders-for-logged-in-admin-user-1.html
+++ b/src/server/admin/audit/__file_snapshots__/Audit-page-list-view-page-renders-for-logged-in-admin-user-1.html
@@ -318,9 +318,8 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 </div>
 
 
-
-      <article>
-        
+    <article>
+      
 
 
 
@@ -367,18 +366,18 @@ width="8%"        >
             Team
         </th>
 
-        <th id="duration" scope="col"
+        <th id="service" scope="col"
             class="app-entity-table__heading"
             data-testid="app-entity-table-header-6"
 width="10%"        >
-            Duration
+            Service
         </th>
 
-        <th id="service" scope="col"
+        <th id="duration" scope="col"
             class="app-entity-table__heading"
             data-testid="app-entity-table-header-7"
 width="10%"        >
-            Service
+            Duration
         </th>
 
         <th id="reason" scope="col"
@@ -509,27 +508,11 @@ width="15%"        >
 
 
 
-      <span data-testid="app-entity-text"
-      >Platform</span>
+      <a class="app-link"
+         href="/teams/platform"         data-testid="app-entity-link">
+        Platform
+      </a>
 
-
-</div>
-
-
-          </td>
-
-
-          <td headers="duration"
-              class="app-entity-table__cell"
-              data-label="Duration">
-              
-
-<div class="app-entity" data-testid="app-entity-6">
-
-
-
-      <span data-testid="app-entity-text"
-      >2 hours</span>
 
 
 </div>
@@ -543,12 +526,27 @@ width="15%"        >
               data-label="Service">
               
 
+<div class="app-entity" data-testid="app-entity-6">
+
+
+    <span class="app-entity-no-value">- - -</span>
+</div>
+
+
+          </td>
+
+
+          <td headers="duration"
+              class="app-entity-table__cell"
+              data-label="Duration">
+              
+
 <div class="app-entity" data-testid="app-entity-7">
 
 
 
       <span data-testid="app-entity-text"
-      >- - -</span>
+      >2 hours</span>
 
 
 </div>
@@ -674,11 +672,7 @@ width="15%"        >
 <div class="app-entity" data-testid="app-entity-4">
 
 
-
-      <span data-testid="app-entity-text"
-      >- - -</span>
-
-
+    <span class="app-entity-no-value">- - -</span>
 </div>
 
 
@@ -693,9 +687,27 @@ width="15%"        >
 <div class="app-entity" data-testid="app-entity-5">
 
 
+    <span class="app-entity-no-value">- - -</span>
+</div>
 
-      <span data-testid="app-entity-text"
-      >- - -</span>
+
+          </td>
+
+
+          <td headers="service"
+              class="app-entity-table__cell"
+              data-label="Service">
+              
+
+<div class="app-entity" data-testid="app-entity-6">
+
+
+
+      <a class="app-link"
+         href="/services/cdp-portal-backend"         data-testid="app-entity-link">
+        cdp-portal-backend
+      </a>
+
 
 
 </div>
@@ -709,31 +721,12 @@ width="15%"        >
               data-label="Duration">
               
 
-<div class="app-entity" data-testid="app-entity-6">
-
-
-
-      <span data-testid="app-entity-text"
-      >- - -</span>
-
-
-</div>
-
-
-          </td>
-
-
-          <td headers="service"
-              class="app-entity-table__cell"
-              data-label="Service">
-              
-
 <div class="app-entity" data-testid="app-entity-7">
 
 
 
       <span data-testid="app-entity-text"
-      >cdp-portal-backend</span>
+      >- - -</span>
 
 
 </div>
@@ -750,11 +743,7 @@ width="15%"        >
 <div class="app-entity" data-testid="app-entity-8">
 
 
-
-      <span data-testid="app-entity-text"
-      >- - -</span>
-
-
+    <span class="app-entity-no-value">- - -</span>
 </div>
 
 
@@ -859,11 +848,7 @@ width="15%"        >
 <div class="app-entity" data-testid="app-entity-4">
 
 
-
-      <span data-testid="app-entity-text"
-      >- - -</span>
-
-
+    <span class="app-entity-no-value">- - -</span>
 </div>
 
 
@@ -878,9 +863,27 @@ width="15%"        >
 <div class="app-entity" data-testid="app-entity-5">
 
 
+    <span class="app-entity-no-value">- - -</span>
+</div>
 
-      <span data-testid="app-entity-text"
-      >- - -</span>
+
+          </td>
+
+
+          <td headers="service"
+              class="app-entity-table__cell"
+              data-label="Service">
+              
+
+<div class="app-entity" data-testid="app-entity-6">
+
+
+
+      <a class="app-link"
+         href="/services/cdp-postgres-service"         data-testid="app-entity-link">
+        cdp-postgres-service
+      </a>
+
 
 
 </div>
@@ -894,31 +897,12 @@ width="15%"        >
               data-label="Duration">
               
 
-<div class="app-entity" data-testid="app-entity-6">
-
-
-
-      <span data-testid="app-entity-text"
-      >- - -</span>
-
-
-</div>
-
-
-          </td>
-
-
-          <td headers="service"
-              class="app-entity-table__cell"
-              data-label="Service">
-              
-
 <div class="app-entity" data-testid="app-entity-7">
 
 
 
       <span data-testid="app-entity-text"
-      >cdp-postgres-service</span>
+      >- - -</span>
 
 
 </div>
@@ -935,11 +919,7 @@ width="15%"        >
 <div class="app-entity" data-testid="app-entity-8">
 
 
-
-      <span data-testid="app-entity-text"
-      >- - -</span>
-
-
+    <span class="app-entity-no-value">- - -</span>
 </div>
 
 
@@ -1046,7 +1026,7 @@ width="15%"        >
 
 
       <span data-testid="app-entity-text"
-      >- - -</span>
+      >Non-Admin User</span>
 
 
 </div>
@@ -1064,27 +1044,11 @@ width="15%"        >
 
 
 
-      <span data-testid="app-entity-text"
-      >Platform</span>
+      <a class="app-link"
+         href="/teams/platform"         data-testid="app-entity-link">
+        Platform
+      </a>
 
-
-</div>
-
-
-          </td>
-
-
-          <td headers="duration"
-              class="app-entity-table__cell"
-              data-label="Duration">
-              
-
-<div class="app-entity" data-testid="app-entity-6">
-
-
-
-      <span data-testid="app-entity-text"
-      >- - -</span>
 
 
 </div>
@@ -1096,6 +1060,21 @@ width="15%"        >
           <td headers="service"
               class="app-entity-table__cell"
               data-label="Service">
+              
+
+<div class="app-entity" data-testid="app-entity-6">
+
+
+    <span class="app-entity-no-value">- - -</span>
+</div>
+
+
+          </td>
+
+
+          <td headers="duration"
+              class="app-entity-table__cell"
+              data-label="Duration">
               
 
 <div class="app-entity" data-testid="app-entity-7">
@@ -1120,11 +1099,7 @@ width="15%"        >
 <div class="app-entity" data-testid="app-entity-8">
 
 
-
-      <span data-testid="app-entity-text"
-      >- - -</span>
-
-
+    <span class="app-entity-no-value">- - -</span>
 </div>
 
 
@@ -1136,8 +1111,7 @@ width="15%"        >
 
 </article>
 
-      </article>
-
+    </article>
 
     </section>
   </div>

--- a/src/server/admin/audit/audit.test.js
+++ b/src/server/admin/audit/audit.test.js
@@ -76,7 +76,7 @@ describe('Audit page', () => {
           user: {
             email: 'non-admin.user@oidc.mock',
             github: 'nonadminuser',
-            name: 'Non-Admin User',
+            displayName: 'Non-Admin User',
             createdAt: '2024-11-11T13:51:00.028Z',
             scopes: [
               {

--- a/src/server/admin/audit/controllers/audit-list.js
+++ b/src/server/admin/audit/controllers/audit-list.js
@@ -7,7 +7,7 @@ const auditListController = {
   },
   handler: async (request, h) => {
     const audits = await fetchAudit()
-    const rows = audits.map((audit) => transformAuditToRow(audit))
+    const rows = audits.map(transformAuditToRow)
 
     return h.view('admin/audit/views/audit-list', {
       pageTitle: 'Audit',
@@ -18,8 +18,8 @@ const auditListController = {
           { id: 'performedAt', text: 'Performed At', width: '12' },
           { id: 'user', text: 'User', width: '10' },
           { id: 'team', text: 'Team', width: '8' },
-          { id: 'duration', text: 'Duration', width: '10' },
           { id: 'service', text: 'Service', width: '10' },
+          { id: 'duration', text: 'Duration', width: '10' },
           { id: 'reason', text: 'Reason', width: '15' }
         ],
         rows,

--- a/src/server/admin/audit/transformers/audit-to-row.js
+++ b/src/server/admin/audit/transformers/audit-to-row.js
@@ -11,31 +11,13 @@ function tagMap(action) {
     case 'TerminalAccess':
       return 'govuk-tag--blue'
     default:
-      break
+      return 'govuk-tag--grey'
   }
 }
 
 export function transformAuditToRow(audit) {
-  const durationEntity =
-    audit.details?.startDate && audit.details?.endDate
-      ? {
-          entity: {
-            kind: 'text',
-            value: formatDistanceStrict(
-              audit.details.startDate,
-              audit.details.endDate,
-              {
-                includeSeconds: true
-              }
-            )
-          }
-        }
-      : {
-          entity: {
-            kind: 'text',
-            value: noValue
-          }
-        }
+  const { startDate, endDate } = audit.details
+  const hasDuration = startDate && endDate
 
   return {
     cells: [
@@ -43,7 +25,7 @@ export function transformAuditToRow(audit) {
         headers: 'performedBy',
         entity: {
           kind: 'text',
-          value: audit.performedBy?.displayName ?? noValue
+          value: audit.performedBy?.displayName
         }
       },
       {
@@ -65,32 +47,39 @@ export function transformAuditToRow(audit) {
         headers: 'user',
         entity: {
           kind: 'text',
-          value: audit.details?.user?.displayName ?? noValue
+          value: audit.details?.user?.displayName
         }
       },
       {
         headers: 'team',
         entity: {
-          kind: 'text',
-          value: audit.details?.team?.name ?? noValue
+          kind: 'link',
+          url: `/teams/${audit.details?.team?.name?.toLowerCase()}`,
+          value: audit.details?.team?.name
         }
-      },
-      {
-        headers: 'duration',
-        ...durationEntity
       },
       {
         headers: 'service',
         entity: {
+          kind: 'link',
+          url: `/services/${audit.details?.service?.toLowerCase()}`,
+          value: audit.details?.service
+        }
+      },
+      {
+        headers: 'duration',
+        entity: {
           kind: 'text',
-          value: audit.details?.service ?? noValue
+          value: hasDuration
+            ? formatDistanceStrict(startDate, endDate, { includeSeconds: true })
+            : noValue
         }
       },
       {
         headers: 'reason',
         entity: {
           kind: 'text',
-          value: audit.details?.reason ?? noValue
+          value: audit.details?.reason
         }
       }
     ]

--- a/src/server/admin/audit/views/audit-list.njk
+++ b/src/server/admin/audit/views/audit-list.njk
@@ -8,11 +8,9 @@
       intro: "Audit details for BreakGlass users"
     }) }}
 
-
-      <article>
-        {{ appEntityTable(tableData) }}
-      </article>
-
+    <article>
+      {{ appEntityTable(tableData) }}
+    </article>
   {% endcall %}
 {% endblock %}
 

--- a/src/server/common/components/button/_button.scss
+++ b/src/server/common/components/button/_button.scss
@@ -66,6 +66,22 @@ $shadow-opacity-light: 0.4;
   }
 }
 
+.app-button--significant {
+  background-color: govuk-colour("blue");
+  color: govuk-colour("white");
+  box-shadow: 0 2px 0 rgba(12, 45, 74, $shadow-opacity);
+
+  &:hover {
+    background-color: govuk-shade(govuk-colour("blue"), 20%);
+  }
+
+  &:link,
+  &:active,
+  &:visited {
+    color: govuk-colour("white");
+  }
+}
+
 .app-button--destructive {
   background-color: govuk-colour("red");
   color: govuk-colour("white");

--- a/src/server/common/components/entity-table/_entity-table.scss
+++ b/src/server/common/components/entity-table/_entity-table.scss
@@ -166,7 +166,7 @@ $min-grid-cell-width: 100px;
     color: govuk-colour("dark-grey");
 
     .app-entity-table__cell {
-      padding-left: govuk-spacing(9);
+      padding-left: govuk-spacing(2);
     }
   }
 

--- a/src/server/services/service/terminal/__file_snapshots__/Service-Terminal-page-page-renders-for-with-prod-terminal-button-for-admin-user-with-break-glass-1.html
+++ b/src/server/services/service/terminal/__file_snapshots__/Service-Terminal-page-page-renders-for-with-prod-terminal-button-for-admin-user-with-break-glass-1.html
@@ -1,0 +1,870 @@
+<!DOCTYPE html>
+<html lang="en" class="govuk-template govuk-template--rebranded">
+  <head>
+    <meta charset="utf-8">
+    <title>  mock-service-with-terminal - Terminal | Core Delivery Platform - Portal
+</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#1d70b8">
+
+
+          <link rel="icon" sizes="48x48" href="/.public/assets/images/favicon.ico">
+      <link rel="icon" sizes="any" href="/.public/assets/images/favicon.svg" type="image/svg+xml">
+      <link rel="mask-icon" href="/.public/assets/images/govuk-icon-mask.svg" color="#1d70b8">
+      <link rel="apple-touch-icon" href="/.public/assets/images/govuk-icon-180.png">
+      <link rel="manifest" href="/.public/assets/manifest.json">
+
+
+  <link href="/.public/stylesheets/application.css" rel="stylesheet">
+    <meta name="service-version" content="0.1.0">
+    <meta name="service-environment" content="test">
+
+  </head>
+  <body class="govuk-template__body">
+    <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
+
+  
+  <div>
+    <a href="#main-content" class="govuk-skip-link app-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+
+  </div>
+
+
+  
+
+
+<header class="app-service-header" role="banner" data-testid="app-service-header">
+  <div class="app-service-header__container app-service-header__container--full-width">
+    <div class="app-service-header__content">
+      <a href="/"
+         class="app-service-header__link app-service-header__service-name"
+         data-testid="app-service-header-service-name">
+        Core Delivery Platform - Portal
+      </a>
+
+
+    </div>
+    <div class="app-service-header__actions">
+        
+<svg class="app-icon app-user-icon app-icon--tiny"
+     xmlns="http://www.w3.org/2000/svg" width="38" height="38" viewBox="0 0 38 38" role="img"
+     aria-label="User">
+  <g fill-rule="evenodd">
+    <circle cx="19" cy="12" r="8" />
+    <path
+      d="M19 25c6.1827536 0 11.6757612 2.1477482 15.1454151 5.4733482C30.6757769 35.0468378 25.1827625 38 19 38c-6.1827625 0-11.6757769-2.9531622-15.14542996-7.5258733C7.32458451 27.147613 12.8174409 25 19 25Z" />
+  </g>
+</svg>
+
+        <span data-testid="app-login-username">
+          B. A. Baracus
+        </span>
+
+      <span class="app-service-header__login app-service-header__login--logged-in">
+        <a href="/logout"
+           class="app-service-header__link app-service-header__login-link"
+           data-testid="app-login-link">
+            Sign out
+        </a>
+      </span>
+
+    </div>
+  </div>
+</header>
+
+
+  
+  <div class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+      <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+
+      
+        <nav aria-label="Menu" class="govuk-service-navigation__wrapper app-navigation">
+          <button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle" aria-controls="navigation" hidden>
+            Menu
+          </button>
+
+          <ul class="govuk-service-navigation__list" id="navigation" >
+
+            
+              
+              <li class="govuk-service-navigation__item">
+                  <a class="govuk-service-navigation__link" href="/" data-testid="nav-home">
+                                    
+Home
+                  </a>
+              </li>
+
+              
+              <li class="govuk-service-navigation__item">
+                  <a class="govuk-service-navigation__link" href="/documentation" data-testid="nav-documentation">
+                                    
+Documentation
+                  </a>
+              </li>
+
+              
+              <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
+                  <a class="govuk-service-navigation__link" href="/services" aria-current="page" data-testid="nav-services">
+                                    
+                  <strong class="govuk-service-navigation__active-fallback">Services</strong>
+
+                  </a>
+              </li>
+
+              
+              <li class="govuk-service-navigation__item">
+                  <a class="govuk-service-navigation__link" href="/test-suites" data-testid="nav-test-suites">
+                                    
+Test suites
+                  </a>
+              </li>
+
+              
+              <li class="govuk-service-navigation__item">
+                  <a class="govuk-service-navigation__link" href="/utilities/templates" data-testid="nav-utilities">
+                                    
+Utilities
+                  </a>
+              </li>
+
+              
+              <li class="govuk-service-navigation__item">
+                  <a class="govuk-service-navigation__link" href="/teams" data-testid="nav-teams">
+                                    
+Teams
+                  </a>
+              </li>
+
+              
+              <li class="govuk-service-navigation__item">
+                  <a class="govuk-service-navigation__link" href="/deployments" data-testid="nav-deployments">
+                                    
+Deployments
+                  </a>
+              </li>
+
+              
+              <li class="govuk-service-navigation__item">
+                  <a class="govuk-service-navigation__link" href="/running-services" data-testid="nav-running-services">
+                                    
+Running Services
+                  </a>
+              </li>
+
+              <ul class="app-navigation__actions">
+      
+
+
+
+<li
+  class="govuk-service-navigation__item">
+    <a class="govuk-service-navigation__link" href="/deploy-service" data-testid="nav-deploy-service">
+      Deploy Service
+    </a>
+</li>
+
+
+      
+
+
+
+<li
+  class="govuk-service-navigation__item">
+    <a class="govuk-service-navigation__link" href="/create" data-testid="nav-create">
+      Create
+    </a>
+</li>
+
+
+
+      <ul class="app-navigation__admin">
+          
+
+
+
+<li
+  class="govuk-service-navigation__item">
+    <a class="govuk-service-navigation__link" href="/admin" data-testid="nav-admin">
+      Admin
+    </a>
+</li>
+
+
+      </ul>
+  </ul>
+</ul>
+        </nav>
+    </div>
+
+    </div>
+
+  </div>
+
+
+      <div class="govuk-width-container">
+  
+  <div
+  class="app-banner app-banner--hidden"
+  tabindex="-1"
+  role="alert"
+  data-testid="app-banner"
+data-js="app-client-notifications">
+  <p class="app-banner__content"
+data-js="app-client-notifications-content"     data-testid="app-banner-content"></p>
+</div>
+
+
+
+
+    
+<nav class="app-breadcrumbs" data-testid="app-breadcrumbs" aria-label="Breadcrumb">
+  <ol class="app-breadcrumbs__list">
+        <li class="app-breadcrumbs__list-item" data-testid="app-breadcrumbs-list-item">
+          <a class="app-breadcrumbs__link" href="/services"
+             data-testid="app-breadcrumbs-link">Services</a>
+        </li>
+        <li class="app-breadcrumbs__list-item" data-testid="app-breadcrumbs-list-item">
+          <a class="app-breadcrumbs__link" href="/services/mock-service-with-terminal"
+             data-testid="app-breadcrumbs-link">mock-service-with-terminal</a>
+        </li>
+        <li class="app-breadcrumbs__list-item app-breadcrumbs__list-item--current" aria-current="page"
+            data-testid="app-breadcrumbs-list-item">Terminal</li>
+  </ol>
+</nav>
+
+        <main class="govuk-main-wrapper app-main-wrapper" id="main-content">
+
+  <div class="govuk-!-margin-top-2">
+    <span class="govuk-caption-l" data-testid="app-page-heading-caption">Terminal</span>
+
+  <div class="app-page-heading">
+    <h1 class="app-page-heading--title" data-testid="app-page-heading-title">mock-service-with-terminal</h1>
+
+
+  </div>
+</div>
+
+
+  <div>
+    <ul class="govuk-list govuk-!-margin-bottom-2">
+        <li>
+
+
+<div
+  class="app-warning govuk-!-margin-top-0 govuk-!-margin-bottom-0"
+  tabindex="-1"
+  role="alert"
+  data-testid="app-warning">
+
+  <svg class="app-icon app-warning-icon app-icon--small"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Warning">
+  <path fill-rule="nonzero"
+        d="M23.9476157 36.7259786c.9649347 0 1.7226097-.2577461 2.2730249-.7732384.5504152-.5154923.8256227-1.2557058.8256227-2.2206406 0-.9649347-.267236-1.7320996-.8017081-2.3014946-.5344722-.569395-1.2841756-.8540925-2.2491104-.8540925-.9649347 0-1.7226097.2810913-2.2730249.843274-.5504152.5618031-.8256227 1.3253618-.8256227 2.2906761 0 .9649348.267236 1.7087545.8017081 2.2314591.5344722.5227046 1.2841756.7840569 2.2491104.7840569Zm.1867615-9.9644128c.7645077 0 1.3840095-.2397153 1.8585054-.7191459.4744958-.479051.7117437-1.112408.7117437-1.9000711V14.0071174c0-.7508422-.2406643-1.365599-.7219928-1.8442704-.480949-.4786714-1.1036774-.7180071-1.8681851-.7180071-.726548 0-1.3401661.2393357-1.8408541.7180071-.5003084.4786714-.7504626 1.0934282-.7504626 1.8442704v10.1352314c0 .7876631.2535706 1.4210201.7607117 1.9000711.5071412.4794306 1.1239858.7191459 1.8505338.7191459ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.94908659-5.46011862 5.12683274-7.64583629 2.17812574-2.18533808 4.72635823-3.90282325 7.64469753-5.15245552C17.549134.62500593 20.6595492 0 23.9624199 0c3.3165362 0 6.4385291.62348754 9.3659787 1.87046263 2.9278292 1.24697509 5.4789086 2.9608541 7.6532384 5.14163701 2.1747094 2.18116252 3.888019 4.73432976 5.1399288 7.65950176C47.3738553 17.597153 48 20.7214235 48 24.0444128c0 3.3199526-.6250059 6.4334045-1.8750178 9.3403559-1.2496323 2.9069513-2.9671174 5.4460735-5.1524555 7.6173665-2.1857177 2.1716726-4.7375564 3.8808067-7.655516 5.1274022C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+
+
+  <span class="app-warning__content" data-testid="app-warning-content">
+                <a class="app-link app-link--underline"
+               href="https://portal-test.cdp-int.defra.cloud"
+               target="_blank" rel="noopener noreferrer">https://portal-test.cdp-int.defra.cloud</a> is currently shuttered.              To unshutter go to the
+              <a class="app-link app-link--underline"
+                 href="/services/mock-service-with-terminal/maintenance">Maintenance</a> page
+
+  </span>
+</div>
+
+        </li>
+    </ul>
+  </div>
+
+
+<div class="app-tabs"
+     data-js="app-tabs">
+    <ul class="app-tabs__list" data-testid="app-tabs-list" role="tablist" aria-label="Service tabs">
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-about">
+
+
+          <a id="tab-about"
+             class="app-tabs__tab"
+             href="/services/mock-service-with-terminal"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-about"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
+            About
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-automations">
+
+
+          <a id="tab-automations"
+             class="app-tabs__tab"
+             href="/services/mock-service-with-terminal/automations"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-automations"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-automations">
+            Automations
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-maintenance">
+
+
+          <a id="tab-maintenance"
+             class="app-tabs__tab"
+             href="/services/mock-service-with-terminal/maintenance"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-maintenance"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
+            Maintenance
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-proxy">
+
+
+          <a id="tab-proxy"
+             class="app-tabs__tab"
+             href="/services/mock-service-with-terminal/proxy"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-proxy"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
+            Proxy
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-resources">
+
+
+          <a id="tab-resources"
+             class="app-tabs__tab"
+             href="/services/mock-service-with-terminal/resources"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-resources"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-resources">
+            Resources
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-secrets">
+
+
+          <a id="tab-secrets"
+             class="app-tabs__tab"
+             href="/services/mock-service-with-terminal/secrets"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-secrets"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
+            Secrets
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item app-tabs__list-item--selected"
+            data-testid="app-tabs-list-item-terminal app-tabs-list-item--selected">
+
+
+          <a id="tab-terminal"
+             class="app-tabs__tab"
+             href="/services/mock-service-with-terminal/terminal"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-terminal"
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-terminal">
+            Terminal
+          </a>
+        </li>
+    </ul>
+
+      <section id="tab-panel-terminal"
+               class="app-tabs__panel"
+               role="tabpanel"
+               aria-labelledby="tab-terminal"
+               data-testid="app-tabs-panel">
+          <section class="govuk-!-margin-top-6">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third-from-desktop-wide">
+
+        <section class="govuk-!-margin-bottom-6">
+          <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Terminal</h2>
+          <p class="govuk-!-margin-right-2">
+            Welcome to the CDP terminal for mock-service-with-terminal. Launch a short-lived terminal in an environment
+            with the same permissions, visibility and security as your service.
+          </p>
+        </section>
+
+        <article class="govuk-!-margin-bottom-6">
+
+<section class="app-summary-item">
+  <header class="app-summary-item__header">
+    <span class="app-summary-item__icon"><svg class="app-icon app-terminal app-icon--small"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Terminal">
+  <path fill-rule="nonzero"
+        d="M4.8 43c-1.32 0-2.45-.4651042-3.39-1.3953125C.47 40.6744792 0 39.55625 0 38.25V9.75c0-1.30625.47-2.42447917 1.41-3.3546875C2.35 5.46510417 3.48 5 4.8 5h38.4c1.32 0 2.45.46510417 3.39 1.3953125C47.53 7.32552083 48 8.44375 48 9.75v28.5c0 1.30625-.47 2.4244792-1.41 3.3546875C45.65 42.5348958 44.52 43 43.2 43H4.8Zm0-4.75h38.4v-28H4.8v28Zm8.4-2.375L9.84 32.55l6.18-6.175L9.78 20.2l3.42-3.325 9.6 9.5-9.6 9.5Zm10.8 0v-4.75h14.4v4.75H24Z" />
+</svg>
+</span>
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Launch a terminal</h2>
+  </header>
+  <p class="app-summary-item__intro">
+    Launch a secure terminal, as your service in an environment.
+  </p>
+  
+              <table class="govuk-table app-table app-table--inverse govuk-!-margin-bottom-4" data-testid="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Environment</th>
+      <th scope="col" class="govuk-table__header">Action</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Infra-dev</td>
+      <td class="govuk-table__cell">    <form method="post" action="/services/mock-service-with-terminal/terminal/infra-dev" target="_blank">
+      <input type="hidden" name="csrfToken" value="test-token" />
+
+
+      <button type="submit" class="govuk-button app-button app-button--primary app-button--small" data-module="govuk-button">
+  Launch
+</button>
+    </form>
+</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Management</td>
+      <td class="govuk-table__cell">    <form method="post" action="/services/mock-service-with-terminal/terminal/management" target="_blank">
+      <input type="hidden" name="csrfToken" value="test-token" />
+
+
+      <button type="submit" class="govuk-button app-button app-button--primary app-button--small" data-module="govuk-button">
+  Launch
+</button>
+    </form>
+</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Dev</td>
+      <td class="govuk-table__cell">    <form method="post" action="/services/mock-service-with-terminal/terminal/dev" target="_blank">
+      <input type="hidden" name="csrfToken" value="test-token" />
+
+
+      <button type="submit" class="govuk-button app-button app-button--primary app-button--small" data-module="govuk-button">
+  Launch
+</button>
+    </form>
+</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Test</td>
+      <td class="govuk-table__cell">    <form method="post" action="/services/mock-service-with-terminal/terminal/test" target="_blank">
+      <input type="hidden" name="csrfToken" value="test-token" />
+
+
+      <button type="submit" class="govuk-button app-button app-button--primary app-button--small" data-module="govuk-button">
+  Launch
+</button>
+    </form>
+</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Perf-test</td>
+      <td class="govuk-table__cell">    <form method="post" action="/services/mock-service-with-terminal/terminal/perf-test" target="_blank">
+      <input type="hidden" name="csrfToken" value="test-token" />
+
+
+      <button type="submit" class="govuk-button app-button app-button--primary app-button--small" data-module="govuk-button">
+  Launch
+</button>
+    </form>
+</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Prod</td>
+      <td class="govuk-table__cell">    <form method="post" action="/services/mock-service-with-terminal/terminal/prod" target="_blank">
+      <input type="hidden" name="csrfToken" value="test-token" />
+
+
+      <button type="submit" class="govuk-button app-button app-button--primary app-button--small app-button--significant" data-module="govuk-button">
+  Launch
+</button>
+    </form>
+</td>
+    </tr>
+  </tbody>
+</table>
+
+
+
+</section>
+        </article>
+      </div>
+
+      <div class="govuk-grid-column-one-third-from-desktop-wide">
+
+
+
+
+<div
+  class="app-info govuk-!-margin-top-0"
+  tabindex="-1"
+  role="alert"
+  data-testid="app-info">
+
+  <svg class="app-icon app-info-icon app-icon--small"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Info">
+  <path fill-rule="nonzero"
+        d="M24.138363 35.9288256c.6244365 0 1.1513167-.2180783 1.5806406-.6542349.4293238-.4361565.6439857-.9772716.6439857-1.6233451v-9.6797154c0-.6092526-.2156109-1.1315776-.6468327-1.566975-.4308422-.435777-.9527877-.6536655-1.5658363-.6536655-.6130487 0-1.1471412.2178885-1.6022776.6536655-.455516.4353974-.683274.9577224-.683274 1.566975v9.6797154c0 .6460735.2228232 1.1871886.6684697 1.6233451.4456465.4361566.9806881.6542349 1.6051246.6542349Zm-.1679715-17.4234875c.7789323 0 1.4198813-.2448399 1.9228469-.7345196.5029656-.4896797.7544484-1.1144958.7544484-1.8744484 0-.8780071-.2501542-1.5546382-.7504626-2.0298932-.5003084-.4756347-1.1386002-.713452-1.9148754-.713452-.8613049 0-1.5244603.234401-1.9894662.7032029-.465006.4688019-.6975089 1.1230367-.6975089 1.9627046 0 .8077817.2511032 1.4574614.7533096 1.9490391.5022064.4915777 1.1427758.7373666 1.9217082.7373666ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.95231317-5.45954922 5.13651245-7.64412811 2.18419929-2.18457888 4.73224202-3.90225385 7.64412812-5.15302491C17.5521708.62538553 20.6595492 0 23.9624199 0c3.3165362 0 6.4394781.62367734 9.3688257 1.87103203 2.9293475 1.24735468 5.4802372 2.9602847 7.652669 5.13879003 2.1724318 2.17888494 3.8847924 4.73205224 5.1370818 7.65950174C47.3736655 17.5963938 48 20.7214235 48 24.0444128c0 3.3199526-.6253855 6.4303677-1.8761566 9.3312456-1.250771 2.9004982-2.968446 5.4396204-5.1530249 7.6173665-2.1845789 2.1777462-4.7358482 3.889917-7.6538078 5.1365125C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+
+
+  <span class="app-info__content" data-testid="app-info-content">
+              <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Tooling</h2>
+
+          <p class="govuk-!-margin-bottom-2">
+            A number of tools are available to you in the CDP terminal.
+          </p>
+
+          <ul class="govuk-list">
+            <li>
+              <div class="app-!-layout-flex-start">
+                <svg class="app-icon app-icon--small govuk-!-margin-right-1" width="48" height="48"
+     viewBox="0 0 48 48"
+     role="img" aria-label="Curl logo">
+  <g fill="none" fill-rule="nonzero">
+    <path fill="#0C544C"
+          d="M40.1716969 11.22957271c-.8539659 0-1.5449235-.66943831-1.5449235-1.49417513 0-.82591446.6909576-1.49417512 1.5449235-1.49417512.8527483 0 1.5449236.66826066 1.5449236 1.49417512 0 .82473682-.6921753 1.49417513-1.5449236 1.49417513M24.8283031 36.7587745c-.853966 0-1.5449236-.6694353-1.5449236-1.4941721 0-.8259144.6909576-1.4941751 1.5449236-1.4941751.8527483 0 1.5437059.6682607 1.5437059 1.4941751 0 .8247368-.6909576 1.4941721-1.5437059 1.4941721M40.1716969 7c-1.5619549 0-2.8283031 1.22475049-2.8283031 2.73539758 0 .32236443.0839364.62237469.1897685.90944592L24.2650734 32.6386204C22.9829115 32.8986299 22 33.9469053 22 35.2646024 22 36.7752465 23.2663481 38 24.8283031 38c1.5607373 0 2.8270854-1.2247535 2.8270854-2.7353976 0-.3035432-.0839363-.5811993-.1776045-.8541508l13.3349939-22.06554394C42.0560157 12.0566618 43 11.02603293 43 9.73539758 43 8.22475049 41.7336488 7 40.1716969 7" />
+    <path fill="#073551"
+          d="M29.1718609 11.22957271c-.8539133 0-1.5448308-.66943831-1.5448308-1.49417513 0-.82591446.6909175-1.49417512 1.5448308-1.49417512.8526989 0 1.5436164.66826066 1.5436164 1.49417512 0 .82473682-.6909175 1.49417513-1.5436164 1.49417513M13.82814221 36.7587745c-.85270199 0-1.54483396-.6694353-1.54483396-1.4941721 0-.8259144.69213197-1.4941751 1.54483396-1.4941751.85391332 0 1.54483079.6682607 1.54483079 1.4941751 0 .8247368-.69091747 1.4941721-1.54483079 1.4941721M29.1718609 7c-1.5630788 0-2.8281391 1.22475049-2.8281391 2.73539758 0 .32236443.0839315.62237469.1897606.90944592L13.26616274 32.6386204C11.98285449 32.8986299 11 33.9469053 11 35.2646024 11 36.7752465 12.26627781 38 13.82814221 38c1.56186129 0 2.82813909-1.2247535 2.82813909-2.7353976 0-.3035432-.0839315-.5811993-.1775973-.8541508l13.3342238-22.06554394C31.0560704 12.0566618 32 11.02603293 32 9.73539758 32 8.22475049 30.7325077 7 29.1718609 7M8 16.36128927c.90451584 0 1.63871073.73419493 1.63871073 1.63871073 0 .9045158-.73419489 1.6387074-1.63871073 1.6387074-.9058074 0-1.63871073-.7341916-1.63871073-1.6387074 0-.9045158.73290333-1.63871073 1.63871073-1.63871073M8 21c1.65677277 0 3-1.3432272 3-3 0-.3316142-.09032342-.6374203-.18967786-.9367751C10.41290438 15.87225653 9.32387032 15 8 15c-.21161458 0-.39742106.07870928-.5974215.12128786C6.04258079 15.40516052 5 16.55483851 5 18c0 1.6567728 1.34322393 3 3 3M6.36128927 28c0-.9058074.73419489-1.6387107 1.63871073-1.6387107.90451584 0 1.63871073.7329033 1.63871073 1.6387107 0 .9045158-.73419489 1.6374192-1.63871073 1.6374192-.90451584 0-1.63871073-.7329034-1.63871073-1.6374192M11 28c0-.3329024-.09032342-.6374203-.18967786-.9367751C10.41290438 25.8722598 9.32516189 25 8 25c-.21161458 0-.39742106.0787093-.5974215.1199996C6.04258079 25.4051605 5 26.5548385 5 28c0 1.6554845 1.34322393 3 3 3 1.65677277 0 3-1.3445155 3-3" />
+  </g>
+</svg>
+
+                <strong class="govuk-!-margin-right-1">Curl</strong>
+                <a class="app-link" href="https://curl.se"
+                   target="_blank" rel="noopener noreferrer">
+                  https://curl.se</a>
+              </div>
+            </li>
+            <li>
+              <div class="app-!-layout-flex-start">
+                <svg class="app-icon app-icon--small govuk-!-margin-right-1" width="48" height="48"
+     viewBox="0 0 48 48"
+     role="img" aria-label="Aws Logo">
+  <g fill="none" fill-rule="evenodd">
+    <path fill="#252F3E" fill-rule="nonzero"
+          d="M12.8011356 20.6419194c0 .6029878.0651721 1.0918968.1792233 1.4504301.1303442.3585333.2932745.7496605.5213769 1.1733816.0814651.1303757.1140512.2607515.1140512.3748302 0 .1629697-.0977582.3259394-.3095676.488909l-1.0264607.6844727c-.1466373.0977818-.2932745.1466727-.4236187.1466727-.1629303 0-.3258606-.0814849-.4887909-.2281576-.2281023-.2444545-.4236187-.5052059-.586549-.7659574-.1629302-.2770485-.3258605-.5866908-.5050838-.9615211-1.27085616 1.499321-2.86757287 2.2489815-4.79015013 2.2489815-1.36861432 0-2.46024718-.3911272-3.25860553-1.1733817-.79835835-.7822544-1.20568404-1.8252603-1.20568404-3.1290176 0-1.3852422.48879082-2.50973292 1.48266551-3.3571752.99387469-.84744228 2.31360992-1.27116342 3.99179177-1.27116342.55396294 0 1.12421891.0488909 1.72706093.13037573.60284202.08148484 1.22197707.21186057 1.87369819.35853328V15.6224536c0-1.23856949-.26068845-2.10230874-.76577231-2.60751471-.52137689-.50520598-1.40120038-.74966048-2.65576351-.74966048-.57025596 0-1.15680496.06518786-1.75964698.21186057-.60284202.1466727-1.18939102.32593934-1.75964698.55409687-.26068845.11407877-.45620478.17926664-.57025597.21186057-.11405119.03259394-.19551633.0488909-.26068844.0488909-.22810239 0-.34215358-.16296966-.34215358-.50520597v-.79855138c0-.26075147.03258605-.45631508.11405119-.57039385.08146514-.11407876.22810239-.22815753.45620477-.3422363.57025597-.2933454 1.25456313-.53779991 2.05292149-.73336351.79835835-.21186057 1.64559579-.30964238 2.54171231-.30964238 1.93887028 0 3.35636371.44001811 4.26877321 1.32005433.8961165.88003621 1.3523213 2.2163875 1.3523213 4.00905387v5.28021727h.0325861Zm-6.61496924 2.477139c.53766991 0 1.09163285-.0977818 1.67818184-.2933454.586549-.1955636 1.10792588-.5540969 1.54783763-1.0430059.26068844-.3096424.45620477-.6518787.55396294-1.0430059.09775813-.3911272.16293023-.86373923.16293023-1.4178361v-.68447261c-.47249776-.11407877-.97758162-.21186058-1.4989585-.27704844-.52137688-.06518787-1.02646074-.0977818-1.5315446-.0977818-1.09163285 0-1.8899912.21186057-2.42766111.65187867-.53766992.44001811-.79835836 1.05930286-.79835836 1.87415118 0 .7659575.19551633 1.3363513.60284202 1.7274785.39103267.4074242.96128863.6029878 1.71076791.6029878Zm13.08330114 1.7600724c-.2932745 0-.4887908-.0488909-.619135-.1629696-.1303442-.0977818-.2443954-.3259394-.3421536-.6355818l-3.8288615-12.59755541c-.0977581-.32593934-.1466372-.5377999-.1466372-.65187867 0-.26075148.1303442-.40742418.3910326-.40742418h1.5967167c.3095676 0 .5213769.0488909.6354281.16296967.1303442.0977818.2281024.32593934.3258606.63558171l2.7372286 10.78859208 2.5417123-10.78859208c.0814652-.32593934.1792233-.5377999.3095676-.63558171.1303442-.0977818.3584466-.16296967.6517211-.16296967H24.82539c.3095675 0 .5213769.0488909.6517211.16296967.1303442.0977818.2443954.32593934.3095675.63558171L28.360977 22.1412404l2.8186937-10.91896788c.0977582-.32593934.2118094-.5377999.3258606-.63558171.1303442-.0977818.3421536-.16296967.6354281-.16296967h1.5152515c.2606885 0 .4073257.13037574.4073257.40742418 0 .08148483-.016293.16296966-.032586.26075147-.016293.0977818-.0488791.22815753-.1140512.40742417L29.9902797 24.0968764c-.0977581.3259394-.2118093.5377999-.3421536.6355817-.1303442.0977818-.3421535.1629697-.619135.1629697h-1.4012004c-.3095675 0-.5213769-.0488909-.6517211-.1629697-.1303442-.1140787-.2443954-.3259393-.3095675-.6518787l-2.5254193-10.51154364-2.5091262 10.49524674c-.0814652.3259393-.1792234.5377999-.3095676.6518787-.1303442.1140787-.3584466.1629696-.6517211.1629696h-1.4012004Zm20.9365406.4400181c-.8472375 0-1.6944749-.0977818-2.5091263-.2933454-.8146514-.1955636-1.4500795-.4074241-1.8736982-.6518786-.2606884-.1466727-.4399117-.3096424-.5050838-.4563151-.0651721-.1466727-.0977582-.3096424-.0977582-.4563151v-.8311453c0-.3422363.1303442-.505206.3747396-.505206.0977582 0 .1955164.016297.2932745.0488909.0977582.0325939.2443954.0977818.4073257.1629697.553963.2444545 1.156805.4400181 1.7922331.5703938.6517211.1303758 1.2871491.1955636 1.9388702.1955636 1.0264608 0 1.8248191-.1792666 2.3787821-.5377999.5539629-.3585333.8472374-.8800362.8472374-1.5482118 0-.4563151-.1466372-.8311454-.4399117-1.14078773-.2932745-.30964237-.8472375-.58669081-1.6455958-.84744228l-2.362489-.73336351c-1.189391-.37483024-2.0692145-.92892712-2.6068844-1.66229063-.53767-.71706655-.8146514-1.51561793-.8146514-2.36306021 0-.68447261.1466372-1.28746039.4399117-1.80896333.2932745-.52150294.6843072-.97781802 1.173098-1.33635129.4887908-.37483024 1.0427538-.65187868 1.6944749-.84744228C39.3424776 10.08148484 40.0267847 10 40.743678 10c.3584466 0 .7331862.01629697 1.0916328.06518787.3747397.0488909.7168932.11407877 1.0590468.17926663.3258606.08148484.6354281.16296967.9287026.26075148.2932745.0977818.5213769.1955636.6843071.2933454.2281024.13037574.3910327.26075147.4887909.40742417.0977581.13037574.1466372.30964238.1466372.53779991v.76595745c0 .34223631-.1303442.52150294-.3747396.52150294-.1303442 0-.3421536-.06518786-.6191351-.1955636-.9287025-.42372114-1.9714563-.63558171-3.1282613-.63558171-.9287025 0-1.6618888.1466727-2.1669726.45631507-.5050839.30964238-.7657723.78225442-.7657723 1.45043006 0 .45631508.1629302.84744228.4887908 1.15708466.3258605.30964237.9287026.61928474 1.792233.89633318l2.31361.73336351c1.1730979.37483024 2.0203354.89633318 2.5254192 1.56450883.5050839.66817564.7494793 1.43413309.7494793 2.28157535 0 .7007696-.1466372 1.3363513-.4236187 1.8904482-.2932745.5540969-.6843072 1.0430059-1.189391 1.4341331-.5050839.4074242-1.1079259.7007696-1.8085261.9126301-.7331862.2281576-1.4989585.3422363-2.3299029.3422363Z" />
+    <g fill="#F90">
+      <path
+        d="M43.3112583 32.99374245c-5.2291391 3.64956196-12.8264901 5.58698375-19.3589404 5.58698375-9.1549669 0-17.40397353-3.19899876-23.6344371-8.51564457-.49271524-.42052566-.04768213-.99123905.54039735-.66082603 6.73907284 3.69461827 15.05165565 5.93241552 23.65033115 5.93241552 5.8013245 0 12.1748344-1.14142679 18.0397351-3.48435545.8741722-.37546934 1.621192.54067585.7629139 1.14142678Z" />
+      <path
+        d="M45.4887417 30.65081379c-.6675496-.81101376-4.418543-.39048811-6.1192053-.19524405-.5086092.06007509-.5880794-.36045056-.1271523-.67584481 2.9880795-1.9824781 7.8993378-1.4117647 8.4715232-.75093867.5721854.67584481-.1589404 5.31664581-2.9562914 7.53942428-.4291391.34543179-.8423841.16520651-.6516556-.2853567.6357616-1.48685857 2.0503311-4.83604505 1.3827814-5.63204005Z" />
+    </g>
+  </g>
+</svg>
+
+                <strong class="govuk-!-margin-right-1">AWS Cli</strong>
+                <a class="app-link" href="https://aws.amazon.com/cli"
+                   target="_blank" rel="noopener noreferrer">
+                  https://aws.amazon.com/cli</a>
+              </div>
+            </li>
+            <li>
+              <div class="app-!-layout-flex-start">
+                <svg class="app-icon app-icon--small govuk-!-margin-right-1" width="48" height="48"
+     viewBox="0 0 48 48"
+     role="img" aria-label="Redis Logo">
+  <g fill="none" fill-rule="nonzero">
+    <path fill="#912626"
+          d="M43.3544531 32.9697113c-2.2414219 1.1384836-13.8524531 5.790742-16.3243828 7.0465752-2.4719297 1.2559931-3.8451328 1.2438424-5.7979687.3341428-1.9526719-.9096997-14.30887504-5.7734753-16.53471098-6.8102771C3.58504687 33.022151 3 32.5847277 3 32.1716058v-4.1369752s16.0863281-3.4125728 18.6832734-4.3205138c2.5967813-.907941 3.4978125-.9407158 5.7077344-.1518831 2.21025.7891525 15.4248281 3.1124838 17.6089922 3.8920437l-.0009844 4.0784602c.0003282.4089651-.5036718.8575798-1.6445625 1.4369737" />
+    <path fill="#C6302B"
+          d="M43.3536365 29.5958877c-2.2412601 1.1910429-13.8519748 6.0602966-16.323907 7.3744931-2.4717681 1.3146985-3.8449726 1.3018142-5.7976464.3497162-1.9528379-.9514288-14.30856125-6.0427271-16.53423536-7.1271819-2.2256741-1.085124-2.2722679-1.8319103-.08596884-2.7050294 2.18629907-.8734537 14.4742645-5.790396 17.0715406-6.7406534 2.5967838-.9499228 3.4976519-.9845598 5.707576-.1586273 2.2100882.8255979 13.7515685 5.5109578 15.9354066 6.3266833 2.1846584.8167294 2.2684945 1.4892219.0272344 2.6805994" />
+    <path fill="#912626"
+          d="M43.3544531 25.9696418C41.1130312 27.1082884 29.502 31.7603997 27.0300703 33.016716c-2.4719297 1.2555168-3.8451328 1.2433662-5.7979687.333664-1.952836-.9092225-14.30887504-5.7734911-16.53471098-6.8102958C3.58504687 26.0220816 3 25.5852967 3 25.1720137v-4.1374661s16.0863281-3.4124223 18.6832734-4.3203658c2.5967813-.9079435 3.4978125-.9408783 5.7077344-.1518835C29.6014219 17.351293 42.816 19.6741511 45 20.453873l-.0009844 4.078951c.0003282.4088064-.5036718.8574223-1.6445625 1.4368178" />
+    <path fill="#C6302B"
+          d="M43.3536365 22.5958222c-2.2412601 1.1913798-13.8519748 6.060308-16.323907 7.375009-2.4717681 1.3141989-3.8449726 1.3013146-5.7976464.3492148-1.9528379-.9514306-14.30856125-6.0425712-16.53423536-7.1271953-2.2256741-1.0847915-2.2722679-1.8317464-.08596884-2.7052018 2.18629907-.8729534 14.4744286-5.7902396 17.0715406-6.74033154 2.5967838-.95009191 3.4976519-.9845616 5.707576-.15879486 2.2100882.82559942 13.7515685 5.5106335 15.9354066 6.3266952 2.1846584.8165636 2.2684945 1.4892247.0272344 2.6806045" />
+    <path fill="#912626"
+          d="M43.3544531 17.9694657C41.1130312 19.1078096 29.502 23.7603108 27.0300703 25.016646c-2.4719297 1.2556956-3.8451328 1.2433849-5.7979687.333669-1.952836-.9092362-14.30887504-5.7737379-16.53471098-6.8100785C3.58504687 18.0217464 3 17.584795 3 17.1719854v-4.13768827s16.0863281-3.41231381 18.6832734-4.32011112c2.5967813-.90811706 3.4978125-.94073253 5.7077344-.15188577C29.6014219 9.35130687 42.816 11.67419998 45 12.45393359l-.0009844 4.07885251c.0003282.4084928-.5036718.8571155-1.6445625 1.4366796" />
+    <path fill="#C6302B"
+          d="M43.3536333 14.5957771c-2.2412644 1.1913989-13.8520019 6.0607397-16.3239389 7.3749597-2.4717729 1.31422-3.8449801 1.3013355-5.7976578.3497224-1.9526776-.9521151-14.30858912-6.0430025-16.53410351-7.1278114-2.22584252-1.08464143-2.27227234-1.83177568-.08613307-2.70507774C6.79810336 11.61443535 19.0862569 6.69773978 21.6833739 5.747298c2.5967889-.95027445 3.4976588-.98441003 5.7075872-.15863007 2.2100925.82577996 13.7515953 5.51088901 15.9354377 6.32696375 2.1846627.81590742 2.2684989 1.48874657.0272345 2.68014542" />
+    <path fill="#FFF"
+          d="m29 9.9453744-3.3959935.35971035-.7602027 1.86640079-1.2278653-2.08269927-3.9213619-.35955292 2.9260164-1.07661227L21.7426646 7l2.739476 1.09314163 2.5825597-.86267513-.6980225 1.7088209L29 9.9453744M24.6410626 19l-6.3379022-2.6820066 9.0816983-1.422312L24.6410626 19m-8.7869983-8.01721152c2.6808445 0 4.8540644.85952668 4.8540644 1.91960959 0 1.06039775-2.1732199 1.91976703-4.8540644 1.91976703C13.1732198 14.8221651 11 13.9626384 11 12.90239807c0-1.06008291 2.1732198-1.91960959 4.8540643-1.91960959" />
+    <path fill="#621B1C" d="m33 11.00018169 6 2.50109011L33.0051671 16 33 11" />
+    <path fill="#9A2928" d="M27 13.62872021 33.9945554 11 34 15.745146 33.3141561 16 27 13.62872021" />
+  </g>
+</svg>
+
+                <strong class="govuk-!-margin-right-1">Redis Cli</strong>
+                <a class="app-link" href="https://redis.io/docs/latest/develop/connect/cli"
+                   target="_blank" rel="noopener noreferrer">
+                  https://redis.io/docs/latest/develop/connect/cli</a>
+              </div>
+            </li>
+            <li>
+              <div class="app-!-layout-flex-start">
+                <svg class="app-icon app-icon--small govuk-!-margin-right-1" width="48" height="48"
+     viewBox="0 0 48 48"
+     role="img" aria-label="Mongo Db Logo">
+  <path fill="#00684A" fill-rule="nonzero"
+        d="M27.4065134 6.90410699c-1.8875888-2.1910124-3.5130071-4.41626465-3.845085-4.8784311-.0349537-.03423452-.0874017-.03423452-.1223554 0-.3320779.46216645-1.95751365 2.6874187-3.84510241 4.8784311C3.3921656 27.1195659 22.14573249 40.762124 22.14573249 40.762124l.15729183.1026667C22.44283928 42.9703101 22.79239404 46 22.79239404 46H24.1906131s.3495721-3.0126356.4893871-5.1352093l.1572744-.1197209c.0174943 0 18.7710264-13.6255039 2.5692388-33.84096281ZM23.4915036 40.4539535s-.83892452-.7017829-1.06612383-1.0612868v-.0341085L23.439073 17.3456481c0-.0684729.1048785-.0684729.1048785 0l1.0136932 22.0129101v.0341085c-.2272167.3595039-1.0661411 1.0612868-1.0661411 1.0612868Z" />
+</svg>
+
+                <strong class="govuk-!-margin-right-1">MongoDb Cli</strong>
+                <a class="app-link" href="https://www.mongodb.com/docs/mongocli/current"
+                   target="_blank" rel="noopener noreferrer">
+                  https://www.mongodb.com/docs/mongocli/current</a>
+              </div>
+            </li>
+          </ul>
+
+  </span>
+
+</div>
+
+
+      </div>
+
+      <div class="govuk-grid-column-one-third-from-desktop-wide">
+
+
+
+
+<div
+  class="app-info govuk-!-margin-top-0"
+  tabindex="-1"
+  role="alert"
+  data-testid="app-info">
+
+  <svg class="app-icon app-info-icon app-icon--small"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Info">
+  <path fill-rule="nonzero"
+        d="M24.138363 35.9288256c.6244365 0 1.1513167-.2180783 1.5806406-.6542349.4293238-.4361565.6439857-.9772716.6439857-1.6233451v-9.6797154c0-.6092526-.2156109-1.1315776-.6468327-1.566975-.4308422-.435777-.9527877-.6536655-1.5658363-.6536655-.6130487 0-1.1471412.2178885-1.6022776.6536655-.455516.4353974-.683274.9577224-.683274 1.566975v9.6797154c0 .6460735.2228232 1.1871886.6684697 1.6233451.4456465.4361566.9806881.6542349 1.6051246.6542349Zm-.1679715-17.4234875c.7789323 0 1.4198813-.2448399 1.9228469-.7345196.5029656-.4896797.7544484-1.1144958.7544484-1.8744484 0-.8780071-.2501542-1.5546382-.7504626-2.0298932-.5003084-.4756347-1.1386002-.713452-1.9148754-.713452-.8613049 0-1.5244603.234401-1.9894662.7032029-.465006.4688019-.6975089 1.1230367-.6975089 1.9627046 0 .8077817.2511032 1.4574614.7533096 1.9490391.5022064.4915777 1.1427758.7373666 1.9217082.7373666ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.95231317-5.45954922 5.13651245-7.64412811 2.18419929-2.18457888 4.73224202-3.90225385 7.64412812-5.15302491C17.5521708.62538553 20.6595492 0 23.9624199 0c3.3165362 0 6.4394781.62367734 9.3688257 1.87103203 2.9293475 1.24735468 5.4802372 2.9602847 7.652669 5.13879003 2.1724318 2.17888494 3.8847924 4.73205224 5.1370818 7.65950174C47.3736655 17.5963938 48 20.7214235 48 24.0444128c0 3.3199526-.6253855 6.4303677-1.8761566 9.3312456-1.250771 2.9004982-2.968446 5.4396204-5.1530249 7.6173665-2.1845789 2.1777462-4.7358482 3.889917-7.6538078 5.1365125C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+
+
+  <span class="app-info__content" data-testid="app-info-content">
+              <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Info</h2>
+
+          <p class="govuk-!-margin-bottom-2">
+            The CDP Terminal is a web shell into a dedicated container running with the permissions that your service
+            has.
+          </p>
+          <ul class="govuk-list">
+<li>
+                <div class="app-!-layout-flex-start">
+                  <svg class="app-icon app-info-icon app-icon--tiny govuk-!-margin-right-1"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Info">
+  <path fill-rule="nonzero"
+        d="M24.138363 35.9288256c.6244365 0 1.1513167-.2180783 1.5806406-.6542349.4293238-.4361565.6439857-.9772716.6439857-1.6233451v-9.6797154c0-.6092526-.2156109-1.1315776-.6468327-1.566975-.4308422-.435777-.9527877-.6536655-1.5658363-.6536655-.6130487 0-1.1471412.2178885-1.6022776.6536655-.455516.4353974-.683274.9577224-.683274 1.566975v9.6797154c0 .6460735.2228232 1.1871886.6684697 1.6233451.4456465.4361566.9806881.6542349 1.6051246.6542349Zm-.1679715-17.4234875c.7789323 0 1.4198813-.2448399 1.9228469-.7345196.5029656-.4896797.7544484-1.1144958.7544484-1.8744484 0-.8780071-.2501542-1.5546382-.7504626-2.0298932-.5003084-.4756347-1.1386002-.713452-1.9148754-.713452-.8613049 0-1.5244603.234401-1.9894662.7032029-.465006.4688019-.6975089 1.1230367-.6975089 1.9627046 0 .8077817.2511032 1.4574614.7533096 1.9490391.5022064.4915777 1.1427758.7373666 1.9217082.7373666ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.95231317-5.45954922 5.13651245-7.64412811 2.18419929-2.18457888 4.73224202-3.90225385 7.64412812-5.15302491C17.5521708.62538553 20.6595492 0 23.9624199 0c3.3165362 0 6.4394781.62367734 9.3688257 1.87103203 2.9293475 1.24735468 5.4802372 2.9602847 7.652669 5.13879003 2.1724318 2.17888494 3.8847924 4.73205224 5.1370818 7.65950174C47.3736655 17.5963938 48 20.7214235 48 24.0444128c0 3.3199526-.6253855 6.4303677-1.8761566 9.3312456-1.250771 2.9004982-2.968446 5.4396204-5.1530249 7.6173665-2.1845789 2.1777462-4.7358482 3.889917-7.6538078 5.1365125C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+ Behave as your service does, same permissions, same visibility
+                </div>
+              </li>
+<li>
+                <div class="app-!-layout-flex-start">
+                  <svg class="app-icon app-info-icon app-icon--tiny govuk-!-margin-right-1"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Info">
+  <path fill-rule="nonzero"
+        d="M24.138363 35.9288256c.6244365 0 1.1513167-.2180783 1.5806406-.6542349.4293238-.4361565.6439857-.9772716.6439857-1.6233451v-9.6797154c0-.6092526-.2156109-1.1315776-.6468327-1.566975-.4308422-.435777-.9527877-.6536655-1.5658363-.6536655-.6130487 0-1.1471412.2178885-1.6022776.6536655-.455516.4353974-.683274.9577224-.683274 1.566975v9.6797154c0 .6460735.2228232 1.1871886.6684697 1.6233451.4456465.4361566.9806881.6542349 1.6051246.6542349Zm-.1679715-17.4234875c.7789323 0 1.4198813-.2448399 1.9228469-.7345196.5029656-.4896797.7544484-1.1144958.7544484-1.8744484 0-.8780071-.2501542-1.5546382-.7504626-2.0298932-.5003084-.4756347-1.1386002-.713452-1.9148754-.713452-.8613049 0-1.5244603.234401-1.9894662.7032029-.465006.4688019-.6975089 1.1230367-.6975089 1.9627046 0 .8077817.2511032 1.4574614.7533096 1.9490391.5022064.4915777 1.1427758.7373666 1.9217082.7373666ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.95231317-5.45954922 5.13651245-7.64412811 2.18419929-2.18457888 4.73224202-3.90225385 7.64412812-5.15302491C17.5521708.62538553 20.6595492 0 23.9624199 0c3.3165362 0 6.4394781.62367734 9.3688257 1.87103203 2.9293475 1.24735468 5.4802372 2.9602847 7.652669 5.13879003 2.1724318 2.17888494 3.8847924 4.73205224 5.1370818 7.65950174C47.3736655 17.5963938 48 20.7214235 48 24.0444128c0 3.3199526-.6253855 6.4303677-1.8761566 9.3312456-1.250771 2.9004982-2.968446 5.4396204-5.1530249 7.6173665-2.1845789 2.1777462-4.7358482 3.889917-7.6538078 5.1365125C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+ You can upload files
+                </div>
+              </li>
+<li>
+                <div class="app-!-layout-flex-start">
+                  <svg class="app-icon app-info-icon app-icon--tiny govuk-!-margin-right-1"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Info">
+  <path fill-rule="nonzero"
+        d="M24.138363 35.9288256c.6244365 0 1.1513167-.2180783 1.5806406-.6542349.4293238-.4361565.6439857-.9772716.6439857-1.6233451v-9.6797154c0-.6092526-.2156109-1.1315776-.6468327-1.566975-.4308422-.435777-.9527877-.6536655-1.5658363-.6536655-.6130487 0-1.1471412.2178885-1.6022776.6536655-.455516.4353974-.683274.9577224-.683274 1.566975v9.6797154c0 .6460735.2228232 1.1871886.6684697 1.6233451.4456465.4361566.9806881.6542349 1.6051246.6542349Zm-.1679715-17.4234875c.7789323 0 1.4198813-.2448399 1.9228469-.7345196.5029656-.4896797.7544484-1.1144958.7544484-1.8744484 0-.8780071-.2501542-1.5546382-.7504626-2.0298932-.5003084-.4756347-1.1386002-.713452-1.9148754-.713452-.8613049 0-1.5244603.234401-1.9894662.7032029-.465006.4688019-.6975089 1.1230367-.6975089 1.9627046 0 .8077817.2511032 1.4574614.7533096 1.9490391.5022064.4915777 1.1427758.7373666 1.9217082.7373666ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.95231317-5.45954922 5.13651245-7.64412811 2.18419929-2.18457888 4.73224202-3.90225385 7.64412812-5.15302491C17.5521708.62538553 20.6595492 0 23.9624199 0c3.3165362 0 6.4394781.62367734 9.3688257 1.87103203 2.9293475 1.24735468 5.4802372 2.9602847 7.652669 5.13879003 2.1724318 2.17888494 3.8847924 4.73205224 5.1370818 7.65950174C47.3736655 17.5963938 48 20.7214235 48 24.0444128c0 3.3199526-.6253855 6.4303677-1.8761566 9.3312456-1.250771 2.9004982-2.968446 5.4396204-5.1530249 7.6173665-2.1845789 2.1777462-4.7358482 3.889917-7.6538078 5.1365125C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+ For a Backend service talk to MongoDb
+                </div>
+              </li>
+<li>
+                <div class="app-!-layout-flex-start">
+                  <svg class="app-icon app-info-icon app-icon--tiny govuk-!-margin-right-1"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Info">
+  <path fill-rule="nonzero"
+        d="M24.138363 35.9288256c.6244365 0 1.1513167-.2180783 1.5806406-.6542349.4293238-.4361565.6439857-.9772716.6439857-1.6233451v-9.6797154c0-.6092526-.2156109-1.1315776-.6468327-1.566975-.4308422-.435777-.9527877-.6536655-1.5658363-.6536655-.6130487 0-1.1471412.2178885-1.6022776.6536655-.455516.4353974-.683274.9577224-.683274 1.566975v9.6797154c0 .6460735.2228232 1.1871886.6684697 1.6233451.4456465.4361566.9806881.6542349 1.6051246.6542349Zm-.1679715-17.4234875c.7789323 0 1.4198813-.2448399 1.9228469-.7345196.5029656-.4896797.7544484-1.1144958.7544484-1.8744484 0-.8780071-.2501542-1.5546382-.7504626-2.0298932-.5003084-.4756347-1.1386002-.713452-1.9148754-.713452-.8613049 0-1.5244603.234401-1.9894662.7032029-.465006.4688019-.6975089 1.1230367-.6975089 1.9627046 0 .8077817.2511032 1.4574614.7533096 1.9490391.5022064.4915777 1.1427758.7373666 1.9217082.7373666ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.95231317-5.45954922 5.13651245-7.64412811 2.18419929-2.18457888 4.73224202-3.90225385 7.64412812-5.15302491C17.5521708.62538553 20.6595492 0 23.9624199 0c3.3165362 0 6.4394781.62367734 9.3688257 1.87103203 2.9293475 1.24735468 5.4802372 2.9602847 7.652669 5.13879003 2.1724318 2.17888494 3.8847924 4.73205224 5.1370818 7.65950174C47.3736655 17.5963938 48 20.7214235 48 24.0444128c0 3.3199526-.6253855 6.4303677-1.8761566 9.3312456-1.250771 2.9004982-2.968446 5.4396204-5.1530249 7.6173665-2.1845789 2.1777462-4.7358482 3.889917-7.6538078 5.1365125C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+ For a Frontend service talk to Redis
+                </div>
+              </li>
+<li>
+                <div class="app-!-layout-flex-start">
+                  <svg class="app-icon app-info-icon app-icon--tiny govuk-!-margin-right-1"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Info">
+  <path fill-rule="nonzero"
+        d="M24.138363 35.9288256c.6244365 0 1.1513167-.2180783 1.5806406-.6542349.4293238-.4361565.6439857-.9772716.6439857-1.6233451v-9.6797154c0-.6092526-.2156109-1.1315776-.6468327-1.566975-.4308422-.435777-.9527877-.6536655-1.5658363-.6536655-.6130487 0-1.1471412.2178885-1.6022776.6536655-.455516.4353974-.683274.9577224-.683274 1.566975v9.6797154c0 .6460735.2228232 1.1871886.6684697 1.6233451.4456465.4361566.9806881.6542349 1.6051246.6542349Zm-.1679715-17.4234875c.7789323 0 1.4198813-.2448399 1.9228469-.7345196.5029656-.4896797.7544484-1.1144958.7544484-1.8744484 0-.8780071-.2501542-1.5546382-.7504626-2.0298932-.5003084-.4756347-1.1386002-.713452-1.9148754-.713452-.8613049 0-1.5244603.234401-1.9894662.7032029-.465006.4688019-.6975089 1.1230367-.6975089 1.9627046 0 .8077817.2511032 1.4574614.7533096 1.9490391.5022064.4915777 1.1427758.7373666 1.9217082.7373666ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.95231317-5.45954922 5.13651245-7.64412811 2.18419929-2.18457888 4.73224202-3.90225385 7.64412812-5.15302491C17.5521708.62538553 20.6595492 0 23.9624199 0c3.3165362 0 6.4394781.62367734 9.3688257 1.87103203 2.9293475 1.24735468 5.4802372 2.9602847 7.652669 5.13879003 2.1724318 2.17888494 3.8847924 4.73205224 5.1370818 7.65950174C47.3736655 17.5963938 48 20.7214235 48 24.0444128c0 3.3199526-.6253855 6.4303677-1.8761566 9.3312456-1.250771 2.9004982-2.968446 5.4396204-5.1530249 7.6173665-2.1845789 2.1777462-4.7358482 3.889917-7.6538078 5.1365125C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+ Curl your Backend from your Frontend
+                </div>
+              </li>
+<li>
+                <div class="app-!-layout-flex-start">
+                  <svg class="app-icon app-info-icon app-icon--tiny govuk-!-margin-right-1"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Info">
+  <path fill-rule="nonzero"
+        d="M24.138363 35.9288256c.6244365 0 1.1513167-.2180783 1.5806406-.6542349.4293238-.4361565.6439857-.9772716.6439857-1.6233451v-9.6797154c0-.6092526-.2156109-1.1315776-.6468327-1.566975-.4308422-.435777-.9527877-.6536655-1.5658363-.6536655-.6130487 0-1.1471412.2178885-1.6022776.6536655-.455516.4353974-.683274.9577224-.683274 1.566975v9.6797154c0 .6460735.2228232 1.1871886.6684697 1.6233451.4456465.4361566.9806881.6542349 1.6051246.6542349Zm-.1679715-17.4234875c.7789323 0 1.4198813-.2448399 1.9228469-.7345196.5029656-.4896797.7544484-1.1144958.7544484-1.8744484 0-.8780071-.2501542-1.5546382-.7504626-2.0298932-.5003084-.4756347-1.1386002-.713452-1.9148754-.713452-.8613049 0-1.5244603.234401-1.9894662.7032029-.465006.4688019-.6975089 1.1230367-.6975089 1.9627046 0 .8077817.2511032 1.4574614.7533096 1.9490391.5022064.4915777 1.1427758.7373666 1.9217082.7373666ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.95231317-5.45954922 5.13651245-7.64412811 2.18419929-2.18457888 4.73224202-3.90225385 7.64412812-5.15302491C17.5521708.62538553 20.6595492 0 23.9624199 0c3.3165362 0 6.4394781.62367734 9.3688257 1.87103203 2.9293475 1.24735468 5.4802372 2.9602847 7.652669 5.13879003 2.1724318 2.17888494 3.8847924 4.73205224 5.1370818 7.65950174C47.3736655 17.5963938 48 20.7214235 48 24.0444128c0 3.3199526-.6253855 6.4303677-1.8761566 9.3312456-1.250771 2.9004982-2.968446 5.4396204-5.1530249 7.6173665-2.1845789 2.1777462-4.7358482 3.889917-7.6538078 5.1365125C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+ Access your AWS services
+                </div>
+              </li>
+          </ul>
+
+          <p class="govuk-!-margin-bottom-2">
+            The CDP Terminal also comes with a few things you need to be aware of.
+          </p>
+
+          <ul class="govuk-list">
+<li>
+                <div class="app-!-layout-flex-start">
+                  <svg class="app-icon app-warning-icon app-icon--tiny govuk-!-margin-right-1"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Warning">
+  <path fill-rule="nonzero"
+        d="M23.9476157 36.7259786c.9649347 0 1.7226097-.2577461 2.2730249-.7732384.5504152-.5154923.8256227-1.2557058.8256227-2.2206406 0-.9649347-.267236-1.7320996-.8017081-2.3014946-.5344722-.569395-1.2841756-.8540925-2.2491104-.8540925-.9649347 0-1.7226097.2810913-2.2730249.843274-.5504152.5618031-.8256227 1.3253618-.8256227 2.2906761 0 .9649348.267236 1.7087545.8017081 2.2314591.5344722.5227046 1.2841756.7840569 2.2491104.7840569Zm.1867615-9.9644128c.7645077 0 1.3840095-.2397153 1.8585054-.7191459.4744958-.479051.7117437-1.112408.7117437-1.9000711V14.0071174c0-.7508422-.2406643-1.365599-.7219928-1.8442704-.480949-.4786714-1.1036774-.7180071-1.8681851-.7180071-.726548 0-1.3401661.2393357-1.8408541.7180071-.5003084.4786714-.7504626 1.0934282-.7504626 1.8442704v10.1352314c0 .7876631.2535706 1.4210201.7607117 1.9000711.5071412.4794306 1.1239858.7191459 1.8505338.7191459ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.94908659-5.46011862 5.12683274-7.64583629 2.17812574-2.18533808 4.72635823-3.90282325 7.64469753-5.15245552C17.549134.62500593 20.6595492 0 23.9624199 0c3.3165362 0 6.4385291.62348754 9.3659787 1.87046263 2.9278292 1.24697509 5.4789086 2.9608541 7.6532384 5.14163701 2.1747094 2.18116252 3.888019 4.73432976 5.1399288 7.65950176C47.3738553 17.597153 48 20.7214235 48 24.0444128c0 3.3199526-.6250059 6.4334045-1.8750178 9.3403559-1.2496323 2.9069513-2.9671174 5.4460735-5.1524555 7.6173665-2.1857177 2.1716726-4.7375564 3.8808067-7.655516 5.1274022C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+ The connection is short-lived, lasting around 2 hours
+                </div>
+              </li>
+<li>
+                <div class="app-!-layout-flex-start">
+                  <svg class="app-icon app-warning-icon app-icon--tiny govuk-!-margin-right-1"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Warning">
+  <path fill-rule="nonzero"
+        d="M23.9476157 36.7259786c.9649347 0 1.7226097-.2577461 2.2730249-.7732384.5504152-.5154923.8256227-1.2557058.8256227-2.2206406 0-.9649347-.267236-1.7320996-.8017081-2.3014946-.5344722-.569395-1.2841756-.8540925-2.2491104-.8540925-.9649347 0-1.7226097.2810913-2.2730249.843274-.5504152.5618031-.8256227 1.3253618-.8256227 2.2906761 0 .9649348.267236 1.7087545.8017081 2.2314591.5344722.5227046 1.2841756.7840569 2.2491104.7840569Zm.1867615-9.9644128c.7645077 0 1.3840095-.2397153 1.8585054-.7191459.4744958-.479051.7117437-1.112408.7117437-1.9000711V14.0071174c0-.7508422-.2406643-1.365599-.7219928-1.8442704-.480949-.4786714-1.1036774-.7180071-1.8681851-.7180071-.726548 0-1.3401661.2393357-1.8408541.7180071-.5003084.4786714-.7504626 1.0934282-.7504626 1.8442704v10.1352314c0 .7876631.2535706 1.4210201.7607117 1.9000711.5071412.4794306 1.1239858.7191459 1.8505338.7191459ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.94908659-5.46011862 5.12683274-7.64583629 2.17812574-2.18533808 4.72635823-3.90282325 7.64469753-5.15245552C17.549134.62500593 20.6595492 0 23.9624199 0c3.3165362 0 6.4385291.62348754 9.3659787 1.87046263 2.9278292 1.24697509 5.4789086 2.9608541 7.6532384 5.14163701 2.1747094 2.18116252 3.888019 4.73432976 5.1399288 7.65950176C47.3738553 17.597153 48 20.7214235 48 24.0444128c0 3.3199526-.6250059 6.4334045-1.8750178 9.3403559-1.2496323 2.9069513-2.9671174 5.4460735-5.1524555 7.6173665-2.1857177 2.1716726-4.7375564 3.8808067-7.655516 5.1274022C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+ Any changes you make to the container, will be lost when the terminal is closed
+                </div>
+              </li>
+<li>
+                <div class="app-!-layout-flex-start">
+                  <svg class="app-icon app-warning-icon app-icon--tiny govuk-!-margin-right-1"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Warning">
+  <path fill-rule="nonzero"
+        d="M23.9476157 36.7259786c.9649347 0 1.7226097-.2577461 2.2730249-.7732384.5504152-.5154923.8256227-1.2557058.8256227-2.2206406 0-.9649347-.267236-1.7320996-.8017081-2.3014946-.5344722-.569395-1.2841756-.8540925-2.2491104-.8540925-.9649347 0-1.7226097.2810913-2.2730249.843274-.5504152.5618031-.8256227 1.3253618-.8256227 2.2906761 0 .9649348.267236 1.7087545.8017081 2.2314591.5344722.5227046 1.2841756.7840569 2.2491104.7840569Zm.1867615-9.9644128c.7645077 0 1.3840095-.2397153 1.8585054-.7191459.4744958-.479051.7117437-1.112408.7117437-1.9000711V14.0071174c0-.7508422-.2406643-1.365599-.7219928-1.8442704-.480949-.4786714-1.1036774-.7180071-1.8681851-.7180071-.726548 0-1.3401661.2393357-1.8408541.7180071-.5003084.4786714-.7504626 1.0934282-.7504626 1.8442704v10.1352314c0 .7876631.2535706 1.4210201.7607117 1.9000711.5071412.4794306 1.1239858.7191459 1.8505338.7191459ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.94908659-5.46011862 5.12683274-7.64583629 2.17812574-2.18533808 4.72635823-3.90282325 7.64469753-5.15245552C17.549134.62500593 20.6595492 0 23.9624199 0c3.3165362 0 6.4385291.62348754 9.3659787 1.87046263 2.9278292 1.24697509 5.4789086 2.9608541 7.6532384 5.14163701 2.1747094 2.18116252 3.888019 4.73432976 5.1399288 7.65950176C47.3738553 17.597153 48 20.7214235 48 24.0444128c0 3.3199526-.6250059 6.4334045-1.8750178 9.3403559-1.2496323 2.9069513-2.9671174 5.4460735-5.1524555 7.6173665-2.1857177 2.1716726-4.7375564 3.8808067-7.655516 5.1274022C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+ Changes to external services will persist. S3, MongoDb, Redis, etc
+                </div>
+              </li>
+<li>
+                <div class="app-!-layout-flex-start">
+                  <svg class="app-icon app-warning-icon app-icon--tiny govuk-!-margin-right-1"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Warning">
+  <path fill-rule="nonzero"
+        d="M23.9476157 36.7259786c.9649347 0 1.7226097-.2577461 2.2730249-.7732384.5504152-.5154923.8256227-1.2557058.8256227-2.2206406 0-.9649347-.267236-1.7320996-.8017081-2.3014946-.5344722-.569395-1.2841756-.8540925-2.2491104-.8540925-.9649347 0-1.7226097.2810913-2.2730249.843274-.5504152.5618031-.8256227 1.3253618-.8256227 2.2906761 0 .9649348.267236 1.7087545.8017081 2.2314591.5344722.5227046 1.2841756.7840569 2.2491104.7840569Zm.1867615-9.9644128c.7645077 0 1.3840095-.2397153 1.8585054-.7191459.4744958-.479051.7117437-1.112408.7117437-1.9000711V14.0071174c0-.7508422-.2406643-1.365599-.7219928-1.8442704-.480949-.4786714-1.1036774-.7180071-1.8681851-.7180071-.726548 0-1.3401661.2393357-1.8408541.7180071-.5003084.4786714-.7504626 1.0934282-.7504626 1.8442704v10.1352314c0 .7876631.2535706 1.4210201.7607117 1.9000711.5071412.4794306 1.1239858.7191459 1.8505338.7191459ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.94908659-5.46011862 5.12683274-7.64583629 2.17812574-2.18533808 4.72635823-3.90282325 7.64469753-5.15245552C17.549134.62500593 20.6595492 0 23.9624199 0c3.3165362 0 6.4385291.62348754 9.3659787 1.87046263 2.9278292 1.24697509 5.4789086 2.9608541 7.6532384 5.14163701 2.1747094 2.18116252 3.888019 4.73432976 5.1399288 7.65950176C47.3738553 17.597153 48 20.7214235 48 24.0444128c0 3.3199526-.6250059 6.4334045-1.8750178 9.3403559-1.2496323 2.9069513-2.9671174 5.4460735-5.1524555 7.6173665-2.1857177 2.1716726-4.7375564 3.8808067-7.655516 5.1274022C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+ Maximum 20 GB of ephemeral storage
+                </div>
+              </li>
+          </ul>
+
+  </span>
+
+</div>
+
+
+      </div>
+    </div>
+  </section>
+
+      </section>
+</div>
+
+        </main>
+      </div>
+
+  
+<footer class="app-footer" role="contentinfo" data-testid="app-footer">
+
+  <div class="app-footer__row">
+    <div class="app-footer__primary">
+      <p>
+        If you have a question, idea or suggestion. Contact the Platform team via Slack
+        <a class="app-footer__link" href="https://defra-digital-team.slack.com/archives/C05UJ3SE5C6" target="_blank"
+           rel="noopener noreferrer">#cdp-support</a>
+      </p>
+
+      <ul class="app-footer__list">
+        <li class="app-footer__list-item">
+          <a href="/documentation" class="app-footer__link">Documentation</a>
+        </li>
+        <li class="app-footer__list-item">
+          <a href="/help/cookie-policy" class="app-footer__link">Cookie policy</a>
+        </li>
+        <li class="app-footer__list-item">
+          <a href="/help/accessibility-statement" class="app-footer__link">Accessibility statement</a>
+        </li>
+      </ul>
+
+        <ul class="app-footer__list">
+          <li class="app-footer__list-item">
+            <a class="app-footer__link"
+               href="https://github.com/DEFRA/cdp-portal-frontend/releases/tag/0.1.0"
+               target="_blank" rel="noopener noreferrer">0.1.0</a>
+          </li>
+        </ul>
+    </div>
+
+    <div class="app-footer__secondary">
+      <a class="app-footer__link"
+         href="https://github.com/DEFRA/cdp-portal-frontend"
+         target="_blank"
+         rel="noopener noreferrer"><svg class="app-icon app-github-icon app-icon--small"
+     xmlns="http://www.w3.org/2000/svg"
+     width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="CDP Portal Frontend repository on GitHub">
+  <path d="M23.9284898 0C10.6966531 0 0 11 0 24.6085c0 10.878 6.85371429 20.086 16.3616327 23.345 1.1887346.245 1.6241632-.5295 1.6241632-1.181 0-.5705-.0391837-2.526-.0391837-4.5635-6.6563265 1.467-8.04244893-2.9335-8.04244893-2.9335-1.06971429-2.852-2.65469388-3.585-2.65469388-3.585-2.17861225-1.5075.15869388-1.5075.15869388-1.5075 2.41665306.163 3.68473473 2.526 3.68473473 2.526 2.1389387 3.748 5.5856326 2.689 6.9722449 2.037.1978775-1.589.8321632-2.689 1.5056326-3.3-5.3088979-.5705-10.8945306-2.689-10.8945306-12.1415 0-2.689.95020408-4.889 2.4558367-6.6-.237551-.611-1.0697143-3.1375.2380408-6.519 0 0 2.0204082-.652 6.576 2.526 1.9504109-.5386687 3.9618381-.8126928 5.9823674-.815 2.0204082 0 4.08.2855 5.9818775.815 4.5560817-3.178 6.5764898-2.526 6.5764898-2.526 1.3077551 3.3815.4751021 5.908.2375511 6.519 1.5453061 1.711 2.4563265 3.911 2.4563265 6.6 0 9.4525-5.5856327 11.53-10.9342041 12.1415.8718367.774 1.6241633 2.2405 1.6241633 4.563 0 3.3-.0391837 5.9485-.0391837 6.763 0 .652.4359184 1.4265 1.6241633 1.182 9.5079183-3.26 16.3617395-12.4675 16.3617395-23.3455C47.8564898 11 37.1206531 0 23.9284898 0Z" />
+</svg>
+</a>
+    </div>
+  </div>
+
+</footer>
+
+
+  <script type="module" src="/.public/javascripts/application.js"></script>
+  </body>
+</html>

--- a/src/server/services/service/terminal/__file_snapshots__/Service-Terminal-page-page-renders-for-with-prod-terminal-button-for-service-owner-tenant-1.html
+++ b/src/server/services/service/terminal/__file_snapshots__/Service-Terminal-page-page-renders-for-with-prod-terminal-button-for-service-owner-tenant-1.html
@@ -1,0 +1,832 @@
+<!DOCTYPE html>
+<html lang="en" class="govuk-template govuk-template--rebranded">
+  <head>
+    <meta charset="utf-8">
+    <title>  mock-service-with-terminal - Terminal | Core Delivery Platform - Portal
+</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#1d70b8">
+
+
+          <link rel="icon" sizes="48x48" href="/.public/assets/images/favicon.ico">
+      <link rel="icon" sizes="any" href="/.public/assets/images/favicon.svg" type="image/svg+xml">
+      <link rel="mask-icon" href="/.public/assets/images/govuk-icon-mask.svg" color="#1d70b8">
+      <link rel="apple-touch-icon" href="/.public/assets/images/govuk-icon-180.png">
+      <link rel="manifest" href="/.public/assets/manifest.json">
+
+
+  <link href="/.public/stylesheets/application.css" rel="stylesheet">
+    <meta name="service-version" content="0.1.0">
+    <meta name="service-environment" content="test">
+
+  </head>
+  <body class="govuk-template__body">
+    <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
+
+  
+  <div>
+    <a href="#main-content" class="govuk-skip-link app-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+
+  </div>
+
+
+  
+
+
+<header class="app-service-header" role="banner" data-testid="app-service-header">
+  <div class="app-service-header__container app-service-header__container--full-width">
+    <div class="app-service-header__content">
+      <a href="/"
+         class="app-service-header__link app-service-header__service-name"
+         data-testid="app-service-header-service-name">
+        Core Delivery Platform - Portal
+      </a>
+
+
+    </div>
+    <div class="app-service-header__actions">
+        
+<svg class="app-icon app-user-icon app-icon--tiny"
+     xmlns="http://www.w3.org/2000/svg" width="38" height="38" viewBox="0 0 38 38" role="img"
+     aria-label="User">
+  <g fill-rule="evenodd">
+    <circle cx="19" cy="12" r="8" />
+    <path
+      d="M19 25c6.1827536 0 11.6757612 2.1477482 15.1454151 5.4733482C30.6757769 35.0468378 25.1827625 38 19 38c-6.1827625 0-11.6757769-2.9531622-15.14542996-7.5258733C7.32458451 27.147613 12.8174409 25 19 25Z" />
+  </g>
+</svg>
+
+        <span data-testid="app-login-username">
+          B. A. Baracus
+        </span>
+
+      <span class="app-service-header__login app-service-header__login--logged-in">
+        <a href="/logout"
+           class="app-service-header__link app-service-header__login-link"
+           data-testid="app-login-link">
+            Sign out
+        </a>
+      </span>
+
+    </div>
+  </div>
+</header>
+
+
+  
+  <div class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+      <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+
+      
+        <nav aria-label="Menu" class="govuk-service-navigation__wrapper app-navigation">
+          <button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle" aria-controls="navigation" hidden>
+            Menu
+          </button>
+
+          <ul class="govuk-service-navigation__list" id="navigation" >
+
+            
+              
+              <li class="govuk-service-navigation__item">
+                  <a class="govuk-service-navigation__link" href="/" data-testid="nav-home">
+                                    
+Home
+                  </a>
+              </li>
+
+              
+              <li class="govuk-service-navigation__item">
+                  <a class="govuk-service-navigation__link" href="/documentation" data-testid="nav-documentation">
+                                    
+Documentation
+                  </a>
+              </li>
+
+              
+              <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
+                  <a class="govuk-service-navigation__link" href="/services" aria-current="page" data-testid="nav-services">
+                                    
+                  <strong class="govuk-service-navigation__active-fallback">Services</strong>
+
+                  </a>
+              </li>
+
+              
+              <li class="govuk-service-navigation__item">
+                  <a class="govuk-service-navigation__link" href="/test-suites" data-testid="nav-test-suites">
+                                    
+Test suites
+                  </a>
+              </li>
+
+              
+              <li class="govuk-service-navigation__item">
+                  <a class="govuk-service-navigation__link" href="/utilities/templates" data-testid="nav-utilities">
+                                    
+Utilities
+                  </a>
+              </li>
+
+              
+              <li class="govuk-service-navigation__item">
+                  <a class="govuk-service-navigation__link" href="/teams" data-testid="nav-teams">
+                                    
+Teams
+                  </a>
+              </li>
+
+              
+              <li class="govuk-service-navigation__item">
+                  <a class="govuk-service-navigation__link" href="/deployments" data-testid="nav-deployments">
+                                    
+Deployments
+                  </a>
+              </li>
+
+              
+              <li class="govuk-service-navigation__item">
+                  <a class="govuk-service-navigation__link" href="/running-services" data-testid="nav-running-services">
+                                    
+Running Services
+                  </a>
+              </li>
+
+              <ul class="app-navigation__actions">
+      
+
+
+
+<li
+  class="govuk-service-navigation__item">
+    <a class="govuk-service-navigation__link" href="/deploy-service" data-testid="nav-deploy-service">
+      Deploy Service
+    </a>
+</li>
+
+
+      
+
+
+
+<li
+  class="govuk-service-navigation__item">
+    <a class="govuk-service-navigation__link" href="/create" data-testid="nav-create">
+      Create
+    </a>
+</li>
+
+
+
+  </ul>
+</ul>
+        </nav>
+    </div>
+
+    </div>
+
+  </div>
+
+
+      <div class="govuk-width-container">
+  
+  <div
+  class="app-banner app-banner--hidden"
+  tabindex="-1"
+  role="alert"
+  data-testid="app-banner"
+data-js="app-client-notifications">
+  <p class="app-banner__content"
+data-js="app-client-notifications-content"     data-testid="app-banner-content"></p>
+</div>
+
+
+
+
+    
+<nav class="app-breadcrumbs" data-testid="app-breadcrumbs" aria-label="Breadcrumb">
+  <ol class="app-breadcrumbs__list">
+        <li class="app-breadcrumbs__list-item" data-testid="app-breadcrumbs-list-item">
+          <a class="app-breadcrumbs__link" href="/services"
+             data-testid="app-breadcrumbs-link">Services</a>
+        </li>
+        <li class="app-breadcrumbs__list-item" data-testid="app-breadcrumbs-list-item">
+          <a class="app-breadcrumbs__link" href="/services/mock-service-with-terminal"
+             data-testid="app-breadcrumbs-link">mock-service-with-terminal</a>
+        </li>
+        <li class="app-breadcrumbs__list-item app-breadcrumbs__list-item--current" aria-current="page"
+            data-testid="app-breadcrumbs-list-item">Terminal</li>
+  </ol>
+</nav>
+
+        <main class="govuk-main-wrapper app-main-wrapper" id="main-content">
+
+  <div class="govuk-!-margin-top-2">
+    <span class="govuk-caption-l" data-testid="app-page-heading-caption">Terminal</span>
+
+  <div class="app-page-heading">
+    <h1 class="app-page-heading--title" data-testid="app-page-heading-title">mock-service-with-terminal</h1>
+
+
+  </div>
+</div>
+
+
+  <div>
+    <ul class="govuk-list govuk-!-margin-bottom-2">
+        <li>
+
+
+<div
+  class="app-warning govuk-!-margin-top-0 govuk-!-margin-bottom-0"
+  tabindex="-1"
+  role="alert"
+  data-testid="app-warning">
+
+  <svg class="app-icon app-warning-icon app-icon--small"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Warning">
+  <path fill-rule="nonzero"
+        d="M23.9476157 36.7259786c.9649347 0 1.7226097-.2577461 2.2730249-.7732384.5504152-.5154923.8256227-1.2557058.8256227-2.2206406 0-.9649347-.267236-1.7320996-.8017081-2.3014946-.5344722-.569395-1.2841756-.8540925-2.2491104-.8540925-.9649347 0-1.7226097.2810913-2.2730249.843274-.5504152.5618031-.8256227 1.3253618-.8256227 2.2906761 0 .9649348.267236 1.7087545.8017081 2.2314591.5344722.5227046 1.2841756.7840569 2.2491104.7840569Zm.1867615-9.9644128c.7645077 0 1.3840095-.2397153 1.8585054-.7191459.4744958-.479051.7117437-1.112408.7117437-1.9000711V14.0071174c0-.7508422-.2406643-1.365599-.7219928-1.8442704-.480949-.4786714-1.1036774-.7180071-1.8681851-.7180071-.726548 0-1.3401661.2393357-1.8408541.7180071-.5003084.4786714-.7504626 1.0934282-.7504626 1.8442704v10.1352314c0 .7876631.2535706 1.4210201.7607117 1.9000711.5071412.4794306 1.1239858.7191459 1.8505338.7191459ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.94908659-5.46011862 5.12683274-7.64583629 2.17812574-2.18533808 4.72635823-3.90282325 7.64469753-5.15245552C17.549134.62500593 20.6595492 0 23.9624199 0c3.3165362 0 6.4385291.62348754 9.3659787 1.87046263 2.9278292 1.24697509 5.4789086 2.9608541 7.6532384 5.14163701 2.1747094 2.18116252 3.888019 4.73432976 5.1399288 7.65950176C47.3738553 17.597153 48 20.7214235 48 24.0444128c0 3.3199526-.6250059 6.4334045-1.8750178 9.3403559-1.2496323 2.9069513-2.9671174 5.4460735-5.1524555 7.6173665-2.1857177 2.1716726-4.7375564 3.8808067-7.655516 5.1274022C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+
+
+  <span class="app-warning__content" data-testid="app-warning-content">
+                <a class="app-link app-link--underline"
+               href="https://portal-test.cdp-int.defra.cloud"
+               target="_blank" rel="noopener noreferrer">https://portal-test.cdp-int.defra.cloud</a> is currently shuttered.              To unshutter go to the
+              <a class="app-link app-link--underline"
+                 href="/services/mock-service-with-terminal/maintenance">Maintenance</a> page
+
+  </span>
+</div>
+
+        </li>
+    </ul>
+  </div>
+
+
+<div class="app-tabs"
+     data-js="app-tabs">
+    <ul class="app-tabs__list" data-testid="app-tabs-list" role="tablist" aria-label="Service tabs">
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-about">
+
+
+          <a id="tab-about"
+             class="app-tabs__tab"
+             href="/services/mock-service-with-terminal"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-about"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
+            About
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-automations">
+
+
+          <a id="tab-automations"
+             class="app-tabs__tab"
+             href="/services/mock-service-with-terminal/automations"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-automations"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-automations">
+            Automations
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-maintenance">
+
+
+          <a id="tab-maintenance"
+             class="app-tabs__tab"
+             href="/services/mock-service-with-terminal/maintenance"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-maintenance"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
+            Maintenance
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-proxy">
+
+
+          <a id="tab-proxy"
+             class="app-tabs__tab"
+             href="/services/mock-service-with-terminal/proxy"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-proxy"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
+            Proxy
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-resources">
+
+
+          <a id="tab-resources"
+             class="app-tabs__tab"
+             href="/services/mock-service-with-terminal/resources"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-resources"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-resources">
+            Resources
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-secrets">
+
+
+          <a id="tab-secrets"
+             class="app-tabs__tab"
+             href="/services/mock-service-with-terminal/secrets"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-secrets"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
+            Secrets
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item app-tabs__list-item--selected"
+            data-testid="app-tabs-list-item-terminal app-tabs-list-item--selected">
+
+
+          <a id="tab-terminal"
+             class="app-tabs__tab"
+             href="/services/mock-service-with-terminal/terminal"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-terminal"
+             aria-selected="true"
+             data-testid="app-tabs-list-item__anchor-terminal">
+            Terminal
+          </a>
+        </li>
+    </ul>
+
+      <section id="tab-panel-terminal"
+               class="app-tabs__panel"
+               role="tabpanel"
+               aria-labelledby="tab-terminal"
+               data-testid="app-tabs-panel">
+          <section class="govuk-!-margin-top-6">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third-from-desktop-wide">
+
+        <section class="govuk-!-margin-bottom-6">
+          <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Terminal</h2>
+          <p class="govuk-!-margin-right-2">
+            Welcome to the CDP terminal for mock-service-with-terminal. Launch a short-lived terminal in an environment
+            with the same permissions, visibility and security as your service.
+          </p>
+        </section>
+
+        <article class="govuk-!-margin-bottom-6">
+
+<section class="app-summary-item">
+  <header class="app-summary-item__header">
+    <span class="app-summary-item__icon"><svg class="app-icon app-terminal app-icon--small"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Terminal">
+  <path fill-rule="nonzero"
+        d="M4.8 43c-1.32 0-2.45-.4651042-3.39-1.3953125C.47 40.6744792 0 39.55625 0 38.25V9.75c0-1.30625.47-2.42447917 1.41-3.3546875C2.35 5.46510417 3.48 5 4.8 5h38.4c1.32 0 2.45.46510417 3.39 1.3953125C47.53 7.32552083 48 8.44375 48 9.75v28.5c0 1.30625-.47 2.4244792-1.41 3.3546875C45.65 42.5348958 44.52 43 43.2 43H4.8Zm0-4.75h38.4v-28H4.8v28Zm8.4-2.375L9.84 32.55l6.18-6.175L9.78 20.2l3.42-3.325 9.6 9.5-9.6 9.5Zm10.8 0v-4.75h14.4v4.75H24Z" />
+</svg>
+</span>
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Launch a terminal</h2>
+  </header>
+  <p class="app-summary-item__intro">
+    Launch a secure terminal, as your service in an environment.
+  </p>
+  
+              <table class="govuk-table app-table app-table--inverse govuk-!-margin-bottom-4" data-testid="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Environment</th>
+      <th scope="col" class="govuk-table__header">Action</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Dev</td>
+      <td class="govuk-table__cell">    <form method="post" action="/services/mock-service-with-terminal/terminal/dev" target="_blank">
+      <input type="hidden" name="csrfToken" value="test-token" />
+
+
+      <button type="submit" class="govuk-button app-button app-button--primary app-button--small" data-module="govuk-button">
+  Launch
+</button>
+    </form>
+</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Test</td>
+      <td class="govuk-table__cell">    <form method="post" action="/services/mock-service-with-terminal/terminal/test" target="_blank">
+      <input type="hidden" name="csrfToken" value="test-token" />
+
+
+      <button type="submit" class="govuk-button app-button app-button--primary app-button--small" data-module="govuk-button">
+  Launch
+</button>
+    </form>
+</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Perf-test</td>
+      <td class="govuk-table__cell">    <form method="post" action="/services/mock-service-with-terminal/terminal/perf-test" target="_blank">
+      <input type="hidden" name="csrfToken" value="test-token" />
+
+
+      <button type="submit" class="govuk-button app-button app-button--primary app-button--small" data-module="govuk-button">
+  Launch
+</button>
+    </form>
+</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Prod</td>
+      <td class="govuk-table__cell">    <form method="post" action="/services/mock-service-with-terminal/terminal/prod" target="_blank">
+      <input type="hidden" name="csrfToken" value="test-token" />
+
+
+      <button type="submit" class="govuk-button app-button app-button--primary app-button--small app-button--significant" data-module="govuk-button">
+  Launch
+</button>
+    </form>
+</td>
+    </tr>
+  </tbody>
+</table>
+
+
+
+</section>
+        </article>
+      </div>
+
+      <div class="govuk-grid-column-one-third-from-desktop-wide">
+
+
+
+
+<div
+  class="app-info govuk-!-margin-top-0"
+  tabindex="-1"
+  role="alert"
+  data-testid="app-info">
+
+  <svg class="app-icon app-info-icon app-icon--small"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Info">
+  <path fill-rule="nonzero"
+        d="M24.138363 35.9288256c.6244365 0 1.1513167-.2180783 1.5806406-.6542349.4293238-.4361565.6439857-.9772716.6439857-1.6233451v-9.6797154c0-.6092526-.2156109-1.1315776-.6468327-1.566975-.4308422-.435777-.9527877-.6536655-1.5658363-.6536655-.6130487 0-1.1471412.2178885-1.6022776.6536655-.455516.4353974-.683274.9577224-.683274 1.566975v9.6797154c0 .6460735.2228232 1.1871886.6684697 1.6233451.4456465.4361566.9806881.6542349 1.6051246.6542349Zm-.1679715-17.4234875c.7789323 0 1.4198813-.2448399 1.9228469-.7345196.5029656-.4896797.7544484-1.1144958.7544484-1.8744484 0-.8780071-.2501542-1.5546382-.7504626-2.0298932-.5003084-.4756347-1.1386002-.713452-1.9148754-.713452-.8613049 0-1.5244603.234401-1.9894662.7032029-.465006.4688019-.6975089 1.1230367-.6975089 1.9627046 0 .8077817.2511032 1.4574614.7533096 1.9490391.5022064.4915777 1.1427758.7373666 1.9217082.7373666ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.95231317-5.45954922 5.13651245-7.64412811 2.18419929-2.18457888 4.73224202-3.90225385 7.64412812-5.15302491C17.5521708.62538553 20.6595492 0 23.9624199 0c3.3165362 0 6.4394781.62367734 9.3688257 1.87103203 2.9293475 1.24735468 5.4802372 2.9602847 7.652669 5.13879003 2.1724318 2.17888494 3.8847924 4.73205224 5.1370818 7.65950174C47.3736655 17.5963938 48 20.7214235 48 24.0444128c0 3.3199526-.6253855 6.4303677-1.8761566 9.3312456-1.250771 2.9004982-2.968446 5.4396204-5.1530249 7.6173665-2.1845789 2.1777462-4.7358482 3.889917-7.6538078 5.1365125C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+
+
+  <span class="app-info__content" data-testid="app-info-content">
+              <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Tooling</h2>
+
+          <p class="govuk-!-margin-bottom-2">
+            A number of tools are available to you in the CDP terminal.
+          </p>
+
+          <ul class="govuk-list">
+            <li>
+              <div class="app-!-layout-flex-start">
+                <svg class="app-icon app-icon--small govuk-!-margin-right-1" width="48" height="48"
+     viewBox="0 0 48 48"
+     role="img" aria-label="Curl logo">
+  <g fill="none" fill-rule="nonzero">
+    <path fill="#0C544C"
+          d="M40.1716969 11.22957271c-.8539659 0-1.5449235-.66943831-1.5449235-1.49417513 0-.82591446.6909576-1.49417512 1.5449235-1.49417512.8527483 0 1.5449236.66826066 1.5449236 1.49417512 0 .82473682-.6921753 1.49417513-1.5449236 1.49417513M24.8283031 36.7587745c-.853966 0-1.5449236-.6694353-1.5449236-1.4941721 0-.8259144.6909576-1.4941751 1.5449236-1.4941751.8527483 0 1.5437059.6682607 1.5437059 1.4941751 0 .8247368-.6909576 1.4941721-1.5437059 1.4941721M40.1716969 7c-1.5619549 0-2.8283031 1.22475049-2.8283031 2.73539758 0 .32236443.0839364.62237469.1897685.90944592L24.2650734 32.6386204C22.9829115 32.8986299 22 33.9469053 22 35.2646024 22 36.7752465 23.2663481 38 24.8283031 38c1.5607373 0 2.8270854-1.2247535 2.8270854-2.7353976 0-.3035432-.0839363-.5811993-.1776045-.8541508l13.3349939-22.06554394C42.0560157 12.0566618 43 11.02603293 43 9.73539758 43 8.22475049 41.7336488 7 40.1716969 7" />
+    <path fill="#073551"
+          d="M29.1718609 11.22957271c-.8539133 0-1.5448308-.66943831-1.5448308-1.49417513 0-.82591446.6909175-1.49417512 1.5448308-1.49417512.8526989 0 1.5436164.66826066 1.5436164 1.49417512 0 .82473682-.6909175 1.49417513-1.5436164 1.49417513M13.82814221 36.7587745c-.85270199 0-1.54483396-.6694353-1.54483396-1.4941721 0-.8259144.69213197-1.4941751 1.54483396-1.4941751.85391332 0 1.54483079.6682607 1.54483079 1.4941751 0 .8247368-.69091747 1.4941721-1.54483079 1.4941721M29.1718609 7c-1.5630788 0-2.8281391 1.22475049-2.8281391 2.73539758 0 .32236443.0839315.62237469.1897606.90944592L13.26616274 32.6386204C11.98285449 32.8986299 11 33.9469053 11 35.2646024 11 36.7752465 12.26627781 38 13.82814221 38c1.56186129 0 2.82813909-1.2247535 2.82813909-2.7353976 0-.3035432-.0839315-.5811993-.1775973-.8541508l13.3342238-22.06554394C31.0560704 12.0566618 32 11.02603293 32 9.73539758 32 8.22475049 30.7325077 7 29.1718609 7M8 16.36128927c.90451584 0 1.63871073.73419493 1.63871073 1.63871073 0 .9045158-.73419489 1.6387074-1.63871073 1.6387074-.9058074 0-1.63871073-.7341916-1.63871073-1.6387074 0-.9045158.73290333-1.63871073 1.63871073-1.63871073M8 21c1.65677277 0 3-1.3432272 3-3 0-.3316142-.09032342-.6374203-.18967786-.9367751C10.41290438 15.87225653 9.32387032 15 8 15c-.21161458 0-.39742106.07870928-.5974215.12128786C6.04258079 15.40516052 5 16.55483851 5 18c0 1.6567728 1.34322393 3 3 3M6.36128927 28c0-.9058074.73419489-1.6387107 1.63871073-1.6387107.90451584 0 1.63871073.7329033 1.63871073 1.6387107 0 .9045158-.73419489 1.6374192-1.63871073 1.6374192-.90451584 0-1.63871073-.7329034-1.63871073-1.6374192M11 28c0-.3329024-.09032342-.6374203-.18967786-.9367751C10.41290438 25.8722598 9.32516189 25 8 25c-.21161458 0-.39742106.0787093-.5974215.1199996C6.04258079 25.4051605 5 26.5548385 5 28c0 1.6554845 1.34322393 3 3 3 1.65677277 0 3-1.3445155 3-3" />
+  </g>
+</svg>
+
+                <strong class="govuk-!-margin-right-1">Curl</strong>
+                <a class="app-link" href="https://curl.se"
+                   target="_blank" rel="noopener noreferrer">
+                  https://curl.se</a>
+              </div>
+            </li>
+            <li>
+              <div class="app-!-layout-flex-start">
+                <svg class="app-icon app-icon--small govuk-!-margin-right-1" width="48" height="48"
+     viewBox="0 0 48 48"
+     role="img" aria-label="Aws Logo">
+  <g fill="none" fill-rule="evenodd">
+    <path fill="#252F3E" fill-rule="nonzero"
+          d="M12.8011356 20.6419194c0 .6029878.0651721 1.0918968.1792233 1.4504301.1303442.3585333.2932745.7496605.5213769 1.1733816.0814651.1303757.1140512.2607515.1140512.3748302 0 .1629697-.0977582.3259394-.3095676.488909l-1.0264607.6844727c-.1466373.0977818-.2932745.1466727-.4236187.1466727-.1629303 0-.3258606-.0814849-.4887909-.2281576-.2281023-.2444545-.4236187-.5052059-.586549-.7659574-.1629302-.2770485-.3258605-.5866908-.5050838-.9615211-1.27085616 1.499321-2.86757287 2.2489815-4.79015013 2.2489815-1.36861432 0-2.46024718-.3911272-3.25860553-1.1733817-.79835835-.7822544-1.20568404-1.8252603-1.20568404-3.1290176 0-1.3852422.48879082-2.50973292 1.48266551-3.3571752.99387469-.84744228 2.31360992-1.27116342 3.99179177-1.27116342.55396294 0 1.12421891.0488909 1.72706093.13037573.60284202.08148484 1.22197707.21186057 1.87369819.35853328V15.6224536c0-1.23856949-.26068845-2.10230874-.76577231-2.60751471-.52137689-.50520598-1.40120038-.74966048-2.65576351-.74966048-.57025596 0-1.15680496.06518786-1.75964698.21186057-.60284202.1466727-1.18939102.32593934-1.75964698.55409687-.26068845.11407877-.45620478.17926664-.57025597.21186057-.11405119.03259394-.19551633.0488909-.26068844.0488909-.22810239 0-.34215358-.16296966-.34215358-.50520597v-.79855138c0-.26075147.03258605-.45631508.11405119-.57039385.08146514-.11407876.22810239-.22815753.45620477-.3422363.57025597-.2933454 1.25456313-.53779991 2.05292149-.73336351.79835835-.21186057 1.64559579-.30964238 2.54171231-.30964238 1.93887028 0 3.35636371.44001811 4.26877321 1.32005433.8961165.88003621 1.3523213 2.2163875 1.3523213 4.00905387v5.28021727h.0325861Zm-6.61496924 2.477139c.53766991 0 1.09163285-.0977818 1.67818184-.2933454.586549-.1955636 1.10792588-.5540969 1.54783763-1.0430059.26068844-.3096424.45620477-.6518787.55396294-1.0430059.09775813-.3911272.16293023-.86373923.16293023-1.4178361v-.68447261c-.47249776-.11407877-.97758162-.21186058-1.4989585-.27704844-.52137688-.06518787-1.02646074-.0977818-1.5315446-.0977818-1.09163285 0-1.8899912.21186057-2.42766111.65187867-.53766992.44001811-.79835836 1.05930286-.79835836 1.87415118 0 .7659575.19551633 1.3363513.60284202 1.7274785.39103267.4074242.96128863.6029878 1.71076791.6029878Zm13.08330114 1.7600724c-.2932745 0-.4887908-.0488909-.619135-.1629696-.1303442-.0977818-.2443954-.3259394-.3421536-.6355818l-3.8288615-12.59755541c-.0977581-.32593934-.1466372-.5377999-.1466372-.65187867 0-.26075148.1303442-.40742418.3910326-.40742418h1.5967167c.3095676 0 .5213769.0488909.6354281.16296967.1303442.0977818.2281024.32593934.3258606.63558171l2.7372286 10.78859208 2.5417123-10.78859208c.0814652-.32593934.1792233-.5377999.3095676-.63558171.1303442-.0977818.3584466-.16296967.6517211-.16296967H24.82539c.3095675 0 .5213769.0488909.6517211.16296967.1303442.0977818.2443954.32593934.3095675.63558171L28.360977 22.1412404l2.8186937-10.91896788c.0977582-.32593934.2118094-.5377999.3258606-.63558171.1303442-.0977818.3421536-.16296967.6354281-.16296967h1.5152515c.2606885 0 .4073257.13037574.4073257.40742418 0 .08148483-.016293.16296966-.032586.26075147-.016293.0977818-.0488791.22815753-.1140512.40742417L29.9902797 24.0968764c-.0977581.3259394-.2118093.5377999-.3421536.6355817-.1303442.0977818-.3421535.1629697-.619135.1629697h-1.4012004c-.3095675 0-.5213769-.0488909-.6517211-.1629697-.1303442-.1140787-.2443954-.3259393-.3095675-.6518787l-2.5254193-10.51154364-2.5091262 10.49524674c-.0814652.3259393-.1792234.5377999-.3095676.6518787-.1303442.1140787-.3584466.1629696-.6517211.1629696h-1.4012004Zm20.9365406.4400181c-.8472375 0-1.6944749-.0977818-2.5091263-.2933454-.8146514-.1955636-1.4500795-.4074241-1.8736982-.6518786-.2606884-.1466727-.4399117-.3096424-.5050838-.4563151-.0651721-.1466727-.0977582-.3096424-.0977582-.4563151v-.8311453c0-.3422363.1303442-.505206.3747396-.505206.0977582 0 .1955164.016297.2932745.0488909.0977582.0325939.2443954.0977818.4073257.1629697.553963.2444545 1.156805.4400181 1.7922331.5703938.6517211.1303758 1.2871491.1955636 1.9388702.1955636 1.0264608 0 1.8248191-.1792666 2.3787821-.5377999.5539629-.3585333.8472374-.8800362.8472374-1.5482118 0-.4563151-.1466372-.8311454-.4399117-1.14078773-.2932745-.30964237-.8472375-.58669081-1.6455958-.84744228l-2.362489-.73336351c-1.189391-.37483024-2.0692145-.92892712-2.6068844-1.66229063-.53767-.71706655-.8146514-1.51561793-.8146514-2.36306021 0-.68447261.1466372-1.28746039.4399117-1.80896333.2932745-.52150294.6843072-.97781802 1.173098-1.33635129.4887908-.37483024 1.0427538-.65187868 1.6944749-.84744228C39.3424776 10.08148484 40.0267847 10 40.743678 10c.3584466 0 .7331862.01629697 1.0916328.06518787.3747397.0488909.7168932.11407877 1.0590468.17926663.3258606.08148484.6354281.16296967.9287026.26075148.2932745.0977818.5213769.1955636.6843071.2933454.2281024.13037574.3910327.26075147.4887909.40742417.0977581.13037574.1466372.30964238.1466372.53779991v.76595745c0 .34223631-.1303442.52150294-.3747396.52150294-.1303442 0-.3421536-.06518786-.6191351-.1955636-.9287025-.42372114-1.9714563-.63558171-3.1282613-.63558171-.9287025 0-1.6618888.1466727-2.1669726.45631507-.5050839.30964238-.7657723.78225442-.7657723 1.45043006 0 .45631508.1629302.84744228.4887908 1.15708466.3258605.30964237.9287026.61928474 1.792233.89633318l2.31361.73336351c1.1730979.37483024 2.0203354.89633318 2.5254192 1.56450883.5050839.66817564.7494793 1.43413309.7494793 2.28157535 0 .7007696-.1466372 1.3363513-.4236187 1.8904482-.2932745.5540969-.6843072 1.0430059-1.189391 1.4341331-.5050839.4074242-1.1079259.7007696-1.8085261.9126301-.7331862.2281576-1.4989585.3422363-2.3299029.3422363Z" />
+    <g fill="#F90">
+      <path
+        d="M43.3112583 32.99374245c-5.2291391 3.64956196-12.8264901 5.58698375-19.3589404 5.58698375-9.1549669 0-17.40397353-3.19899876-23.6344371-8.51564457-.49271524-.42052566-.04768213-.99123905.54039735-.66082603 6.73907284 3.69461827 15.05165565 5.93241552 23.65033115 5.93241552 5.8013245 0 12.1748344-1.14142679 18.0397351-3.48435545.8741722-.37546934 1.621192.54067585.7629139 1.14142678Z" />
+      <path
+        d="M45.4887417 30.65081379c-.6675496-.81101376-4.418543-.39048811-6.1192053-.19524405-.5086092.06007509-.5880794-.36045056-.1271523-.67584481 2.9880795-1.9824781 7.8993378-1.4117647 8.4715232-.75093867.5721854.67584481-.1589404 5.31664581-2.9562914 7.53942428-.4291391.34543179-.8423841.16520651-.6516556-.2853567.6357616-1.48685857 2.0503311-4.83604505 1.3827814-5.63204005Z" />
+    </g>
+  </g>
+</svg>
+
+                <strong class="govuk-!-margin-right-1">AWS Cli</strong>
+                <a class="app-link" href="https://aws.amazon.com/cli"
+                   target="_blank" rel="noopener noreferrer">
+                  https://aws.amazon.com/cli</a>
+              </div>
+            </li>
+            <li>
+              <div class="app-!-layout-flex-start">
+                <svg class="app-icon app-icon--small govuk-!-margin-right-1" width="48" height="48"
+     viewBox="0 0 48 48"
+     role="img" aria-label="Redis Logo">
+  <g fill="none" fill-rule="nonzero">
+    <path fill="#912626"
+          d="M43.3544531 32.9697113c-2.2414219 1.1384836-13.8524531 5.790742-16.3243828 7.0465752-2.4719297 1.2559931-3.8451328 1.2438424-5.7979687.3341428-1.9526719-.9096997-14.30887504-5.7734753-16.53471098-6.8102771C3.58504687 33.022151 3 32.5847277 3 32.1716058v-4.1369752s16.0863281-3.4125728 18.6832734-4.3205138c2.5967813-.907941 3.4978125-.9407158 5.7077344-.1518831 2.21025.7891525 15.4248281 3.1124838 17.6089922 3.8920437l-.0009844 4.0784602c.0003282.4089651-.5036718.8575798-1.6445625 1.4369737" />
+    <path fill="#C6302B"
+          d="M43.3536365 29.5958877c-2.2412601 1.1910429-13.8519748 6.0602966-16.323907 7.3744931-2.4717681 1.3146985-3.8449726 1.3018142-5.7976464.3497162-1.9528379-.9514288-14.30856125-6.0427271-16.53423536-7.1271819-2.2256741-1.085124-2.2722679-1.8319103-.08596884-2.7050294 2.18629907-.8734537 14.4742645-5.790396 17.0715406-6.7406534 2.5967838-.9499228 3.4976519-.9845598 5.707576-.1586273 2.2100882.8255979 13.7515685 5.5109578 15.9354066 6.3266833 2.1846584.8167294 2.2684945 1.4892219.0272344 2.6805994" />
+    <path fill="#912626"
+          d="M43.3544531 25.9696418C41.1130312 27.1082884 29.502 31.7603997 27.0300703 33.016716c-2.4719297 1.2555168-3.8451328 1.2433662-5.7979687.333664-1.952836-.9092225-14.30887504-5.7734911-16.53471098-6.8102958C3.58504687 26.0220816 3 25.5852967 3 25.1720137v-4.1374661s16.0863281-3.4124223 18.6832734-4.3203658c2.5967813-.9079435 3.4978125-.9408783 5.7077344-.1518835C29.6014219 17.351293 42.816 19.6741511 45 20.453873l-.0009844 4.078951c.0003282.4088064-.5036718.8574223-1.6445625 1.4368178" />
+    <path fill="#C6302B"
+          d="M43.3536365 22.5958222c-2.2412601 1.1913798-13.8519748 6.060308-16.323907 7.375009-2.4717681 1.3141989-3.8449726 1.3013146-5.7976464.3492148-1.9528379-.9514306-14.30856125-6.0425712-16.53423536-7.1271953-2.2256741-1.0847915-2.2722679-1.8317464-.08596884-2.7052018 2.18629907-.8729534 14.4744286-5.7902396 17.0715406-6.74033154 2.5967838-.95009191 3.4976519-.9845616 5.707576-.15879486 2.2100882.82559942 13.7515685 5.5106335 15.9354066 6.3266952 2.1846584.8165636 2.2684945 1.4892247.0272344 2.6806045" />
+    <path fill="#912626"
+          d="M43.3544531 17.9694657C41.1130312 19.1078096 29.502 23.7603108 27.0300703 25.016646c-2.4719297 1.2556956-3.8451328 1.2433849-5.7979687.333669-1.952836-.9092362-14.30887504-5.7737379-16.53471098-6.8100785C3.58504687 18.0217464 3 17.584795 3 17.1719854v-4.13768827s16.0863281-3.41231381 18.6832734-4.32011112c2.5967813-.90811706 3.4978125-.94073253 5.7077344-.15188577C29.6014219 9.35130687 42.816 11.67419998 45 12.45393359l-.0009844 4.07885251c.0003282.4084928-.5036718.8571155-1.6445625 1.4366796" />
+    <path fill="#C6302B"
+          d="M43.3536333 14.5957771c-2.2412644 1.1913989-13.8520019 6.0607397-16.3239389 7.3749597-2.4717729 1.31422-3.8449801 1.3013355-5.7976578.3497224-1.9526776-.9521151-14.30858912-6.0430025-16.53410351-7.1278114-2.22584252-1.08464143-2.27227234-1.83177568-.08613307-2.70507774C6.79810336 11.61443535 19.0862569 6.69773978 21.6833739 5.747298c2.5967889-.95027445 3.4976588-.98441003 5.7075872-.15863007 2.2100925.82577996 13.7515953 5.51088901 15.9354377 6.32696375 2.1846627.81590742 2.2684989 1.48874657.0272345 2.68014542" />
+    <path fill="#FFF"
+          d="m29 9.9453744-3.3959935.35971035-.7602027 1.86640079-1.2278653-2.08269927-3.9213619-.35955292 2.9260164-1.07661227L21.7426646 7l2.739476 1.09314163 2.5825597-.86267513-.6980225 1.7088209L29 9.9453744M24.6410626 19l-6.3379022-2.6820066 9.0816983-1.422312L24.6410626 19m-8.7869983-8.01721152c2.6808445 0 4.8540644.85952668 4.8540644 1.91960959 0 1.06039775-2.1732199 1.91976703-4.8540644 1.91976703C13.1732198 14.8221651 11 13.9626384 11 12.90239807c0-1.06008291 2.1732198-1.91960959 4.8540643-1.91960959" />
+    <path fill="#621B1C" d="m33 11.00018169 6 2.50109011L33.0051671 16 33 11" />
+    <path fill="#9A2928" d="M27 13.62872021 33.9945554 11 34 15.745146 33.3141561 16 27 13.62872021" />
+  </g>
+</svg>
+
+                <strong class="govuk-!-margin-right-1">Redis Cli</strong>
+                <a class="app-link" href="https://redis.io/docs/latest/develop/connect/cli"
+                   target="_blank" rel="noopener noreferrer">
+                  https://redis.io/docs/latest/develop/connect/cli</a>
+              </div>
+            </li>
+            <li>
+              <div class="app-!-layout-flex-start">
+                <svg class="app-icon app-icon--small govuk-!-margin-right-1" width="48" height="48"
+     viewBox="0 0 48 48"
+     role="img" aria-label="Mongo Db Logo">
+  <path fill="#00684A" fill-rule="nonzero"
+        d="M27.4065134 6.90410699c-1.8875888-2.1910124-3.5130071-4.41626465-3.845085-4.8784311-.0349537-.03423452-.0874017-.03423452-.1223554 0-.3320779.46216645-1.95751365 2.6874187-3.84510241 4.8784311C3.3921656 27.1195659 22.14573249 40.762124 22.14573249 40.762124l.15729183.1026667C22.44283928 42.9703101 22.79239404 46 22.79239404 46H24.1906131s.3495721-3.0126356.4893871-5.1352093l.1572744-.1197209c.0174943 0 18.7710264-13.6255039 2.5692388-33.84096281ZM23.4915036 40.4539535s-.83892452-.7017829-1.06612383-1.0612868v-.0341085L23.439073 17.3456481c0-.0684729.1048785-.0684729.1048785 0l1.0136932 22.0129101v.0341085c-.2272167.3595039-1.0661411 1.0612868-1.0661411 1.0612868Z" />
+</svg>
+
+                <strong class="govuk-!-margin-right-1">MongoDb Cli</strong>
+                <a class="app-link" href="https://www.mongodb.com/docs/mongocli/current"
+                   target="_blank" rel="noopener noreferrer">
+                  https://www.mongodb.com/docs/mongocli/current</a>
+              </div>
+            </li>
+          </ul>
+
+  </span>
+
+</div>
+
+
+      </div>
+
+      <div class="govuk-grid-column-one-third-from-desktop-wide">
+
+
+
+
+<div
+  class="app-info govuk-!-margin-top-0"
+  tabindex="-1"
+  role="alert"
+  data-testid="app-info">
+
+  <svg class="app-icon app-info-icon app-icon--small"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Info">
+  <path fill-rule="nonzero"
+        d="M24.138363 35.9288256c.6244365 0 1.1513167-.2180783 1.5806406-.6542349.4293238-.4361565.6439857-.9772716.6439857-1.6233451v-9.6797154c0-.6092526-.2156109-1.1315776-.6468327-1.566975-.4308422-.435777-.9527877-.6536655-1.5658363-.6536655-.6130487 0-1.1471412.2178885-1.6022776.6536655-.455516.4353974-.683274.9577224-.683274 1.566975v9.6797154c0 .6460735.2228232 1.1871886.6684697 1.6233451.4456465.4361566.9806881.6542349 1.6051246.6542349Zm-.1679715-17.4234875c.7789323 0 1.4198813-.2448399 1.9228469-.7345196.5029656-.4896797.7544484-1.1144958.7544484-1.8744484 0-.8780071-.2501542-1.5546382-.7504626-2.0298932-.5003084-.4756347-1.1386002-.713452-1.9148754-.713452-.8613049 0-1.5244603.234401-1.9894662.7032029-.465006.4688019-.6975089 1.1230367-.6975089 1.9627046 0 .8077817.2511032 1.4574614.7533096 1.9490391.5022064.4915777 1.1427758.7373666 1.9217082.7373666ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.95231317-5.45954922 5.13651245-7.64412811 2.18419929-2.18457888 4.73224202-3.90225385 7.64412812-5.15302491C17.5521708.62538553 20.6595492 0 23.9624199 0c3.3165362 0 6.4394781.62367734 9.3688257 1.87103203 2.9293475 1.24735468 5.4802372 2.9602847 7.652669 5.13879003 2.1724318 2.17888494 3.8847924 4.73205224 5.1370818 7.65950174C47.3736655 17.5963938 48 20.7214235 48 24.0444128c0 3.3199526-.6253855 6.4303677-1.8761566 9.3312456-1.250771 2.9004982-2.968446 5.4396204-5.1530249 7.6173665-2.1845789 2.1777462-4.7358482 3.889917-7.6538078 5.1365125C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+
+
+  <span class="app-info__content" data-testid="app-info-content">
+              <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Info</h2>
+
+          <p class="govuk-!-margin-bottom-2">
+            The CDP Terminal is a web shell into a dedicated container running with the permissions that your service
+            has.
+          </p>
+          <ul class="govuk-list">
+<li>
+                <div class="app-!-layout-flex-start">
+                  <svg class="app-icon app-info-icon app-icon--tiny govuk-!-margin-right-1"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Info">
+  <path fill-rule="nonzero"
+        d="M24.138363 35.9288256c.6244365 0 1.1513167-.2180783 1.5806406-.6542349.4293238-.4361565.6439857-.9772716.6439857-1.6233451v-9.6797154c0-.6092526-.2156109-1.1315776-.6468327-1.566975-.4308422-.435777-.9527877-.6536655-1.5658363-.6536655-.6130487 0-1.1471412.2178885-1.6022776.6536655-.455516.4353974-.683274.9577224-.683274 1.566975v9.6797154c0 .6460735.2228232 1.1871886.6684697 1.6233451.4456465.4361566.9806881.6542349 1.6051246.6542349Zm-.1679715-17.4234875c.7789323 0 1.4198813-.2448399 1.9228469-.7345196.5029656-.4896797.7544484-1.1144958.7544484-1.8744484 0-.8780071-.2501542-1.5546382-.7504626-2.0298932-.5003084-.4756347-1.1386002-.713452-1.9148754-.713452-.8613049 0-1.5244603.234401-1.9894662.7032029-.465006.4688019-.6975089 1.1230367-.6975089 1.9627046 0 .8077817.2511032 1.4574614.7533096 1.9490391.5022064.4915777 1.1427758.7373666 1.9217082.7373666ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.95231317-5.45954922 5.13651245-7.64412811 2.18419929-2.18457888 4.73224202-3.90225385 7.64412812-5.15302491C17.5521708.62538553 20.6595492 0 23.9624199 0c3.3165362 0 6.4394781.62367734 9.3688257 1.87103203 2.9293475 1.24735468 5.4802372 2.9602847 7.652669 5.13879003 2.1724318 2.17888494 3.8847924 4.73205224 5.1370818 7.65950174C47.3736655 17.5963938 48 20.7214235 48 24.0444128c0 3.3199526-.6253855 6.4303677-1.8761566 9.3312456-1.250771 2.9004982-2.968446 5.4396204-5.1530249 7.6173665-2.1845789 2.1777462-4.7358482 3.889917-7.6538078 5.1365125C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+ Behave as your service does, same permissions, same visibility
+                </div>
+              </li>
+<li>
+                <div class="app-!-layout-flex-start">
+                  <svg class="app-icon app-info-icon app-icon--tiny govuk-!-margin-right-1"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Info">
+  <path fill-rule="nonzero"
+        d="M24.138363 35.9288256c.6244365 0 1.1513167-.2180783 1.5806406-.6542349.4293238-.4361565.6439857-.9772716.6439857-1.6233451v-9.6797154c0-.6092526-.2156109-1.1315776-.6468327-1.566975-.4308422-.435777-.9527877-.6536655-1.5658363-.6536655-.6130487 0-1.1471412.2178885-1.6022776.6536655-.455516.4353974-.683274.9577224-.683274 1.566975v9.6797154c0 .6460735.2228232 1.1871886.6684697 1.6233451.4456465.4361566.9806881.6542349 1.6051246.6542349Zm-.1679715-17.4234875c.7789323 0 1.4198813-.2448399 1.9228469-.7345196.5029656-.4896797.7544484-1.1144958.7544484-1.8744484 0-.8780071-.2501542-1.5546382-.7504626-2.0298932-.5003084-.4756347-1.1386002-.713452-1.9148754-.713452-.8613049 0-1.5244603.234401-1.9894662.7032029-.465006.4688019-.6975089 1.1230367-.6975089 1.9627046 0 .8077817.2511032 1.4574614.7533096 1.9490391.5022064.4915777 1.1427758.7373666 1.9217082.7373666ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.95231317-5.45954922 5.13651245-7.64412811 2.18419929-2.18457888 4.73224202-3.90225385 7.64412812-5.15302491C17.5521708.62538553 20.6595492 0 23.9624199 0c3.3165362 0 6.4394781.62367734 9.3688257 1.87103203 2.9293475 1.24735468 5.4802372 2.9602847 7.652669 5.13879003 2.1724318 2.17888494 3.8847924 4.73205224 5.1370818 7.65950174C47.3736655 17.5963938 48 20.7214235 48 24.0444128c0 3.3199526-.6253855 6.4303677-1.8761566 9.3312456-1.250771 2.9004982-2.968446 5.4396204-5.1530249 7.6173665-2.1845789 2.1777462-4.7358482 3.889917-7.6538078 5.1365125C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+ You can upload files
+                </div>
+              </li>
+<li>
+                <div class="app-!-layout-flex-start">
+                  <svg class="app-icon app-info-icon app-icon--tiny govuk-!-margin-right-1"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Info">
+  <path fill-rule="nonzero"
+        d="M24.138363 35.9288256c.6244365 0 1.1513167-.2180783 1.5806406-.6542349.4293238-.4361565.6439857-.9772716.6439857-1.6233451v-9.6797154c0-.6092526-.2156109-1.1315776-.6468327-1.566975-.4308422-.435777-.9527877-.6536655-1.5658363-.6536655-.6130487 0-1.1471412.2178885-1.6022776.6536655-.455516.4353974-.683274.9577224-.683274 1.566975v9.6797154c0 .6460735.2228232 1.1871886.6684697 1.6233451.4456465.4361566.9806881.6542349 1.6051246.6542349Zm-.1679715-17.4234875c.7789323 0 1.4198813-.2448399 1.9228469-.7345196.5029656-.4896797.7544484-1.1144958.7544484-1.8744484 0-.8780071-.2501542-1.5546382-.7504626-2.0298932-.5003084-.4756347-1.1386002-.713452-1.9148754-.713452-.8613049 0-1.5244603.234401-1.9894662.7032029-.465006.4688019-.6975089 1.1230367-.6975089 1.9627046 0 .8077817.2511032 1.4574614.7533096 1.9490391.5022064.4915777 1.1427758.7373666 1.9217082.7373666ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.95231317-5.45954922 5.13651245-7.64412811 2.18419929-2.18457888 4.73224202-3.90225385 7.64412812-5.15302491C17.5521708.62538553 20.6595492 0 23.9624199 0c3.3165362 0 6.4394781.62367734 9.3688257 1.87103203 2.9293475 1.24735468 5.4802372 2.9602847 7.652669 5.13879003 2.1724318 2.17888494 3.8847924 4.73205224 5.1370818 7.65950174C47.3736655 17.5963938 48 20.7214235 48 24.0444128c0 3.3199526-.6253855 6.4303677-1.8761566 9.3312456-1.250771 2.9004982-2.968446 5.4396204-5.1530249 7.6173665-2.1845789 2.1777462-4.7358482 3.889917-7.6538078 5.1365125C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+ For a Backend service talk to MongoDb
+                </div>
+              </li>
+<li>
+                <div class="app-!-layout-flex-start">
+                  <svg class="app-icon app-info-icon app-icon--tiny govuk-!-margin-right-1"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Info">
+  <path fill-rule="nonzero"
+        d="M24.138363 35.9288256c.6244365 0 1.1513167-.2180783 1.5806406-.6542349.4293238-.4361565.6439857-.9772716.6439857-1.6233451v-9.6797154c0-.6092526-.2156109-1.1315776-.6468327-1.566975-.4308422-.435777-.9527877-.6536655-1.5658363-.6536655-.6130487 0-1.1471412.2178885-1.6022776.6536655-.455516.4353974-.683274.9577224-.683274 1.566975v9.6797154c0 .6460735.2228232 1.1871886.6684697 1.6233451.4456465.4361566.9806881.6542349 1.6051246.6542349Zm-.1679715-17.4234875c.7789323 0 1.4198813-.2448399 1.9228469-.7345196.5029656-.4896797.7544484-1.1144958.7544484-1.8744484 0-.8780071-.2501542-1.5546382-.7504626-2.0298932-.5003084-.4756347-1.1386002-.713452-1.9148754-.713452-.8613049 0-1.5244603.234401-1.9894662.7032029-.465006.4688019-.6975089 1.1230367-.6975089 1.9627046 0 .8077817.2511032 1.4574614.7533096 1.9490391.5022064.4915777 1.1427758.7373666 1.9217082.7373666ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.95231317-5.45954922 5.13651245-7.64412811 2.18419929-2.18457888 4.73224202-3.90225385 7.64412812-5.15302491C17.5521708.62538553 20.6595492 0 23.9624199 0c3.3165362 0 6.4394781.62367734 9.3688257 1.87103203 2.9293475 1.24735468 5.4802372 2.9602847 7.652669 5.13879003 2.1724318 2.17888494 3.8847924 4.73205224 5.1370818 7.65950174C47.3736655 17.5963938 48 20.7214235 48 24.0444128c0 3.3199526-.6253855 6.4303677-1.8761566 9.3312456-1.250771 2.9004982-2.968446 5.4396204-5.1530249 7.6173665-2.1845789 2.1777462-4.7358482 3.889917-7.6538078 5.1365125C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+ For a Frontend service talk to Redis
+                </div>
+              </li>
+<li>
+                <div class="app-!-layout-flex-start">
+                  <svg class="app-icon app-info-icon app-icon--tiny govuk-!-margin-right-1"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Info">
+  <path fill-rule="nonzero"
+        d="M24.138363 35.9288256c.6244365 0 1.1513167-.2180783 1.5806406-.6542349.4293238-.4361565.6439857-.9772716.6439857-1.6233451v-9.6797154c0-.6092526-.2156109-1.1315776-.6468327-1.566975-.4308422-.435777-.9527877-.6536655-1.5658363-.6536655-.6130487 0-1.1471412.2178885-1.6022776.6536655-.455516.4353974-.683274.9577224-.683274 1.566975v9.6797154c0 .6460735.2228232 1.1871886.6684697 1.6233451.4456465.4361566.9806881.6542349 1.6051246.6542349Zm-.1679715-17.4234875c.7789323 0 1.4198813-.2448399 1.9228469-.7345196.5029656-.4896797.7544484-1.1144958.7544484-1.8744484 0-.8780071-.2501542-1.5546382-.7504626-2.0298932-.5003084-.4756347-1.1386002-.713452-1.9148754-.713452-.8613049 0-1.5244603.234401-1.9894662.7032029-.465006.4688019-.6975089 1.1230367-.6975089 1.9627046 0 .8077817.2511032 1.4574614.7533096 1.9490391.5022064.4915777 1.1427758.7373666 1.9217082.7373666ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.95231317-5.45954922 5.13651245-7.64412811 2.18419929-2.18457888 4.73224202-3.90225385 7.64412812-5.15302491C17.5521708.62538553 20.6595492 0 23.9624199 0c3.3165362 0 6.4394781.62367734 9.3688257 1.87103203 2.9293475 1.24735468 5.4802372 2.9602847 7.652669 5.13879003 2.1724318 2.17888494 3.8847924 4.73205224 5.1370818 7.65950174C47.3736655 17.5963938 48 20.7214235 48 24.0444128c0 3.3199526-.6253855 6.4303677-1.8761566 9.3312456-1.250771 2.9004982-2.968446 5.4396204-5.1530249 7.6173665-2.1845789 2.1777462-4.7358482 3.889917-7.6538078 5.1365125C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+ Curl your Backend from your Frontend
+                </div>
+              </li>
+<li>
+                <div class="app-!-layout-flex-start">
+                  <svg class="app-icon app-info-icon app-icon--tiny govuk-!-margin-right-1"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Info">
+  <path fill-rule="nonzero"
+        d="M24.138363 35.9288256c.6244365 0 1.1513167-.2180783 1.5806406-.6542349.4293238-.4361565.6439857-.9772716.6439857-1.6233451v-9.6797154c0-.6092526-.2156109-1.1315776-.6468327-1.566975-.4308422-.435777-.9527877-.6536655-1.5658363-.6536655-.6130487 0-1.1471412.2178885-1.6022776.6536655-.455516.4353974-.683274.9577224-.683274 1.566975v9.6797154c0 .6460735.2228232 1.1871886.6684697 1.6233451.4456465.4361566.9806881.6542349 1.6051246.6542349Zm-.1679715-17.4234875c.7789323 0 1.4198813-.2448399 1.9228469-.7345196.5029656-.4896797.7544484-1.1144958.7544484-1.8744484 0-.8780071-.2501542-1.5546382-.7504626-2.0298932-.5003084-.4756347-1.1386002-.713452-1.9148754-.713452-.8613049 0-1.5244603.234401-1.9894662.7032029-.465006.4688019-.6975089 1.1230367-.6975089 1.9627046 0 .8077817.2511032 1.4574614.7533096 1.9490391.5022064.4915777 1.1427758.7373666 1.9217082.7373666ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.95231317-5.45954922 5.13651245-7.64412811 2.18419929-2.18457888 4.73224202-3.90225385 7.64412812-5.15302491C17.5521708.62538553 20.6595492 0 23.9624199 0c3.3165362 0 6.4394781.62367734 9.3688257 1.87103203 2.9293475 1.24735468 5.4802372 2.9602847 7.652669 5.13879003 2.1724318 2.17888494 3.8847924 4.73205224 5.1370818 7.65950174C47.3736655 17.5963938 48 20.7214235 48 24.0444128c0 3.3199526-.6253855 6.4303677-1.8761566 9.3312456-1.250771 2.9004982-2.968446 5.4396204-5.1530249 7.6173665-2.1845789 2.1777462-4.7358482 3.889917-7.6538078 5.1365125C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+ Access your AWS services
+                </div>
+              </li>
+          </ul>
+
+          <p class="govuk-!-margin-bottom-2">
+            The CDP Terminal also comes with a few things you need to be aware of.
+          </p>
+
+          <ul class="govuk-list">
+<li>
+                <div class="app-!-layout-flex-start">
+                  <svg class="app-icon app-warning-icon app-icon--tiny govuk-!-margin-right-1"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Warning">
+  <path fill-rule="nonzero"
+        d="M23.9476157 36.7259786c.9649347 0 1.7226097-.2577461 2.2730249-.7732384.5504152-.5154923.8256227-1.2557058.8256227-2.2206406 0-.9649347-.267236-1.7320996-.8017081-2.3014946-.5344722-.569395-1.2841756-.8540925-2.2491104-.8540925-.9649347 0-1.7226097.2810913-2.2730249.843274-.5504152.5618031-.8256227 1.3253618-.8256227 2.2906761 0 .9649348.267236 1.7087545.8017081 2.2314591.5344722.5227046 1.2841756.7840569 2.2491104.7840569Zm.1867615-9.9644128c.7645077 0 1.3840095-.2397153 1.8585054-.7191459.4744958-.479051.7117437-1.112408.7117437-1.9000711V14.0071174c0-.7508422-.2406643-1.365599-.7219928-1.8442704-.480949-.4786714-1.1036774-.7180071-1.8681851-.7180071-.726548 0-1.3401661.2393357-1.8408541.7180071-.5003084.4786714-.7504626 1.0934282-.7504626 1.8442704v10.1352314c0 .7876631.2535706 1.4210201.7607117 1.9000711.5071412.4794306 1.1239858.7191459 1.8505338.7191459ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.94908659-5.46011862 5.12683274-7.64583629 2.17812574-2.18533808 4.72635823-3.90282325 7.64469753-5.15245552C17.549134.62500593 20.6595492 0 23.9624199 0c3.3165362 0 6.4385291.62348754 9.3659787 1.87046263 2.9278292 1.24697509 5.4789086 2.9608541 7.6532384 5.14163701 2.1747094 2.18116252 3.888019 4.73432976 5.1399288 7.65950176C47.3738553 17.597153 48 20.7214235 48 24.0444128c0 3.3199526-.6250059 6.4334045-1.8750178 9.3403559-1.2496323 2.9069513-2.9671174 5.4460735-5.1524555 7.6173665-2.1857177 2.1716726-4.7375564 3.8808067-7.655516 5.1274022C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+ The connection is short-lived, lasting around 2 hours
+                </div>
+              </li>
+<li>
+                <div class="app-!-layout-flex-start">
+                  <svg class="app-icon app-warning-icon app-icon--tiny govuk-!-margin-right-1"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Warning">
+  <path fill-rule="nonzero"
+        d="M23.9476157 36.7259786c.9649347 0 1.7226097-.2577461 2.2730249-.7732384.5504152-.5154923.8256227-1.2557058.8256227-2.2206406 0-.9649347-.267236-1.7320996-.8017081-2.3014946-.5344722-.569395-1.2841756-.8540925-2.2491104-.8540925-.9649347 0-1.7226097.2810913-2.2730249.843274-.5504152.5618031-.8256227 1.3253618-.8256227 2.2906761 0 .9649348.267236 1.7087545.8017081 2.2314591.5344722.5227046 1.2841756.7840569 2.2491104.7840569Zm.1867615-9.9644128c.7645077 0 1.3840095-.2397153 1.8585054-.7191459.4744958-.479051.7117437-1.112408.7117437-1.9000711V14.0071174c0-.7508422-.2406643-1.365599-.7219928-1.8442704-.480949-.4786714-1.1036774-.7180071-1.8681851-.7180071-.726548 0-1.3401661.2393357-1.8408541.7180071-.5003084.4786714-.7504626 1.0934282-.7504626 1.8442704v10.1352314c0 .7876631.2535706 1.4210201.7607117 1.9000711.5071412.4794306 1.1239858.7191459 1.8505338.7191459ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.94908659-5.46011862 5.12683274-7.64583629 2.17812574-2.18533808 4.72635823-3.90282325 7.64469753-5.15245552C17.549134.62500593 20.6595492 0 23.9624199 0c3.3165362 0 6.4385291.62348754 9.3659787 1.87046263 2.9278292 1.24697509 5.4789086 2.9608541 7.6532384 5.14163701 2.1747094 2.18116252 3.888019 4.73432976 5.1399288 7.65950176C47.3738553 17.597153 48 20.7214235 48 24.0444128c0 3.3199526-.6250059 6.4334045-1.8750178 9.3403559-1.2496323 2.9069513-2.9671174 5.4460735-5.1524555 7.6173665-2.1857177 2.1716726-4.7375564 3.8808067-7.655516 5.1274022C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+ Any changes you make to the container, will be lost when the terminal is closed
+                </div>
+              </li>
+<li>
+                <div class="app-!-layout-flex-start">
+                  <svg class="app-icon app-warning-icon app-icon--tiny govuk-!-margin-right-1"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Warning">
+  <path fill-rule="nonzero"
+        d="M23.9476157 36.7259786c.9649347 0 1.7226097-.2577461 2.2730249-.7732384.5504152-.5154923.8256227-1.2557058.8256227-2.2206406 0-.9649347-.267236-1.7320996-.8017081-2.3014946-.5344722-.569395-1.2841756-.8540925-2.2491104-.8540925-.9649347 0-1.7226097.2810913-2.2730249.843274-.5504152.5618031-.8256227 1.3253618-.8256227 2.2906761 0 .9649348.267236 1.7087545.8017081 2.2314591.5344722.5227046 1.2841756.7840569 2.2491104.7840569Zm.1867615-9.9644128c.7645077 0 1.3840095-.2397153 1.8585054-.7191459.4744958-.479051.7117437-1.112408.7117437-1.9000711V14.0071174c0-.7508422-.2406643-1.365599-.7219928-1.8442704-.480949-.4786714-1.1036774-.7180071-1.8681851-.7180071-.726548 0-1.3401661.2393357-1.8408541.7180071-.5003084.4786714-.7504626 1.0934282-.7504626 1.8442704v10.1352314c0 .7876631.2535706 1.4210201.7607117 1.9000711.5071412.4794306 1.1239858.7191459 1.8505338.7191459ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.94908659-5.46011862 5.12683274-7.64583629 2.17812574-2.18533808 4.72635823-3.90282325 7.64469753-5.15245552C17.549134.62500593 20.6595492 0 23.9624199 0c3.3165362 0 6.4385291.62348754 9.3659787 1.87046263 2.9278292 1.24697509 5.4789086 2.9608541 7.6532384 5.14163701 2.1747094 2.18116252 3.888019 4.73432976 5.1399288 7.65950176C47.3738553 17.597153 48 20.7214235 48 24.0444128c0 3.3199526-.6250059 6.4334045-1.8750178 9.3403559-1.2496323 2.9069513-2.9671174 5.4460735-5.1524555 7.6173665-2.1857177 2.1716726-4.7375564 3.8808067-7.655516 5.1274022C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+ Changes to external services will persist. S3, MongoDb, Redis, etc
+                </div>
+              </li>
+<li>
+                <div class="app-!-layout-flex-start">
+                  <svg class="app-icon app-warning-icon app-icon--tiny govuk-!-margin-right-1"
+     xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="Warning">
+  <path fill-rule="nonzero"
+        d="M23.9476157 36.7259786c.9649347 0 1.7226097-.2577461 2.2730249-.7732384.5504152-.5154923.8256227-1.2557058.8256227-2.2206406 0-.9649347-.267236-1.7320996-.8017081-2.3014946-.5344722-.569395-1.2841756-.8540925-2.2491104-.8540925-.9649347 0-1.7226097.2810913-2.2730249.843274-.5504152.5618031-.8256227 1.3253618-.8256227 2.2906761 0 .9649348.267236 1.7087545.8017081 2.2314591.5344722.5227046 1.2841756.7840569 2.2491104.7840569Zm.1867615-9.9644128c.7645077 0 1.3840095-.2397153 1.8585054-.7191459.4744958-.479051.7117437-1.112408.7117437-1.9000711V14.0071174c0-.7508422-.2406643-1.365599-.7219928-1.8442704-.480949-.4786714-1.1036774-.7180071-1.8681851-.7180071-.726548 0-1.3401661.2393357-1.8408541.7180071-.5003084.4786714-.7504626 1.0934282-.7504626 1.8442704v10.1352314c0 .7876631.2535706 1.4210201.7607117 1.9000711.5071412.4794306 1.1239858.7191459 1.8505338.7191459ZM23.9686833 48c-3.3047687 0-6.4203084-.6187426-9.3466192-1.8562278-2.9263108-1.2378647-5.47606173-2.9433926-7.64925271-5.1165836-2.17319099-2.173191-3.87871886-4.7242705-5.11658363-7.6532384C.61874259 30.4449822 0 27.3229893 0 24.0079715c0-3.3112218.61988138-6.4227758 1.85964413-9.3346619 1.24014235-2.9115065 2.94908659-5.46011862 5.12683274-7.64583629 2.17812574-2.18533808 4.72635823-3.90282325 7.64469753-5.15245552C17.549134.62500593 20.6595492 0 23.9624199 0c3.3165362 0 6.4385291.62348754 9.3659787 1.87046263 2.9278292 1.24697509 5.4789086 2.9608541 7.6532384 5.14163701 2.1747094 2.18116252 3.888019 4.73432976 5.1399288 7.65950176C47.3738553 17.597153 48 20.7214235 48 24.0444128c0 3.3199526-.6250059 6.4334045-1.8750178 9.3403559-1.2496323 2.9069513-2.9671174 5.4460735-5.1524555 7.6173665-2.1857177 2.1716726-4.7375564 3.8808067-7.655516 5.1274022C30.399051 47.3765125 27.2829419 48 23.9686833 48Z" />
+</svg>
+ Maximum 20 GB of ephemeral storage
+                </div>
+              </li>
+          </ul>
+
+  </span>
+
+</div>
+
+
+      </div>
+    </div>
+  </section>
+
+      </section>
+</div>
+
+        </main>
+      </div>
+
+  
+<footer class="app-footer" role="contentinfo" data-testid="app-footer">
+
+  <div class="app-footer__row">
+    <div class="app-footer__primary">
+      <p>
+        If you have a question, idea or suggestion. Contact the Platform team via Slack
+        <a class="app-footer__link" href="https://defra-digital-team.slack.com/archives/C05UJ3SE5C6" target="_blank"
+           rel="noopener noreferrer">#cdp-support</a>
+      </p>
+
+      <ul class="app-footer__list">
+        <li class="app-footer__list-item">
+          <a href="/documentation" class="app-footer__link">Documentation</a>
+        </li>
+        <li class="app-footer__list-item">
+          <a href="/help/cookie-policy" class="app-footer__link">Cookie policy</a>
+        </li>
+        <li class="app-footer__list-item">
+          <a href="/help/accessibility-statement" class="app-footer__link">Accessibility statement</a>
+        </li>
+      </ul>
+
+        <ul class="app-footer__list">
+          <li class="app-footer__list-item">
+            <a class="app-footer__link"
+               href="https://github.com/DEFRA/cdp-portal-frontend/releases/tag/0.1.0"
+               target="_blank" rel="noopener noreferrer">0.1.0</a>
+          </li>
+        </ul>
+    </div>
+
+    <div class="app-footer__secondary">
+      <a class="app-footer__link"
+         href="https://github.com/DEFRA/cdp-portal-frontend"
+         target="_blank"
+         rel="noopener noreferrer"><svg class="app-icon app-github-icon app-icon--small"
+     xmlns="http://www.w3.org/2000/svg"
+     width="48" height="48" viewBox="0 0 48 48"
+     role="img" aria-label="CDP Portal Frontend repository on GitHub">
+  <path d="M23.9284898 0C10.6966531 0 0 11 0 24.6085c0 10.878 6.85371429 20.086 16.3616327 23.345 1.1887346.245 1.6241632-.5295 1.6241632-1.181 0-.5705-.0391837-2.526-.0391837-4.5635-6.6563265 1.467-8.04244893-2.9335-8.04244893-2.9335-1.06971429-2.852-2.65469388-3.585-2.65469388-3.585-2.17861225-1.5075.15869388-1.5075.15869388-1.5075 2.41665306.163 3.68473473 2.526 3.68473473 2.526 2.1389387 3.748 5.5856326 2.689 6.9722449 2.037.1978775-1.589.8321632-2.689 1.5056326-3.3-5.3088979-.5705-10.8945306-2.689-10.8945306-12.1415 0-2.689.95020408-4.889 2.4558367-6.6-.237551-.611-1.0697143-3.1375.2380408-6.519 0 0 2.0204082-.652 6.576 2.526 1.9504109-.5386687 3.9618381-.8126928 5.9823674-.815 2.0204082 0 4.08.2855 5.9818775.815 4.5560817-3.178 6.5764898-2.526 6.5764898-2.526 1.3077551 3.3815.4751021 5.908.2375511 6.519 1.5453061 1.711 2.4563265 3.911 2.4563265 6.6 0 9.4525-5.5856327 11.53-10.9342041 12.1415.8718367.774 1.6241633 2.2405 1.6241633 4.563 0 3.3-.0391837 5.9485-.0391837 6.763 0 .652.4359184 1.4265 1.6241633 1.182 9.5079183-3.26 16.3617395-12.4675 16.3617395-23.3455C47.8564898 11 37.1206531 0 23.9284898 0Z" />
+</svg>
+</a>
+    </div>
+  </div>
+
+</footer>
+
+
+  <script type="module" src="/.public/javascripts/application.js"></script>
+  </body>
+</html>

--- a/src/server/services/service/terminal/terminal.test.js
+++ b/src/server/services/service/terminal/terminal.test.js
@@ -1,11 +1,13 @@
+import { scopes, statusCodes } from '@defra/cdp-validation-kit'
+
 import {
   initialiseServer,
   mockAuthAndRenderUrl,
   mockFetchShutteringUrlsCall,
   mockServiceEntityCall,
+  mockTeam,
   mockTenantServicesCall
 } from '../../../../../test-helpers/common-page-rendering.js'
-import { statusCodes } from '@defra/cdp-validation-kit'
 
 vi.mock('../../../common/helpers/fetch/fetch-entities.js')
 vi.mock('../../../common/helpers/auth/get-user-session.js')
@@ -38,6 +40,18 @@ describe('Service Terminal page', () => {
     expect(result).toMatchFile()
   })
 
+  test('page renders for with prod terminal button for admin user with break glass', async () => {
+    const { result, statusCode } = await mockAuthAndRenderUrl(server, {
+      targetUrl: '/services/mock-service-with-terminal/terminal',
+      isAdmin: true,
+      isTenant: true,
+      teamScope: mockTeam.teamId,
+      additionalScopes: [`${scopes.breakGlass}:team:${mockTeam.teamId}`]
+    })
+    expect(statusCode).toBe(statusCodes.ok)
+    expect(result).toMatchFile()
+  })
+
   test('page errors for logged in non-service owner tenant', async () => {
     const { statusCode } = await mockAuthAndRenderUrl(server, {
       targetUrl: '/services/mock-service-with-terminal/terminal',
@@ -53,6 +67,18 @@ describe('Service Terminal page', () => {
       isAdmin: false,
       isTenant: true,
       teamScope: 'mock-team-id'
+    })
+    expect(statusCode).toBe(statusCodes.ok)
+    expect(result).toMatchFile()
+  })
+
+  test('page renders for with prod terminal button for service owner tenant', async () => {
+    const { result, statusCode } = await mockAuthAndRenderUrl(server, {
+      targetUrl: '/services/mock-service-with-terminal/terminal',
+      isAdmin: false,
+      isTenant: true,
+      teamScope: mockTeam.teamId,
+      additionalScopes: [`${scopes.breakGlass}:team:${mockTeam.teamId}`]
     })
     expect(statusCode).toBe(statusCodes.ok)
     expect(result).toMatchFile()

--- a/src/server/services/service/terminal/views/terminal.njk
+++ b/src/server/services/service/terminal/views/terminal.njk
@@ -23,7 +23,10 @@
     <form method="post" action="/services/{{ serviceName }}/terminal/{{ terminalEnv }}" target="_blank">
       <input type="hidden" name="csrfToken" value="{{ csrfToken }}" />
 
-      {% set classes = ["app-button app-button--primary app-button--small", "app-button--destructive" if terminalEnv == "prod"] | join(" ") | trim %}
+      {% set classes = [
+        "app-button app-button--primary app-button--small",
+        "app-button--significant" if terminalEnv == "prod"
+      ] | join(" ") | trim %}
 
       {{ govukButton({
         classes: classes,
@@ -37,8 +40,6 @@
     { html: launchFormHtml }
   ]) }}
 {% endfor %}
-
-{# Tips and warnings #}
 
 {% set tips = [
   "Behave as your service does, same permissions, same visibility",

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -2,8 +2,8 @@ import { defineConfig, configDefaults } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    globals: true,
     environment: 'jsdom',
+    globals: true,
     clearMocks: true,
     snapshotFormat: {
       printBasicPrototype: false
@@ -18,14 +18,16 @@ export default defineConfig({
       provider: 'v8',
       reportsDirectory: './coverage',
       reporter: ['text', 'lcov'],
-      include: ['src/**'],
+      include: ['src/**/*.js'],
       exclude: [
         ...configDefaults.exclude,
+        'src/__fixtures__/**',
         '.public',
         'coverage',
         'postcss.config.js',
         'stylelint.config.js',
-        'vitest.config.js'
+        'vitest.config.js',
+        '.sonarlint'
       ]
     }
   }


### PR DESCRIPTION
- Move service column next to team
- Fix missing displayName in PRIT
- Make the terminal button a different colour
- Align no results nicer
- Add vite folder to exclusions

## Audit table re-ordering
<img width="2992" height="1548" alt="Screenshot 2025-09-16 at 18 25 27" src="https://github.com/user-attachments/assets/06e798d0-ab10-4bb8-98b1-a1488771ae84" />


## Prod button

I'll be changing this in my next ticket so this is a stop gap

<img width="2976" height="1505" alt="Screenshot 2025-09-16 at 18 16 14" src="https://github.com/user-attachments/assets/6aaff44e-54fd-403f-a8c6-df658ec14b32" />

