### PR TITLE
CORE-1457: Pass query params through to xhr

### DIFF
--- a/src/client/common/helpers/poll.js
+++ b/src/client/common/helpers/poll.js
@@ -4,7 +4,6 @@ import { xhrRequest } from './xhr.js'
 import { clientNotification } from './client-notification.js'
 
 /**
- *
  * @param {string} url - poll url
  * @param {number} [interval] - poll interval
  * @param {number} [limit] - poll limit in minutes. After this period, polling is paused
@@ -14,7 +13,10 @@ import { clientNotification } from './client-notification.js'
 function startPolling(url, interval, limit, pollBegin) {
   return async function pollUrl() {
     const isBeforePollLimit = isBefore(Date.now(), addMinutes(pollBegin, limit))
-    const { ok, text } = await xhrRequest(url)
+    const urlSearchParams = new URLSearchParams(window.location.search)
+    const urlParams = Object.fromEntries(urlSearchParams.entries())
+
+    const { ok, text } = await xhrRequest(url, urlParams)
     const timerInfo = {}
 
     // TODO roll out the data xhrStop, xhrSuccessMessage, xhrErrorMessage attribute to all pollers


### PR DESCRIPTION
This will then do a few things:
- maintain query params in the browser url
- pass query params through to the polling url via xhr


## Demo

Note this is local data IRL this would poll on pages with tests that have not completed

![polling-pagination-fix](https://github.com/user-attachments/assets/cb7fa48f-e89d-4fb3-babb-c786216fc487)
