### PR TITLE
CORE-1668: Show shuttering section

### DIFF
--- a/src/server/services/service/maintenance/__file_snapshots__/Services---Maintenance-service-page---logged-in-admin-user-2.html
+++ b/src/server/services/service/maintenance/__file_snapshots__/Services---Maintenance-service-page---logged-in-admin-user-2.html
@@ -475,16 +475,17 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
                 </div>
 
 
+
 <div class="app-panel   app-panel--slim" data-testid="shuttering-panel">
   
-                    <section class="govuk-!-margin-bottom-6">
-                      <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-                        Service URLs</h2>
-                      <p class="govuk-!-margin-bottom-2">
-                          User-friendly custom URLs
-                      </p>
+                      <section class="govuk-!-margin-bottom-6">
+                        <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+                          Service URLs</h2>
+                        <p class="govuk-!-margin-bottom-2">
+                            User-friendly custom URLs
+                        </p>
 
-                      <table class="govuk-table app-table app-table--inverse govuk-!-margin-bottom-4">
+                        <table class="govuk-table app-table app-table--inverse govuk-!-margin-bottom-4">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">Service URL</th>
@@ -591,9 +592,10 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 </table>
 
 
-                    </section>
+                      </section>
 
 </div>
+
               </div>
           </article>
 

--- a/src/server/services/service/maintenance/__file_snapshots__/Services---Maintenance-service-page---logged-in-tenant-user-service-owner-with-scope-2.html
+++ b/src/server/services/service/maintenance/__file_snapshots__/Services---Maintenance-service-page---logged-in-tenant-user-service-owner-with-scope-2.html
@@ -464,16 +464,17 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
                 </div>
 
 
+
 <div class="app-panel   app-panel--slim" data-testid="shuttering-panel">
   
-                    <section class="govuk-!-margin-bottom-6">
-                      <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-                        Service URLs</h2>
-                      <p class="govuk-!-margin-bottom-2">
-                          User-friendly custom URLs
-                      </p>
+                      <section class="govuk-!-margin-bottom-6">
+                        <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+                          Service URLs</h2>
+                        <p class="govuk-!-margin-bottom-2">
+                            User-friendly custom URLs
+                        </p>
 
-                      <table class="govuk-table app-table app-table--inverse govuk-!-margin-bottom-4">
+                        <table class="govuk-table app-table app-table--inverse govuk-!-margin-bottom-4">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">Service URL</th>
@@ -580,9 +581,10 @@ data-js="app-client-notifications-content"     data-testid="app-banner-content">
 </table>
 
 
-                    </section>
+                      </section>
 
 </div>
+
               </div>
           </article>
 

--- a/src/server/services/service/maintenance/controllers/maintenance.js
+++ b/src/server/services/service/maintenance/controllers/maintenance.js
@@ -51,11 +51,13 @@ const maintenanceController = {
       )
 
     const isFrontend = entity.subType === 'Frontend'
+    const isPrototype = entity.subType === 'Prototype'
 
     return h.view('services/service/maintenance/views/maintenance', {
       pageTitle: `Maintenance - ${serviceId}`,
       entity,
       isFrontend,
+      isPrototype,
       shouldPoll,
       pendingShutter,
       shutteringDetails: shutteringDetails.toSorted(

--- a/src/server/services/service/maintenance/views/maintenance.njk
+++ b/src/server/services/service/maintenance/views/maintenance.njk
@@ -19,6 +19,17 @@
   </p>
 {% endset %}
 
+{% set vanityUrlsInfoHtml %}
+  <p class="govuk-!-margin-bottom-1">
+    To shutter your service you need to first set up vanity urls. Have a look at our <a
+      href="/documentation/how-to/vanity-urls.md"
+      class="govuk-link app-link"
+      target="_blank" rel="noopener noreferrer">
+      Vanity URLs documentation
+    </a>
+  </p>
+{% endset %}
+
 {% set shutteredUrlsTableRows = [] %}
 {% for detail in shutteringDetails %}
   {% set status %}
@@ -153,7 +164,7 @@
           <article data-xhr="maintenance-{{ entity.name }}"
                    data-xhr-stop="{{ not shouldPoll }}">
 
-            {% if shutteredUrlsTableRows | length %}
+            {% if isFrontend or isPrototype %}
               <div class="govuk-grid-column-one-half-from-desktop-massive govuk-!-margin-bottom-6">
                 <div class="app-section--extra-wide">
                   <h2 class="govuk-heading-l govuk-!-margin-bottom-2" data-testid="shuttering">
@@ -182,37 +193,45 @@
                   {% endif %}
                 </div>
 
-                {% call appPanel({ testId: "shuttering-panel", isSlim: true }) %}
-                  {% if shutteringDetails | length %}
-                    {% set urlText = "URL" | pluralise(shutteringDetails | length) %}
+                {% if shutteredUrlsTableRows | length %}
 
-                    <section class="govuk-!-margin-bottom-6">
-                      <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-                        {{ "Service" if isFrontend else "API Gateway" }} {{ urlText }}</h2>
-                      <p class="govuk-!-margin-bottom-2">
-                        {% if isFrontend %}
-                          User-friendly custom {{ urlText }}
-                        {% else %}
-                          Publicly accessible {{ urlText }} for the service
-                        {% endif %}
-                      </p>
+                  {% call appPanel({ testId: "shuttering-panel", isSlim: true }) %}
+                    {% if shutteringDetails | length %}
+                      {% set urlText = "URL" | pluralise(shutteringDetails | length) %}
 
-                      {{ govukTable({
-                        classes: "app-table app-table--inverse govuk-!-margin-bottom-4",
-                        head: [
-                          { text: "Service URL" if isFrontend else "API Gateway URL" },
-                          { text: "Environment" },
-                          { text: "Status" },
-                          { text: "Action",
-                            classes: "app-!-text-align-right"
-                          }
-                        ],
-                        rows: shutteredUrlsTableRows
-                      }) }}
+                      <section class="govuk-!-margin-bottom-6">
+                        <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+                          {{ "Service" if isFrontend else "API Gateway" }} {{ urlText }}</h2>
+                        <p class="govuk-!-margin-bottom-2">
+                          {% if isFrontend %}
+                            User-friendly custom {{ urlText }}
+                          {% else %}
+                            Publicly accessible {{ urlText }} for the service
+                          {% endif %}
+                        </p>
 
-                    </section>
-                  {% endif %}
-                {% endcall %}
+                        {{ govukTable({
+                          classes: "app-table app-table--inverse govuk-!-margin-bottom-4",
+                          head: [
+                            { text: "Service URL" if isFrontend else "API Gateway URL" },
+                            { text: "Environment" },
+                            { text: "Status" },
+                            { text: "Action",
+                              classes: "app-!-text-align-right"
+                            }
+                          ],
+                          rows: shutteredUrlsTableRows
+                        }) }}
+
+                      </section>
+                    {% endif %}
+                  {% endcall %}
+
+                {% else %}
+
+                  {{ appInfo({ html: vanityUrlsInfoHtml }) }}
+
+                {% endif %}
               </div>
             {% endif %}
           </article>


### PR DESCRIPTION
For prototypes and frontends so tenants can customise shuttering before setting up vanity URLs

## Frontend without vanity URLS
<img width="1537" height="1747" alt="Screenshot 2025-12-18 at 12 57 23" src="https://github.com/user-attachments/assets/27ce1989-79b9-4967-9b2a-ffd7de012fa5" />


## Frontend with vanity URLS
<img width="1537" height="1747" alt="Screenshot 2025-12-18 at 12 57 53" src="https://github.com/user-attachments/assets/af26209f-ab2a-46e4-b447-aca1465ecf0d" />

