### PR TITLE
Core 1140 improve prits

### DIFF
--- a/.vite/setup-env.js
+++ b/.vite/setup-env.js
@@ -1,3 +1,4 @@
 process.env.ENVIRONMENT = 'test'
 process.env.SERVICE_VERSION = '0.1.0'
 process.env.TZ = 'UTC'
+process.env.ASSET_PATH = '/.public'

--- a/src/server/services/service/automations/views/__file_snapshots__/Service-automation-tab---Never-deployed-1.html
+++ b/src/server/services/service/automations/views/__file_snapshots__/Service-automation-tab---Never-deployed-1.html
@@ -135,27 +135,129 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
     <ul class="app-tabs__list" data-testid="app-tabs-list" role="tablist" aria-label="">
 
 
-        <li class="app-tabs__list-item app-tabs__list-item--selected"
-            data-testid="app-tabs-list-item-automation app-tabs-list-item--selected">
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-about">
 
 
-          <a id="tab-automation"
+          <a id="tab-about"
              class="app-tabs__tab"
-             href="services/cdp-portal-backend/automation"
+             href="/services/cdp-portal-backend"
              data-js="app-tab"
              role="tab"
-             aria-controls="tab-panel-automation"
+             aria-controls="tab-panel-about"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
+            About
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-resources">
+
+
+          <a id="tab-resources"
+             class="app-tabs__tab"
+             href="/services/cdp-portal-backend/resources"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-resources"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-resources">
+            Resources
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-proxy">
+
+
+          <a id="tab-proxy"
+             class="app-tabs__tab"
+             href="/services/cdp-portal-backend/proxy"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-proxy"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
+            Proxy
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item app-tabs__list-item--selected"
+            data-testid="app-tabs-list-item-automations app-tabs-list-item--selected">
+
+
+          <a id="tab-automations"
+             class="app-tabs__tab"
+             href="/services/cdp-portal-backend/automations"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-automations"
              aria-selected="true"
-             data-testid="app-tabs-list-item__anchor-automation">
-            Automation
+             data-testid="app-tabs-list-item__anchor-automations">
+            Automations
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-secrets">
+
+
+          <a id="tab-secrets"
+             class="app-tabs__tab"
+             href="/services/cdp-portal-backend/secrets"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-secrets"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
+            Secrets
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-maintenance">
+
+
+          <a id="tab-maintenance"
+             class="app-tabs__tab"
+             href="/services/cdp-portal-backend/maintenance"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-maintenance"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
+            Maintenance
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-terminal">
+
+
+          <a id="tab-terminal"
+             class="app-tabs__tab"
+             href="/services/cdp-portal-backend/terminal"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-terminal"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
+            Terminal
           </a>
         </li>
     </ul>
 
-      <section id="tab-panel-automation"
+      <section id="tab-panel-automations"
                class="app-tabs__panel"
                role="tabpanel"
-               aria-labelledby="tab-automation"
+               aria-labelledby="tab-automations"
                data-testid="app-tabs-panel">
           <section class="govuk-!-margin-top-6">
 

--- a/src/server/services/service/automations/views/__file_snapshots__/Service-automation-tab---Previously-deployed-1.html
+++ b/src/server/services/service/automations/views/__file_snapshots__/Service-automation-tab---Previously-deployed-1.html
@@ -135,27 +135,129 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
     <ul class="app-tabs__list" data-testid="app-tabs-list" role="tablist" aria-label="">
 
 
-        <li class="app-tabs__list-item app-tabs__list-item--selected"
-            data-testid="app-tabs-list-item-automation app-tabs-list-item--selected">
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-about">
 
 
-          <a id="tab-automation"
+          <a id="tab-about"
              class="app-tabs__tab"
-             href="services/cdp-portal-backend/automation"
+             href="/services/cdp-portal-backend"
              data-js="app-tab"
              role="tab"
-             aria-controls="tab-panel-automation"
+             aria-controls="tab-panel-about"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
+            About
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-resources">
+
+
+          <a id="tab-resources"
+             class="app-tabs__tab"
+             href="/services/cdp-portal-backend/resources"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-resources"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-resources">
+            Resources
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-proxy">
+
+
+          <a id="tab-proxy"
+             class="app-tabs__tab"
+             href="/services/cdp-portal-backend/proxy"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-proxy"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
+            Proxy
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item app-tabs__list-item--selected"
+            data-testid="app-tabs-list-item-automations app-tabs-list-item--selected">
+
+
+          <a id="tab-automations"
+             class="app-tabs__tab"
+             href="/services/cdp-portal-backend/automations"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-automations"
              aria-selected="true"
-             data-testid="app-tabs-list-item__anchor-automation">
-            Automation
+             data-testid="app-tabs-list-item__anchor-automations">
+            Automations
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-secrets">
+
+
+          <a id="tab-secrets"
+             class="app-tabs__tab"
+             href="/services/cdp-portal-backend/secrets"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-secrets"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
+            Secrets
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-maintenance">
+
+
+          <a id="tab-maintenance"
+             class="app-tabs__tab"
+             href="/services/cdp-portal-backend/maintenance"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-maintenance"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
+            Maintenance
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-terminal">
+
+
+          <a id="tab-terminal"
+             class="app-tabs__tab"
+             href="/services/cdp-portal-backend/terminal"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-terminal"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
+            Terminal
           </a>
         </li>
     </ul>
 
-      <section id="tab-panel-automation"
+      <section id="tab-panel-automations"
                class="app-tabs__panel"
                role="tabpanel"
-               aria-labelledby="tab-automation"
+               aria-labelledby="tab-automations"
                data-testid="app-tabs-panel">
           <section class="govuk-!-margin-top-6">
 

--- a/src/server/services/service/automations/views/__file_snapshots__/Service-automation-tab---With-auto-deploy-turned-on-1.html
+++ b/src/server/services/service/automations/views/__file_snapshots__/Service-automation-tab---With-auto-deploy-turned-on-1.html
@@ -135,27 +135,129 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
     <ul class="app-tabs__list" data-testid="app-tabs-list" role="tablist" aria-label="">
 
 
-        <li class="app-tabs__list-item app-tabs__list-item--selected"
-            data-testid="app-tabs-list-item-automation app-tabs-list-item--selected">
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-about">
 
 
-          <a id="tab-automation"
+          <a id="tab-about"
              class="app-tabs__tab"
-             href="services/cdp-portal-backend/automation"
+             href="/services/cdp-portal-backend"
              data-js="app-tab"
              role="tab"
-             aria-controls="tab-panel-automation"
+             aria-controls="tab-panel-about"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-about">
+            About
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-resources">
+
+
+          <a id="tab-resources"
+             class="app-tabs__tab"
+             href="/services/cdp-portal-backend/resources"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-resources"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-resources">
+            Resources
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-proxy">
+
+
+          <a id="tab-proxy"
+             class="app-tabs__tab"
+             href="/services/cdp-portal-backend/proxy"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-proxy"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-proxy">
+            Proxy
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item app-tabs__list-item--selected"
+            data-testid="app-tabs-list-item-automations app-tabs-list-item--selected">
+
+
+          <a id="tab-automations"
+             class="app-tabs__tab"
+             href="/services/cdp-portal-backend/automations"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-automations"
              aria-selected="true"
-             data-testid="app-tabs-list-item__anchor-automation">
-            Automation
+             data-testid="app-tabs-list-item__anchor-automations">
+            Automations
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-secrets">
+
+
+          <a id="tab-secrets"
+             class="app-tabs__tab"
+             href="/services/cdp-portal-backend/secrets"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-secrets"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-secrets">
+            Secrets
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-maintenance">
+
+
+          <a id="tab-maintenance"
+             class="app-tabs__tab"
+             href="/services/cdp-portal-backend/maintenance"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-maintenance"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-maintenance">
+            Maintenance
+          </a>
+        </li>
+
+
+        <li class="app-tabs__list-item"
+            data-testid="app-tabs-list-item-terminal">
+
+
+          <a id="tab-terminal"
+             class="app-tabs__tab"
+             href="/services/cdp-portal-backend/terminal"
+             data-js="app-tab"
+             role="tab"
+             aria-controls="tab-panel-terminal"
+             aria-selected="false"
+             data-testid="app-tabs-list-item__anchor-terminal">
+            Terminal
           </a>
         </li>
     </ul>
 
-      <section id="tab-panel-automation"
+      <section id="tab-panel-automations"
                class="app-tabs__panel"
                role="tabpanel"
-               aria-labelledby="tab-automation"
+               aria-labelledby="tab-automations"
                data-testid="app-tabs-panel">
           <section class="govuk-!-margin-top-6">
 

--- a/src/server/services/service/automations/views/auto-deployments.test.js
+++ b/src/server/services/service/automations/views/auto-deployments.test.js
@@ -1,6 +1,7 @@
 import { renderPage } from '../../../../../../test-helpers/component-helpers.js'
 import { buildOptions } from '../../../../common/helpers/options/build-options.js'
 import { entityServicesFixture } from '../../../../../__fixtures__/services/entities.js'
+import { mockServiceTabs } from '../../../../../../test-helpers/mock-tabs.js'
 
 function buildServiceAutomationContext({
   entity,
@@ -8,18 +9,14 @@ function buildServiceAutomationContext({
   formEnvironments
 }) {
   const serviceId = entity.name
+  const tabs = mockServiceTabs({
+    serviceName: serviceId,
+    url: `/services/${serviceId}/automations`
+  })
 
   return {
     isAdmin: true,
-    tabDetails: {
-      tabs: [
-        {
-          isActive: true,
-          url: `services/${serviceId}/automation`,
-          label: 'Automation'
-        }
-      ]
-    },
+    tabDetails: { tabs },
     pageTitle: `${serviceId} - Automation`,
     formValues: {
       environments: formEnvironments
@@ -56,7 +53,7 @@ describe('Service automation tab', () => {
     vi.useRealTimers()
   })
 
-  test('Never deployedq', () => {
+  test('Never deployed', () => {
     const rendered = renderPage(
       'services/service/automations/views/auto-deployments',
       buildServiceAutomationContext({

--- a/src/server/services/service/status/__file_snapshots__/Service-Status-page---Created-status---logged-in-admin-user-2.html
+++ b/src/server/services/service/status/__file_snapshots__/Service-Status-page---Created-status---logged-in-admin-user-2.html
@@ -466,7 +466,7 @@ data-testid="Repository-created">
                   NginxUpstreams
                 </div>
                 <div class="govuk-hint govuk-!-margin-bottom-2">
-                  Enable your service to be accessible to other services/.public on the Core Delivery Platform environments
+                  Enable your service to be accessible to other services/public on the Core Delivery Platform environments
                 </div>
               </li>
               <li>

--- a/src/server/services/service/status/__file_snapshots__/Service-Status-page---Created-status---logged-in-tenant-user-2.html
+++ b/src/server/services/service/status/__file_snapshots__/Service-Status-page---Created-status---logged-in-tenant-user-2.html
@@ -452,7 +452,7 @@ data-testid="Repository-created">
                   NginxUpstreams
                 </div>
                 <div class="govuk-hint govuk-!-margin-bottom-2">
-                  Enable your service to be accessible to other services/.public on the Core Delivery Platform environments
+                  Enable your service to be accessible to other services/public on the Core Delivery Platform environments
                 </div>
               </li>
               <li>

--- a/src/server/services/service/status/__file_snapshots__/Service-Status-page---Created-status---logged-in-tenant-user-service-owner-2.html
+++ b/src/server/services/service/status/__file_snapshots__/Service-Status-page---Created-status---logged-in-tenant-user-service-owner-2.html
@@ -452,7 +452,7 @@ data-testid="Repository-created">
                   NginxUpstreams
                 </div>
                 <div class="govuk-hint govuk-!-margin-bottom-2">
-                  Enable your service to be accessible to other services/.public on the Core Delivery Platform environments
+                  Enable your service to be accessible to other services/public on the Core Delivery Platform environments
                 </div>
               </li>
               <li>

--- a/src/server/services/service/status/__file_snapshots__/Service-Status-page---Created-status---logged-out-2.html
+++ b/src/server/services/service/status/__file_snapshots__/Service-Status-page---Created-status---logged-out-2.html
@@ -414,7 +414,7 @@ data-testid="Repository-created">
                   NginxUpstreams
                 </div>
                 <div class="govuk-hint govuk-!-margin-bottom-2">
-                  Enable your service to be accessible to other services/.public on the Core Delivery Platform environments
+                  Enable your service to be accessible to other services/public on the Core Delivery Platform environments
                 </div>
               </li>
               <li>

--- a/src/server/services/service/status/__file_snapshots__/Service-Status-page---Creating-status---logged-in-admin-user-2.html
+++ b/src/server/services/service/status/__file_snapshots__/Service-Status-page---Creating-status---logged-in-admin-user-2.html
@@ -470,7 +470,7 @@ data-testid="Repository-created">
                   NginxUpstreams
                 </div>
                 <div class="govuk-hint govuk-!-margin-bottom-2">
-                  Enable your service to be accessible to other services/.public on the Core Delivery Platform environments
+                  Enable your service to be accessible to other services/public on the Core Delivery Platform environments
                 </div>
               </li>
               <li>

--- a/src/server/services/service/status/__file_snapshots__/Service-Status-page---Creating-status---logged-in-tenant-user-2.html
+++ b/src/server/services/service/status/__file_snapshots__/Service-Status-page---Creating-status---logged-in-tenant-user-2.html
@@ -456,7 +456,7 @@ data-testid="Repository-created">
                   NginxUpstreams
                 </div>
                 <div class="govuk-hint govuk-!-margin-bottom-2">
-                  Enable your service to be accessible to other services/.public on the Core Delivery Platform environments
+                  Enable your service to be accessible to other services/public on the Core Delivery Platform environments
                 </div>
               </li>
               <li>

--- a/src/server/services/service/status/__file_snapshots__/Service-Status-page---Creating-status---logged-in-tenant-user-service-owner-2.html
+++ b/src/server/services/service/status/__file_snapshots__/Service-Status-page---Creating-status---logged-in-tenant-user-service-owner-2.html
@@ -456,7 +456,7 @@ data-testid="Repository-created">
                   NginxUpstreams
                 </div>
                 <div class="govuk-hint govuk-!-margin-bottom-2">
-                  Enable your service to be accessible to other services/.public on the Core Delivery Platform environments
+                  Enable your service to be accessible to other services/public on the Core Delivery Platform environments
                 </div>
               </li>
               <li>

--- a/src/server/services/service/status/__file_snapshots__/Service-Status-page---Creating-status---logged-out-2.html
+++ b/src/server/services/service/status/__file_snapshots__/Service-Status-page---Creating-status---logged-out-2.html
@@ -418,7 +418,7 @@ data-testid="Repository-created">
                   NginxUpstreams
                 </div>
                 <div class="govuk-hint govuk-!-margin-bottom-2">
-                  Enable your service to be accessible to other services/.public on the Core Delivery Platform environments
+                  Enable your service to be accessible to other services/public on the Core Delivery Platform environments
                 </div>
               </li>
               <li>

--- a/test-helpers/mock-tabs.js
+++ b/test-helpers/mock-tabs.js
@@ -1,0 +1,41 @@
+export const mockServiceTabs = ({ serviceName, url }) => {
+  const serviceBaseUrl = `/services/${serviceName}`
+
+  return [
+    {
+      isActive: url === serviceBaseUrl,
+      url: `${serviceBaseUrl}`,
+      label: 'About'
+    },
+    {
+      isActive: url === `${serviceBaseUrl}/resources`,
+      url: `${serviceBaseUrl}/resources`,
+      label: 'Resources'
+    },
+    {
+      isActive: url === `${serviceBaseUrl}/proxy`,
+      url: `${serviceBaseUrl}/proxy`,
+      label: 'Proxy'
+    },
+    {
+      isActive: url === `${serviceBaseUrl}/automations`,
+      url: `${serviceBaseUrl}/automations`,
+      label: 'Automations'
+    },
+    {
+      isActive: url === `${serviceBaseUrl}/secrets`,
+      url: `${serviceBaseUrl}/secrets`,
+      label: 'Secrets'
+    },
+    {
+      isActive: url === `${serviceBaseUrl}/maintenance`,
+      url: `${serviceBaseUrl}/maintenance`,
+      label: 'Maintenance'
+    },
+    {
+      isActive: url === `${serviceBaseUrl}/terminal`,
+      url: `${serviceBaseUrl}/terminal`,
+      label: 'Terminal'
+    }
+  ]
+}

--- a/test-helpers/test-globals.js
+++ b/test-helpers/test-globals.js
@@ -7,17 +7,6 @@ import { getAssetPath } from '../src/config/nunjucks/context/context.js'
  */
 
 /**
- * Test version of get asset path. Same as app one, but the url references local assets. You need to have run the
- * build command to have the assets available. Which is automatically done via the `pretest` npm script
- * @param {string} asset
- * @returns {string}
- */
-function getTestAssetPath(asset) {
-  const assetPath = getAssetPath(asset)
-  return assetPath.replace(/^\//, '/.')
-}
-
-/**
  * Test version of routeLookup. This returns the id so links using routeLookup in tests will have the id as their href
  * @param {string} id
  * @returns {string}
@@ -26,6 +15,6 @@ const routeLookup = (id) => id
 
 export const testGlobals = {
   ...globals,
-  getAssetPath: getTestAssetPath,
+  getAssetPath,
   routeLookup
 }

--- a/test-helpers/to-match-file.js
+++ b/test-helpers/to-match-file.js
@@ -1,8 +1,8 @@
 import { toMatchFile } from 'jest-file-snapshot'
 
 /**
- * Augment the toMatchFile method to provide markup with local assets and global options for this matcher so
- * they don't have to be passed everytime we use it
+ * Curry the toMatchFile method to provide global options for this matcher so they don't have to be passed everytime
+ * we use it
  *
  * @param {string} content
  * @param {filename} filename
@@ -14,10 +14,7 @@ function toMatchFileWithOptions(
   filename,
   options = { fileExtension: '.html' }
 ) {
-  // Update assets path to use local assets so html snapshot uses the local assets
-  const updatedContent = content.replace(/\/public/g, '/.public')
-
-  return toMatchFile.call(this, updatedContent, filename, options)
+  return toMatchFile.call(this, content, filename, options)
 }
 
 export { toMatchFileWithOptions }


### PR DESCRIPTION
- use `ASSET_PATH` env via config rather than find and replace for asset path. Set this in tests to the path for locally rendered assets `/.public`
- update tab tests to render in PRITs same same as they do in the app
- remove `getAssetPath` find and replace on local asset path and `pageRender` tests
- typo in test description that travelled through to snapshot file name
- add `mockTabs` test helper