### PR TITLE
CORE-1668: Add label ability to the blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ cd cdp-documentation
 node .github/scripts/generate-blog.js ./blog
 awslocal s3 sync . s3://cdp-documentation \
         --exclude ".editorconfig" --exclude ".github/*" --exclude ".git/*" --exclude ".gitignore" --exclude "CONTRIBUTING.md" --exclude ".husky" --exclude "node_modules" \
-        --exclude "package.json" --exclude "package-lock.json" \
+        --exclude "package.json" --exclude "package-lock.json" --exclude ".idea" \
         --metadata "git-commit=$head_ref" \
         --delete
 ```

--- a/src/server/common/components/blog/_blog.scss
+++ b/src/server/common/components/blog/_blog.scss
@@ -24,7 +24,7 @@
 }
 
 .app-blog__nav-sidebar {
-  width: 240px;
+  width: 340px;
   position: sticky;
   top: govuk-spacing(6);
   overflow-y: auto;
@@ -55,7 +55,7 @@
 }
 
 .app-blog__toc-sidebar {
-  width: 240px;
+  width: 340px;
   position: sticky;
   top: govuk-spacing(6);
   overflow-y: auto;
@@ -80,8 +80,12 @@
 
 .app-blog__date {
   color: $govuk-secondary-text-colour;
-  display: block;
+  display: inline-block;
   margin-bottom: govuk-spacing(2);
+
+  .app-tag + & {
+    margin-left: govuk-spacing(1);
+  }
 }
 
 .app-blog__more-link {

--- a/src/server/documentation/helpers/markdown/build-page-html.test.js
+++ b/src/server/documentation/helpers/markdown/build-page-html.test.js
@@ -1,6 +1,10 @@
 import { load } from 'cheerio'
 
-import { buildDocsPageHtml } from './build-page-html.js'
+import {
+  buildDocsPageHtml,
+  extractTagsFromMarkdown,
+  extractHrefs
+} from './build-page-html.js'
 
 describe('#buildDocsPageHtml', () => {
   const searchTerm = ''
@@ -136,5 +140,58 @@ describe('#buildDocsPageHtml', () => {
     expect($link.prop('outerHTML')).toBe(
       '<a href="https://example-another.com" target="_blank" rel="noopener noreferrer">https://example-another.com</a>'
     )
+  })
+})
+
+describe('#extractTagsFromMarkdown', () => {
+  test('Should extract tags from Labels comment', () => {
+    const markdown = '<!-- Labels: NEW FEATURE, UPDATE -->\n\n# Heading'
+    const tags = extractTagsFromMarkdown(markdown)
+
+    expect(tags).toEqual(['NEW FEATURE', 'UPDATE'])
+  })
+
+  test('Should return empty array when no comment exists', () => {
+    const markdown = '# Heading\n\nSome content'
+    const tags = extractTagsFromMarkdown(markdown)
+
+    expect(tags).toEqual([])
+  })
+
+  test('Should return empty array when no Labels in comment', () => {
+    const markdown = '<!-- Some other comment -->\n\n# Heading'
+    const tags = extractTagsFromMarkdown(markdown)
+
+    expect(tags).toEqual([])
+  })
+
+  test('Should trim whitespace from tags', () => {
+    const markdown = '<!-- Labels:   ACTION REQUIRED  ,  BUG FIX   -->'
+    const tags = extractTagsFromMarkdown(markdown)
+
+    expect(tags).toEqual(['ACTION REQUIRED', 'BUG FIX'])
+  })
+
+  test('Should handle single tag', () => {
+    const markdown = '<!-- Labels: RELEASE -->'
+    const tags = extractTagsFromMarkdown(markdown)
+
+    expect(tags).toEqual(['RELEASE'])
+  })
+})
+
+describe('#extractHrefs', () => {
+  test('Should extract hrefs from markdown links', () => {
+    const markdown = '[Link 1](/path/one)\n[Link 2](/path/two)'
+    const hrefs = extractHrefs(markdown)
+
+    expect(hrefs).toEqual(['/path/one', '/path/two'])
+  })
+
+  test('Should return empty array when no links exist', () => {
+    const markdown = '# Heading\n\nSome content without links'
+    const hrefs = extractHrefs(markdown)
+
+    expect(hrefs).toEqual([])
   })
 })

--- a/src/server/home/helpers/blog-markdown-handler.js
+++ b/src/server/home/helpers/blog-markdown-handler.js
@@ -3,7 +3,10 @@ import { statusCodes } from '@defra/cdp-validation-kit'
 
 import { buildArticleNav } from './markdown/build-blog-nav.js'
 import { fetchMarkdown } from '../../documentation/helpers/s3-file-handler.js'
-import { buildBlogPageHtml } from '../../documentation/helpers/markdown/build-page-html.js'
+import {
+  buildBlogPageHtml,
+  extractTagsFromMarkdown
+} from '../../documentation/helpers/markdown/build-page-html.js'
 
 function buildPageTitle(articlePath) {
   const pathParts = articlePath.replace('.md', '').split('-')
@@ -19,8 +22,8 @@ async function blogMarkdownHandler(request, h, articlePath, bucket) {
     fetchMarkdown(request, bucket, articleKey),
     buildArticleNav(request, bucket, articlePath)
   ])
-
-  const { html, toc } = await buildBlogPageHtml({ markdown, articlePath })
+  const tags = extractTagsFromMarkdown(markdown)
+  const { html, toc } = await buildBlogPageHtml({ markdown, tags, articlePath })
   const pageTitle = buildPageTitle(articlePath)
 
   return h


### PR DESCRIPTION
- Add the ability to add labels via the `Markdown` and `HTML` comments in a blog post
- Widen the nav on the left and the TOC on the right to accommodate large titles


## Demo
<img width="4376" height="3638" alt="screencapture-cdp-127-0-0-1-sslip-io-3000-2025-12-16-17_54_04" src="https://github.com/user-attachments/assets/352adbfd-f78b-4b96-a889-c3bf69d3f524" />

<img width="3820" height="3488" alt="screencapture-cdp-127-0-0-1-sslip-io-3000-blog-20251203-mongodb-upgrade-production-md-2025-12-16-18_14_10" src="https://github.com/user-attachments/assets/158424cd-3958-4ffc-b2f8-ec27a8bdc9e0" />


## Associated PR
https://github.com/DEFRA/cdp-documentation/pull/507
