### PR TITLE
CORE-2144 uses dashboard name instead of custom

### DIFF
--- a/src/server/common/helpers/obtain-logs-and-metrics-urls.test.js
+++ b/src/server/common/helpers/obtain-logs-and-metrics-urls.test.js
@@ -1,0 +1,53 @@
+import { obtainLogsAndMetricsUrls } from './obtain-logs-and-metrics-urls.js'
+
+describe('#obtainLogsAndMetricsUrls', () => {
+  test('#custom metrics have their type replaced using the url data', () => {
+    const entity = {
+      name: 'foo-backend',
+      environments: {
+        dev: {
+          logs: [],
+          metrics: [
+            {
+              url: 'https://metrics.dev.cdp-int.defra.cloud/d/bevhbxy38eznkc/foo-backend-service',
+              type: 'service',
+              uid: 'bevhbxy38eznkc',
+              version: 1
+            },
+            {
+              url: 'https://metrics.dev.cdp-int.defra.cloud/d/apha-integration-bridge-oracledb/foo-backend-oracledb',
+              type: 'custom',
+              uid: 'apha-integration-bridge-oracledb',
+              version: 33
+            }
+          ]
+        }
+      }
+    }
+
+    const result = obtainLogsAndMetricsUrls(entity, ['dev'])
+    expect(result).toEqual({
+      logsDetails: [
+        {
+          environment: 'dev'
+        }
+      ],
+      metricsDetails: {
+        dev: [
+          {
+            url: 'https://metrics.dev.cdp-int.defra.cloud/d/bevhbxy38eznkc/foo-backend-service',
+            type: 'service',
+            uid: 'bevhbxy38eznkc',
+            version: 1
+          },
+          {
+            url: 'https://metrics.dev.cdp-int.defra.cloud/d/apha-integration-bridge-oracledb/foo-backend-oracledb',
+            type: 'oracledb',
+            uid: 'apha-integration-bridge-oracledb',
+            version: 33
+          }
+        ]
+      }
+    })
+  })
+})

--- a/src/server/services/service/about/about-handler.js
+++ b/src/server/services/service/about/about-handler.js
@@ -60,7 +60,7 @@ async function aboutHandler(request, h) {
   )
 
   const { logsDetails, metricsDetails } = obtainLogsAndMetricsUrls(
-    request.app.entity.environments,
+    request.app.entity,
     availableServiceEnvironments
   )
 


### PR DESCRIPTION
<img width="673" height="486" alt="image" src="https://github.com/user-attachments/assets/99894760-a806-4619-a0b5-320613300126" />

Extracts the custom dashboard name from the URL since they all follow a common naming convention. 