### PR TITLE
CORE-1581: Link h1 in blog preview to blog articles

### DIFF
--- a/src/client/stylesheets/core/_markdown.scss
+++ b/src/client/stylesheets/core/_markdown.scss
@@ -48,6 +48,14 @@ $caution: #cf222e;
     @include app-link-underline;
   }
 
+  h1 a,
+  h2 a,
+  h3 a,
+  h4 a {
+    @include app-link-underline;
+    @include govuk-link-style-text;
+  }
+
   img {
     max-width: 100%;
     border: 1px solid $app-brand-border-colour-light;

--- a/src/server/common/components/blog/_blog.scss
+++ b/src/server/common/components/blog/_blog.scss
@@ -48,7 +48,7 @@
 }
 
 .app-blog__body {
-  @include app-section-large-width;
+  @include app-section-width;
 
   height: 100%;
   flex: 1;

--- a/src/server/documentation/helpers/markdown/build-page-html.js
+++ b/src/server/documentation/helpers/markdown/build-page-html.js
@@ -6,6 +6,7 @@ import { escapeRegex } from '@hapi/hoek'
 import { linkExtension } from '../extensions/link.js'
 import { headingExtension } from '../extensions/heading.js'
 import { renderComponent } from '../../../common/helpers/nunjucks/render-component.js'
+import { previewHeadingsExtension } from '../../../home/helpers/extensions/preview-headings.js'
 
 function createHighlightExtension(searchTerm) {
   if (!searchTerm) {
@@ -137,19 +138,20 @@ async function buildDocsPageHtml(request, markdown) {
  * Html page for the blog pages. Add article datetime element, heading anchors and build table of contents
  * @param {string} markdown
  * @param {string} articlePath
- * @param {boolean} withHeadingExtension
+ * @param {boolean} withBlogLink
  * @returns {Promise<{html: string, toc: string}>}
  */
 async function buildBlogPageHtml({
   markdown,
   articlePath,
-  withHeadingExtension = true
+  withBlogLink = false
 }) {
+  const previewHeadersExtension = previewHeadingsExtension(
+    withBlogLink ? articlePath : null
+  )
+
   const headings = []
-  const extensions = [
-    linkExtension,
-    ...(withHeadingExtension ? [headingExtension] : [])
-  ]
+  const extensions = [linkExtension, previewHeadersExtension]
   const blogMarked = new Marked({
     gfm: true,
     extensions

--- a/src/server/home/__file_snapshots__/Blog-page---logged-in---admin-user-2.html
+++ b/src/server/home/__file_snapshots__/Blog-page---logged-in---admin-user-2.html
@@ -282,13 +282,9 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 
-<h1 id="introducing-the-cdp-blog">
-                <a class="heading-link" href="#introducing-the-cdp-blog">Introducing the CDP blog</a>
-              </h1><p>We’re excited to introduce a new way to stay informed — the CDP blog! 🎉</p>
+<h1 id="introducing-the-cdp-blog"><a class="heading-link" href="#introducing-the-cdp-blog">Introducing the CDP blog</a></h1><p>We’re excited to introduce a new way to stay informed — the CDP blog! 🎉</p>
 <p>From now on, this will be your central space for platform updates, new feature announcements, improvement rollouts, and insights into what’s coming next on CDP.</p>
-<h2 id="why-are-we-launching-this-blog-">
-                <a class="heading-link" href="#why-are-we-launching-this-blog-">Why are we launching this blog?</a>
-              </h2><p>As CDP continues to grow and evolve, we want to make it easier for every tenant to stay connected with the latest developments; instead of relying solely on Slack for updates.</p>
+<h2 id="why-are-we-launching-this-blog-"><a class="heading-link" href="#why-are-we-launching-this-blog-">Why are we launching this blog?</a></h2><p>As CDP continues to grow and evolve, we want to make it easier for every tenant to stay connected with the latest developments; instead of relying solely on Slack for updates.</p>
 <p>Watch this space!</p>
 
         </article>

--- a/src/server/home/__file_snapshots__/Blog-page---logged-in---tenant-user-2.html
+++ b/src/server/home/__file_snapshots__/Blog-page---logged-in---tenant-user-2.html
@@ -268,38 +268,26 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 
-<h1 id="passing-profile-to-the-test-suite">
-                <a class="heading-link" href="#passing-profile-to-the-test-suite">Passing profile to the test suite</a>
-              </h1><p>You can now pass a profile <code>value</code> to a test-suite when running it on the CDP Platform. The value is sent to the
+<h1 id="passing-profile-to-the-test-suite"><a class="heading-link" href="#passing-profile-to-the-test-suite">Passing profile to the test suite</a></h1><p>You can now pass a profile <code>value</code> to a test-suite when running it on the CDP Platform. The value is sent to the
 test-suite as the environment variable <code>PROFILE</code>. Profiles are a way of changing the behaviour of the test-suite without
 changing the code.</p>
-<h2 id="motivation">
-                <a class="heading-link" href="#motivation">Motivation</a>
-              </h2><p>When running tests it is often useful to be able to change the behaviour of the test suite without having to
+<h2 id="motivation"><a class="heading-link" href="#motivation">Motivation</a></h2><p>When running tests it is often useful to be able to change the behaviour of the test suite without having to
 change the code itself. This is especially useful when you want to run the same test suite in various different ways</p>
-<h2 id="use-cases">
-                <a class="heading-link" href="#use-cases">Use Cases</a>
-              </h2><p>A few example use cases would be to run the same test suite:</p>
+<h2 id="use-cases"><a class="heading-link" href="#use-cases">Use Cases</a></h2><p>A few example use cases would be to run the same test suite:</p>
 <ol>
 <li>Against a different subset of tests (E.g. smoke tests)</li>
 <li>With a varying performance test measure (E.g. number of users/requests per minute)</li>
 </ol>
-<h2 id="implementations">
-                <a class="heading-link" href="#implementations">Implementations</a>
-              </h2><p>Potential implementation options would be:</p>
+<h2 id="implementations"><a class="heading-link" href="#implementations">Implementations</a></h2><p>Potential implementation options would be:</p>
 <ol>
 <li>Read the environment variable <code>PROFILE</code> and pass it into the <code>Dockerfile</code></li>
 <li>Use the environment variable <code>PROFILE</code> to load different config files within your test suite</li>
 <li>Use the environment variable <code>PROFILE</code> to set flags in the test framework</li>
 <li>Any other way that suits your test suite design</li>
 </ol>
-<h2 id="setting-the-profile-value">
-                <a class="heading-link" href="#setting-the-profile-value">Setting the profile value</a>
-              </h2><p>For more information on how to set the value of the profile when running your test suite see the
+<h2 id="setting-the-profile-value"><a class="heading-link" href="#setting-the-profile-value">Setting the profile value</a></h2><p>For more information on how to set the value of the profile when running your test suite see the
 <a href="../how-to/testing/testing.md">Running Test Suites with a profile value</a></p>
-<h2 id="feedback">
-                <a class="heading-link" href="#feedback">Feedback</a>
-              </h2><p>As always any comments, feedback or feature requests please do start a conversation in
+<h2 id="feedback"><a class="heading-link" href="#feedback">Feedback</a></h2><p>As always any comments, feedback or feature requests please do start a conversation in
 Slack <a href="https://defra-digital-team.slack.com/archives/C05UJ3SE5C6/" target="_blank" rel="noopener noreferrer">#cdp-support</a></p>
 
         </article>

--- a/src/server/home/__file_snapshots__/Blog-page---logged-out-user-2.html
+++ b/src/server/home/__file_snapshots__/Blog-page---logged-out-user-2.html
@@ -226,13 +226,9 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 
-<h1 id="introducing-the-cdp-blog">
-                <a class="heading-link" href="#introducing-the-cdp-blog">Introducing the CDP blog</a>
-              </h1><p>We’re excited to introduce a new way to stay informed — the CDP blog! 🎉</p>
+<h1 id="introducing-the-cdp-blog"><a class="heading-link" href="#introducing-the-cdp-blog">Introducing the CDP blog</a></h1><p>We’re excited to introduce a new way to stay informed — the CDP blog! 🎉</p>
 <p>From now on, this will be your central space for platform updates, new feature announcements, improvement rollouts, and insights into what’s coming next on CDP.</p>
-<h2 id="why-are-we-launching-this-blog-">
-                <a class="heading-link" href="#why-are-we-launching-this-blog-">Why are we launching this blog?</a>
-              </h2><p>As CDP continues to grow and evolve, we want to make it easier for every tenant to stay connected with the latest developments; instead of relying solely on Slack for updates.</p>
+<h2 id="why-are-we-launching-this-blog-"><a class="heading-link" href="#why-are-we-launching-this-blog-">Why are we launching this blog?</a></h2><p>As CDP continues to grow and evolve, we want to make it easier for every tenant to stay connected with the latest developments; instead of relying solely on Slack for updates.</p>
 <p>Watch this space!</p>
 
         </article>

--- a/src/server/home/__file_snapshots__/Home-page---logged-in---admin-user-2.html
+++ b/src/server/home/__file_snapshots__/Home-page---logged-in---admin-user-2.html
@@ -352,8 +352,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 
-<h1>Introducing the CDP blog</h1>
-<p>We’re excited to introduce a new way to stay informed — the CDP blog! 🎉</p>
+<h1 id="introducing-the-cdp-blog"><a class="app-link app-link--text-colour" href="/blog/20251024-passing-profile-to-the-test-suite.md">Introducing the CDP blog</a></h1><p>We’re excited to introduce a new way to stay informed — the CDP blog! 🎉</p>
 <p>From now on, this will be your central space for platform updates, new feature announcements, improvement rollouts, and insights into what’s coming next on CDP.</p>
 <p><a class="app-link app-blog__more-link" href="/blog/20251024-passing-profile-to-the-test-suite.md">Read more</a></p></div><div class="app-blog__preview">
 
@@ -369,8 +368,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 
-<h1>Passing profile to the test suite</h1>
-<p>You can now pass a profile <code>value</code> to a test-suite when running it on the CDP Platform. The value is sent to the
+<h1 id="passing-profile-to-the-test-suite"><a class="app-link app-link--text-colour" href="/blog/20251017-introducing-the-cdp-blog.md">Passing profile to the test suite</a></h1><p>You can now pass a profile <code>value</code> to a test-suite when running it on the CDP Platform. The value is sent to the
 test-suite as the environment variable <code>PROFILE</code>. Profiles are a way of changing the behaviour of the test-suite without
 changing the code.</p>
 <p><a class="app-link app-blog__more-link" href="/blog/20251017-introducing-the-cdp-blog.md">Read more</a></p></div>

--- a/src/server/home/__file_snapshots__/Home-page---logged-in---tenant-user-2.html
+++ b/src/server/home/__file_snapshots__/Home-page---logged-in---tenant-user-2.html
@@ -338,8 +338,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 
-<h1>Introducing the CDP blog</h1>
-<p>We’re excited to introduce a new way to stay informed — the CDP blog! 🎉</p>
+<h1 id="introducing-the-cdp-blog"><a class="app-link app-link--text-colour" href="/blog/20251024-passing-profile-to-the-test-suite.md">Introducing the CDP blog</a></h1><p>We’re excited to introduce a new way to stay informed — the CDP blog! 🎉</p>
 <p>From now on, this will be your central space for platform updates, new feature announcements, improvement rollouts, and insights into what’s coming next on CDP.</p>
 <p><a class="app-link app-blog__more-link" href="/blog/20251024-passing-profile-to-the-test-suite.md">Read more</a></p></div><div class="app-blog__preview">
 
@@ -355,8 +354,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 
-<h1>Passing profile to the test suite</h1>
-<p>You can now pass a profile <code>value</code> to a test-suite when running it on the CDP Platform. The value is sent to the
+<h1 id="passing-profile-to-the-test-suite"><a class="app-link app-link--text-colour" href="/blog/20251017-introducing-the-cdp-blog.md">Passing profile to the test suite</a></h1><p>You can now pass a profile <code>value</code> to a test-suite when running it on the CDP Platform. The value is sent to the
 test-suite as the environment variable <code>PROFILE</code>. Profiles are a way of changing the behaviour of the test-suite without
 changing the code.</p>
 <p><a class="app-link app-blog__more-link" href="/blog/20251017-introducing-the-cdp-blog.md">Read more</a></p></div>

--- a/src/server/home/__file_snapshots__/Home-page---logged-in---tenant-user-old-ie-2.html
+++ b/src/server/home/__file_snapshots__/Home-page---logged-in---tenant-user-old-ie-2.html
@@ -361,8 +361,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 
-<h1>Introducing the CDP blog</h1>
-<p>We’re excited to introduce a new way to stay informed — the CDP blog! 🎉</p>
+<h1 id="introducing-the-cdp-blog"><a class="app-link app-link--text-colour" href="/blog/20251024-passing-profile-to-the-test-suite.md">Introducing the CDP blog</a></h1><p>We’re excited to introduce a new way to stay informed — the CDP blog! 🎉</p>
 <p>From now on, this will be your central space for platform updates, new feature announcements, improvement rollouts, and insights into what’s coming next on CDP.</p>
 <p><a class="app-link app-blog__more-link" href="/blog/20251024-passing-profile-to-the-test-suite.md">Read more</a></p></div><div class="app-blog__preview">
 
@@ -378,8 +377,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 
-<h1>Passing profile to the test suite</h1>
-<p>You can now pass a profile <code>value</code> to a test-suite when running it on the CDP Platform. The value is sent to the
+<h1 id="passing-profile-to-the-test-suite"><a class="app-link app-link--text-colour" href="/blog/20251017-introducing-the-cdp-blog.md">Passing profile to the test suite</a></h1><p>You can now pass a profile <code>value</code> to a test-suite when running it on the CDP Platform. The value is sent to the
 test-suite as the environment variable <code>PROFILE</code>. Profiles are a way of changing the behaviour of the test-suite without
 changing the code.</p>
 <p><a class="app-link app-blog__more-link" href="/blog/20251017-introducing-the-cdp-blog.md">Read more</a></p></div>

--- a/src/server/home/__file_snapshots__/Home-page---logged-in---unregistered-user-2.html
+++ b/src/server/home/__file_snapshots__/Home-page---logged-in---unregistered-user-2.html
@@ -334,8 +334,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 
-<h1>Introducing the CDP blog</h1>
-<p>We’re excited to introduce a new way to stay informed — the CDP blog! 🎉</p>
+<h1 id="introducing-the-cdp-blog"><a class="app-link app-link--text-colour" href="/blog/20251024-passing-profile-to-the-test-suite.md">Introducing the CDP blog</a></h1><p>We’re excited to introduce a new way to stay informed — the CDP blog! 🎉</p>
 <p>From now on, this will be your central space for platform updates, new feature announcements, improvement rollouts, and insights into what’s coming next on CDP.</p>
 <p><a class="app-link app-blog__more-link" href="/blog/20251024-passing-profile-to-the-test-suite.md">Read more</a></p></div><div class="app-blog__preview">
 
@@ -351,8 +350,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 
-<h1>Passing profile to the test suite</h1>
-<p>You can now pass a profile <code>value</code> to a test-suite when running it on the CDP Platform. The value is sent to the
+<h1 id="passing-profile-to-the-test-suite"><a class="app-link app-link--text-colour" href="/blog/20251017-introducing-the-cdp-blog.md">Passing profile to the test suite</a></h1><p>You can now pass a profile <code>value</code> to a test-suite when running it on the CDP Platform. The value is sent to the
 test-suite as the environment variable <code>PROFILE</code>. Profiles are a way of changing the behaviour of the test-suite without
 changing the code.</p>
 <p><a class="app-link app-blog__more-link" href="/blog/20251017-introducing-the-cdp-blog.md">Read more</a></p></div>

--- a/src/server/home/__file_snapshots__/Home-page---logged-in---unregistered-user-on-old-ie-2.html
+++ b/src/server/home/__file_snapshots__/Home-page---logged-in---unregistered-user-on-old-ie-2.html
@@ -337,8 +337,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 
-<h1>Introducing the CDP blog</h1>
-<p>We’re excited to introduce a new way to stay informed — the CDP blog! 🎉</p>
+<h1 id="introducing-the-cdp-blog"><a class="app-link app-link--text-colour" href="/blog/20251024-passing-profile-to-the-test-suite.md">Introducing the CDP blog</a></h1><p>We’re excited to introduce a new way to stay informed — the CDP blog! 🎉</p>
 <p>From now on, this will be your central space for platform updates, new feature announcements, improvement rollouts, and insights into what’s coming next on CDP.</p>
 <p><a class="app-link app-blog__more-link" href="/blog/20251024-passing-profile-to-the-test-suite.md">Read more</a></p></div><div class="app-blog__preview">
 
@@ -354,8 +353,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 
-<h1>Passing profile to the test suite</h1>
-<p>You can now pass a profile <code>value</code> to a test-suite when running it on the CDP Platform. The value is sent to the
+<h1 id="passing-profile-to-the-test-suite"><a class="app-link app-link--text-colour" href="/blog/20251017-introducing-the-cdp-blog.md">Passing profile to the test suite</a></h1><p>You can now pass a profile <code>value</code> to a test-suite when running it on the CDP Platform. The value is sent to the
 test-suite as the environment variable <code>PROFILE</code>. Profiles are a way of changing the behaviour of the test-suite without
 changing the code.</p>
 <p><a class="app-link app-blog__more-link" href="/blog/20251017-introducing-the-cdp-blog.md">Read more</a></p></div>

--- a/src/server/home/__file_snapshots__/Home-page---logged-out-user-2.html
+++ b/src/server/home/__file_snapshots__/Home-page---logged-out-user-2.html
@@ -296,8 +296,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 
-<h1>Introducing the CDP blog</h1>
-<p>We’re excited to introduce a new way to stay informed — the CDP blog! 🎉</p>
+<h1 id="introducing-the-cdp-blog"><a class="app-link app-link--text-colour" href="/blog/20251024-passing-profile-to-the-test-suite.md">Introducing the CDP blog</a></h1><p>We’re excited to introduce a new way to stay informed — the CDP blog! 🎉</p>
 <p>From now on, this will be your central space for platform updates, new feature announcements, improvement rollouts, and insights into what’s coming next on CDP.</p>
 <p><a class="app-link app-blog__more-link" href="/blog/20251024-passing-profile-to-the-test-suite.md">Read more</a></p></div><div class="app-blog__preview">
 
@@ -313,8 +312,7 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 
 
 
-<h1>Passing profile to the test suite</h1>
-<p>You can now pass a profile <code>value</code> to a test-suite when running it on the CDP Platform. The value is sent to the
+<h1 id="passing-profile-to-the-test-suite"><a class="app-link app-link--text-colour" href="/blog/20251017-introducing-the-cdp-blog.md">Passing profile to the test suite</a></h1><p>You can now pass a profile <code>value</code> to a test-suite when running it on the CDP Platform. The value is sent to the
 test-suite as the environment variable <code>PROFILE</code>. Profiles are a way of changing the behaviour of the test-suite without
 changing the code.</p>
 <p><a class="app-link app-blog__more-link" href="/blog/20251017-introducing-the-cdp-blog.md">Read more</a></p></div>

--- a/src/server/home/helpers/extensions/preview-headings.js
+++ b/src/server/home/helpers/extensions/preview-headings.js
@@ -1,0 +1,27 @@
+/**
+ * Extension to be used on blog preview articles. Preview headings extension that adds an anchor to h1 elements on the
+ * page linking to the blog article. All other heading elements have in page internal anchors adding to them
+ * @param {string} articlePath
+ * @returns {{name: string, level: string, renderer(*): string}}
+ */
+
+const previewHeadingsExtension = (articlePath) => ({
+  name: 'heading',
+  level: 'block',
+  renderer(token) {
+    const { text, depth: level } = token
+    const internalAnchorId = text.toLowerCase().replace(/\W+/g, '-')
+    const parsedText = this.parser.parseInline(token.tokens)
+    let anchor
+
+    if (articlePath && level === 1) {
+      anchor = `<a class="app-link app-link--text-colour" href="${articlePath}">${parsedText}</a>`
+    } else {
+      anchor = `<a class="heading-link" href="#${internalAnchorId}">${parsedText}</a>`
+    }
+
+    return `<h${level} id="${internalAnchorId}">${anchor}</h${level}>`
+  }
+})
+
+export { previewHeadingsExtension }

--- a/src/server/home/helpers/extensions/preview-headings.test.js
+++ b/src/server/home/helpers/extensions/preview-headings.test.js
@@ -1,0 +1,59 @@
+import { Marked } from 'marked'
+import { load } from 'cheerio'
+
+import { previewHeadingsExtension } from './preview-headings.js'
+
+describe('#previewHeadings', () => {
+  const previewHeadersExtension = previewHeadingsExtension(
+    '44-all-the-things-section'
+  )
+  let testMarked
+
+  beforeEach(() => {
+    testMarked = new Marked({
+      pedantic: false,
+      gfm: true,
+      extensions: [previewHeadersExtension]
+    })
+  })
+
+  test('Should render expected h1 heading', async () => {
+    const html = await testMarked.parse('# Introduction')
+    const $html = load(html)
+    const $heading = $html('h1')
+    const $anchor = $heading.find('a')
+
+    expect($heading).toHaveLength(1)
+    expect($anchor.attr('href')).toBe('44-all-the-things-section')
+    expect($anchor.attr('class')).toBe('app-link app-link--text-colour')
+    expect($anchor.text()).toBe('Introduction')
+  })
+
+  test('Should render heading, containing markdown, as expected', async () => {
+    const html = await testMarked.parse('# 44: All the `things` section')
+
+    const $html = load(html)
+    const $heading = $html('h1')
+    const $anchor = $heading.find('a')
+    const $code = $anchor.find('code')
+
+    expect($heading).toHaveLength(1)
+    expect($anchor.attr('href')).toBe('44-all-the-things-section')
+    expect($anchor.attr('class')).toBe('app-link app-link--text-colour')
+    expect($anchor.text()).toBe('44: All the things section')
+    expect($anchor.html()).toBe('44: All the <code>things</code> section')
+    expect($code.text()).toBe('things')
+  })
+
+  test('Should render expected h2 heading with an internal page anchor', async () => {
+    const html = await testMarked.parse('## Details')
+    const $html = load(html)
+    const $headingH2 = $html('h2')
+    const $anchor = $headingH2.find('a')
+
+    expect($headingH2).toHaveLength(1)
+    expect($anchor.attr('href')).toBe('#details')
+    expect($anchor.attr('class')).toBe('heading-link')
+    expect($anchor.text()).toBe('Details')
+  })
+})

--- a/src/server/home/routes/home.js
+++ b/src/server/home/routes/home.js
@@ -32,7 +32,7 @@ async function buildPreviewArticles(request, navHrefs, bucket) {
       const { html } = await buildBlogPageHtml({
         markdown: previewMd,
         articlePath: articleKey,
-        withHeadingExtension: false
+        withBlogLink: true
       })
 
       return { html, articleKey }


### PR DESCRIPTION
- Link the h1 headers in the blog previews to the blog article
- Make the width of the blog smaller

## Demo

![blog-h1-link-to-article](https://github.com/user-attachments/assets/3a66ea62-14ab-41f8-804b-91cd38a96045)

## Screenshot
<img width="1961" height="1746" alt="Screenshot 2025-10-27 at 14 17 49" src="https://github.com/user-attachments/assets/fd494afa-3e9d-4d10-8f8d-6a1711259693" />

