### PR TITLE
CORE-2185: Default admin users to All Services tab

### DIFF
--- a/src/config/nunjucks/context/build-navigation.js
+++ b/src/config/nunjucks/context/build-navigation.js
@@ -61,7 +61,7 @@ async function buildNavigation(request, userSession) {
     {
       text: 'Services',
       href: servicesPath,
-      current: request?.path?.includes(servicesPath),
+      current: request?.path?.includes('/services'),
       attributes: {
         'data-testid': 'nav-services'
       }

--- a/src/config/nunjucks/context/build-navigation.js
+++ b/src/config/nunjucks/context/build-navigation.js
@@ -10,7 +10,9 @@ async function buildNavigation(request, userSession) {
   }
 
   const documentationPath = request.routeLookup('documentation')
-  const servicesPath = request.routeLookup('services')
+  const servicesPath = userSession?.isAdmin
+    ? request.routeLookup('services/all')
+    : request.routeLookup('services')
   const testSuitesPath = request.routeLookup('test-suites')
   const runningServicesPath = request.routeLookup('running-services')
   const deployServicePath = request.routeLookup('deploy-service')

--- a/src/config/nunjucks/context/build-navigation.test.js
+++ b/src/config/nunjucks/context/build-navigation.test.js
@@ -7,85 +7,69 @@ const mockRequest = ({ path = '', auth = {} } = {}) => ({
   routeLookup: (value) => (value === 'home' ? '/' : `/${value}`)
 })
 
+const buildPrimaryNav = ({ servicesHref = '/services', path = '' } = {}) => [
+  {
+    current: path === '/' || path.startsWith('/blog'),
+    text: 'Home',
+    href: '/',
+    attributes: { 'data-testid': 'nav-home' }
+  },
+  {
+    current: path.includes('/documentation'),
+    text: 'Documentation',
+    href: '/documentation',
+    attributes: { 'data-testid': 'nav-documentation' }
+  },
+  {
+    current: path.includes(servicesHref),
+    text: 'Services',
+    href: servicesHref,
+    attributes: { 'data-testid': 'nav-services' }
+  },
+  {
+    current: path.includes('/test-suites'),
+    text: 'Test Suites',
+    href: '/test-suites',
+    attributes: { 'data-testid': 'nav-test-suites' }
+  },
+  {
+    current: path.includes('/utilities'),
+    text: 'Utilities',
+    href: '/utilities/templates',
+    attributes: { 'data-testid': 'nav-utilities' }
+  },
+  {
+    current: path.includes('/teams') && !path.includes('admin'),
+    text: 'Teams',
+    href: '/teams',
+    attributes: { 'data-testid': 'nav-teams' }
+  },
+  {
+    current: path.split('/').at(1) === 'deployments',
+    text: 'Deployments',
+    href: '/deployments',
+    attributes: { 'data-testid': 'nav-deployments' }
+  },
+  {
+    current: path.includes('/running-services'),
+    text: 'Running Services',
+    href: '/running-services',
+    attributes: { 'data-testid': 'nav-running-services' }
+  },
+  {
+    current: path.includes('/dependency-explorer'),
+    text: 'Dependency Explorer',
+    href: '/dependency-explorer',
+    attributes: { 'data-testid': 'nav-dependencies-explorer' }
+  }
+]
+
 describe('#buildNavigation', () => {
   describe('When user is not authenticated', () => {
     test('Should provide expected navigation details', async () => {
       expect(await buildNavigation(mockRequest())).toEqual({
         actions: undefined,
-        primary: [
-          {
-            current: false,
-            text: 'Home',
-            href: '/',
-            attributes: {
-              'data-testid': 'nav-home'
-            }
-          },
-          {
-            current: false,
-            text: 'Documentation',
-            href: '/documentation',
-            attributes: {
-              'data-testid': 'nav-documentation'
-            }
-          },
-          {
-            current: false,
-            text: 'Services',
-            href: '/services',
-            attributes: {
-              'data-testid': 'nav-services'
-            }
-          },
-          {
-            current: false,
-            text: 'Test Suites',
-            href: '/test-suites',
-            attributes: {
-              'data-testid': 'nav-test-suites'
-            }
-          },
-          {
-            current: false,
-            text: 'Utilities',
-            href: '/utilities/templates',
-            attributes: {
-              'data-testid': 'nav-utilities'
-            }
-          },
-          {
-            current: false,
-            text: 'Teams',
-            href: '/teams',
-            attributes: {
-              'data-testid': 'nav-teams'
-            }
-          },
-          {
-            current: false,
-            text: 'Deployments',
-            href: '/deployments',
-            attributes: {
-              'data-testid': 'nav-deployments'
-            }
-          },
-          {
-            current: false,
-            text: 'Running Services',
-            href: '/running-services',
-            attributes: {
-              'data-testid': 'nav-running-services'
-            }
-          },
-          {
-            attributes: {
-              'data-testid': 'nav-dependencies-explorer'
-            },
-            current: false,
-            href: '/dependency-explorer',
-            text: 'Dependency Explorer'
-          }
-        ],
+        primary: buildPrimaryNav(),
         admin: undefined
       })
     })
@@ -99,93 +83,39 @@ describe('#buildNavigation', () => {
             current: false,
             text: 'Deploy Service',
             href: '/deploy-service',
-            attributes: {
-              'data-testid': 'nav-deploy-service'
-            }
+            attributes: { 'data-testid': 'nav-deploy-service' }
           },
           {
             current: false,
             text: 'Create',
             href: '/create',
-            attributes: {
-              'data-testid': 'nav-create'
-            }
+            attributes: { 'data-testid': 'nav-create' }
           }
         ],
-        primary: [
+        primary: buildPrimaryNav(),
+        admin: undefined
+      })
+    })
+
+    test('Should provide expected navigation details when isAdmin is false', async () => {
+      expect(
+        await buildNavigation(mockRequest(), { isAdmin: false, isTenant: true })
+      ).toEqual({
+        actions: [
           {
             current: false,
-            text: 'Home',
-            href: '/',
-            attributes: {
-              'data-testid': 'nav-home'
-            }
+            text: 'Deploy Service',
+            href: '/deploy-service',
+            attributes: { 'data-testid': 'nav-deploy-service' }
           },
           {
             current: false,
-            text: 'Documentation',
-            href: '/documentation',
-            attributes: {
-              'data-testid': 'nav-documentation'
-            }
-          },
-          {
-            current: false,
-            text: 'Services',
-            href: '/services',
-            attributes: {
-              'data-testid': 'nav-services'
-            }
-          },
-          {
-            current: false,
-            text: 'Test Suites',
-            href: '/test-suites',
-            attributes: {
-              'data-testid': 'nav-test-suites'
-            }
-          },
-          {
-            current: false,
-            text: 'Utilities',
-            href: '/utilities/templates',
-            attributes: {
-              'data-testid': 'nav-utilities'
-            }
-          },
-          {
-            current: false,
-            text: 'Teams',
-            href: '/teams',
-            attributes: {
-              'data-testid': 'nav-teams'
-            }
-          },
-          {
-            current: false,
-            text: 'Deployments',
-            href: '/deployments',
-            attributes: {
-              'data-testid': 'nav-deployments'
-            }
-          },
-          {
-            current: false,
-            text: 'Running Services',
-            href: '/running-services',
-            attributes: {
-              'data-testid': 'nav-running-services'
-            }
-          },
-          {
-            attributes: {
-              'data-testid': 'nav-dependencies-explorer'
-            },
-            current: false,
-            href: '/dependency-explorer',
-            text: 'Dependency Explorer'
+            text: 'Create',
+            href: '/create',
+            attributes: { 'data-testid': 'nav-create' }
           }
         ],
+        primary: buildPrimaryNav(),
         admin: undefined
       })
     })
@@ -199,101 +129,22 @@ describe('#buildNavigation', () => {
             current: false,
             text: 'Deploy Service',
             href: '/deploy-service',
-            attributes: {
-              'data-testid': 'nav-deploy-service'
-            }
+            attributes: { 'data-testid': 'nav-deploy-service' }
           },
           {
             current: false,
             text: 'Create',
             href: '/create',
-            attributes: {
-              'data-testid': 'nav-create'
-            }
+            attributes: { 'data-testid': 'nav-create' }
           }
         ],
-        primary: [
-          {
-            current: false,
-            text: 'Home',
-            href: '/',
-            attributes: {
-              'data-testid': 'nav-home'
-            }
-          },
-          {
-            current: false,
-            text: 'Documentation',
-            href: '/documentation',
-            attributes: {
-              'data-testid': 'nav-documentation'
-            }
-          },
-          {
-            current: false,
-            text: 'Services',
-            href: '/services',
-            attributes: {
-              'data-testid': 'nav-services'
-            }
-          },
-          {
-            current: false,
-            text: 'Test Suites',
-            href: '/test-suites',
-            attributes: {
-              'data-testid': 'nav-test-suites'
-            }
-          },
-          {
-            current: false,
-            text: 'Utilities',
-            href: '/utilities/templates',
-            attributes: {
-              'data-testid': 'nav-utilities'
-            }
-          },
-          {
-            current: false,
-            text: 'Teams',
-            href: '/teams',
-            attributes: {
-              'data-testid': 'nav-teams'
-            }
-          },
-          {
-            current: false,
-            text: 'Deployments',
-            href: '/deployments',
-            attributes: {
-              'data-testid': 'nav-deployments'
-            }
-          },
-          {
-            current: false,
-            text: 'Running Services',
-            href: '/running-services',
-            attributes: {
-              'data-testid': 'nav-running-services'
-            }
-          },
-          {
-            attributes: {
-              'data-testid': 'nav-dependencies-explorer'
-            },
-            current: false,
-            href: '/dependency-explorer',
-            text: 'Dependency Explorer'
-          }
-        ],
+        primary: buildPrimaryNav({ servicesHref: '/services/all' }),
         admin: [
           {
             current: false,
             text: 'Admin',
             href: '/admin',
-            attributes: {
-              'data-testid': 'nav-admin'
-            }
+            attributes: { 'data-testid': 'nav-admin' }
           }
         ]
       })
@@ -312,101 +163,22 @@ describe('#buildNavigation', () => {
               current: false,
               text: 'Apply Changelog',
               href: '/apply-changelog',
-              attributes: {
-                'data-testid': 'nav-apply-changelog'
-              }
+              attributes: { 'data-testid': 'nav-apply-changelog' }
             },
             {
               current: false,
               text: 'Deploy Service',
               href: '/deploy-service',
-              attributes: {
-                'data-testid': 'nav-deploy-service'
-              }
+              attributes: { 'data-testid': 'nav-deploy-service' }
             },
             {
               current: false,
               text: 'Create',
               href: '/create',
-              attributes: {
-                'data-testid': 'nav-create'
-              }
+              attributes: { 'data-testid': 'nav-create' }
             }
           ],
-          primary: [
-            {
-              current: false,
-              text: 'Home',
-              href: '/',
-              attributes: {
-                'data-testid': 'nav-home'
-              }
-            },
-            {
-              current: false,
-              text: 'Documentation',
-              href: '/documentation',
-              attributes: {
-                'data-testid': 'nav-documentation'
-              }
-            },
-            {
-              current: false,
-              text: 'Services',
-              href: '/services',
-              attributes: {
-                'data-testid': 'nav-services'
-              }
-            },
-            {
-              current: false,
-              text: 'Test Suites',
-              href: '/test-suites',
-              attributes: {
-                'data-testid': 'nav-test-suites'
-              }
-            },
-            {
-              current: false,
-              text: 'Utilities',
-              href: '/utilities/templates',
-              attributes: {
-                'data-testid': 'nav-utilities'
-              }
-            },
-            {
-              current: false,
-              text: 'Teams',
-              href: '/teams',
-              attributes: {
-                'data-testid': 'nav-teams'
-              }
-            },
-            {
-              current: false,
-              text: 'Deployments',
-              href: '/deployments',
-              attributes: {
-                'data-testid': 'nav-deployments'
-              }
-            },
-            {
-              current: false,
-              text: 'Running Services',
-              href: '/running-services',
-              attributes: {
-                'data-testid': 'nav-running-services'
-              }
-            },
-            {
-              attributes: {
-                'data-testid': 'nav-dependencies-explorer'
-              },
-              current: false,
-              href: '/dependency-explorer',
-              text: 'Dependency Explorer'
-            }
-          ]
+          primary: buildPrimaryNav()
         })
       })
     })
@@ -424,100 +196,21 @@ describe('#buildNavigation', () => {
               current: false,
               text: 'Deploy Service',
               href: '/deploy-service',
-              attributes: {
-                'data-testid': 'nav-deploy-service'
-              }
+              attributes: { 'data-testid': 'nav-deploy-service' }
             },
             {
               current: false,
               text: 'Create',
               href: '/create',
-              attributes: {
-                'data-testid': 'nav-create'
-              }
+              attributes: { 'data-testid': 'nav-create' }
             }
           ],
-          primary: [
-            {
-              current: false,
-              text: 'Home',
-              href: '/',
-              attributes: {
-                'data-testid': 'nav-home'
-              }
-            },
-            {
-              current: false,
-              text: 'Documentation',
-              href: '/documentation',
-              attributes: {
-                'data-testid': 'nav-documentation'
-              }
-            },
-            {
-              current: false,
-              text: 'Services',
-              href: '/services',
-              attributes: {
-                'data-testid': 'nav-services'
-              }
-            },
-            {
-              current: false,
-              text: 'Test Suites',
-              href: '/test-suites',
-              attributes: {
-                'data-testid': 'nav-test-suites'
-              }
-            },
-            {
-              current: false,
-              text: 'Utilities',
-              href: '/utilities/templates',
-              attributes: {
-                'data-testid': 'nav-utilities'
-              }
-            },
-            {
-              current: false,
-              text: 'Teams',
-              href: '/teams',
-              attributes: {
-                'data-testid': 'nav-teams'
-              }
-            },
-            {
-              current: false,
-              text: 'Deployments',
-              href: '/deployments',
-              attributes: {
-                'data-testid': 'nav-deployments'
-              }
-            },
-            {
-              current: false,
-              text: 'Running Services',
-              href: '/running-services',
-              attributes: {
-                'data-testid': 'nav-running-services'
-              }
-            },
-            {
-              attributes: {
-                'data-testid': 'nav-dependencies-explorer'
-              },
-              current: false,
-              href: '/dependency-explorer',
-              text: 'Dependency Explorer'
-            }
-          ],
+          primary: buildPrimaryNav(),
           admin: [
             {
               text: 'Exit Test as Tenant Mode',
               href: '/admin/removeTestAsTenant',
-              attributes: {
-                'data-testid': 'nav-admin'
-              }
+              attributes: { 'data-testid': 'nav-admin' }
             }
           ]
         })
@@ -530,80 +223,7 @@ describe('#buildNavigation', () => {
       await buildNavigation(mockRequest({ path: '/running-services' }))
     ).toEqual({
       actions: undefined,
-      primary: [
-        {
-          current: false,
-          text: 'Home',
-          href: '/',
-          attributes: {
-            'data-testid': 'nav-home'
-          }
-        },
-        {
-          current: false,
-          text: 'Documentation',
-          href: '/documentation',
-          attributes: {
-            'data-testid': 'nav-documentation'
-          }
-        },
-        {
-          current: false,
-          text: 'Services',
-          href: '/services',
-          attributes: {
-            'data-testid': 'nav-services'
-          }
-        },
-        {
-          current: false,
-          text: 'Test Suites',
-          href: '/test-suites',
-          attributes: {
-            'data-testid': 'nav-test-suites'
-          }
-        },
-        {
-          current: false,
-          text: 'Utilities',
-          href: '/utilities/templates',
-          attributes: {
-            'data-testid': 'nav-utilities'
-          }
-        },
-        {
-          current: false,
-          text: 'Teams',
-          href: '/teams',
-          attributes: {
-            'data-testid': 'nav-teams'
-          }
-        },
-        {
-          current: false,
-          text: 'Deployments',
-          href: '/deployments',
-          attributes: {
-            'data-testid': 'nav-deployments'
-          }
-        },
-        {
-          current: true,
-          text: 'Running Services',
-          href: '/running-services',
-          attributes: {
-            'data-testid': 'nav-running-services'
-          }
-        },
-        {
-          attributes: {
-            'data-testid': 'nav-dependencies-explorer'
-          },
-          current: false,
-          href: '/dependency-explorer',
-          text: 'Dependency Explorer'
-        }
-      ],
+      primary: buildPrimaryNav({ path: '/running-services' }),
       admin: undefined
     })
   })

--- a/src/server/admin/audit/__file_snapshots__/Audit-page---list-view---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/admin/audit/__file_snapshots__/Audit-page---list-view---page-renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/admin/decommissions/__file_snapshots__/Decommissions-pages---confirm-decommission-view---page-renders-regular-view-for-logged-in-admin-user-2.html
+++ b/src/server/admin/decommissions/__file_snapshots__/Decommissions-pages---confirm-decommission-view---page-renders-regular-view-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/admin/decommissions/__file_snapshots__/Decommissions-pages---confirm-decommission-view---unavailable-view-renders-for-logged-in-admin-user--2.html
+++ b/src/server/admin/decommissions/__file_snapshots__/Decommissions-pages---confirm-decommission-view---unavailable-view-renders-for-logged-in-admin-user--2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/admin/decommissions/__file_snapshots__/Decommissions-pages---list-view---page-renders-for-logged-in-admin-user-with-feature-toggle-active-a-2.html
+++ b/src/server/admin/decommissions/__file_snapshots__/Decommissions-pages---list-view---page-renders-for-logged-in-admin-user-with-feature-toggle-active-a-2.html
@@ -109,7 +109,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/admin/decommissions/__file_snapshots__/Decommissions-pages---list-view---page-renders-for-logged-in-admin-user-without-feature-toggle-2.html
+++ b/src/server/admin/decommissions/__file_snapshots__/Decommissions-pages---list-view---page-renders-for-logged-in-admin-user-without-feature-toggle-2.html
@@ -109,7 +109,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/admin/decommissions/__file_snapshots__/Decommissions-pages---start-decommission-view---page-renders-regular-view-for-logged-in-admin-user-w-2.html
+++ b/src/server/admin/decommissions/__file_snapshots__/Decommissions-pages---start-decommission-view---page-renders-regular-view-for-logged-in-admin-user-w-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/admin/decommissions/__file_snapshots__/Decommissions-pages---start-decommission-view---unavailable-view-renders-for-logged-in-admin-user-wi-2.html
+++ b/src/server/admin/decommissions/__file_snapshots__/Decommissions-pages---start-decommission-view---unavailable-view-renders-for-logged-in-admin-user-wi-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/admin/features/__file_snapshots__/Feature-Toggles-page---list-view---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/admin/features/__file_snapshots__/Feature-Toggles-page---list-view---page-renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/auth/controller.js
+++ b/src/server/auth/controller.js
@@ -5,6 +5,7 @@ import Boom from '@hapi/boom'
 import { createUserSession } from '../common/helpers/auth/user-session.js'
 import { sessionNames } from '../common/constants/session-names.js'
 import { redirectWithRefresh } from '../common/helpers/url/url-helpers.js'
+import { fetchScopes } from '../teams/helpers/fetch/fetch-scopes.js'
 
 const authCallbackController = {
   options: {
@@ -15,11 +16,13 @@ const authCallbackController = {
   },
   handler: async (request, h) => {
     const { auth, sessionCookie, audit, yar, logger } = request
+    let userSession
+
     if (auth.isAuthenticated) {
       const sessionId = randomUUID()
 
       logger.info('Creating user session')
-      const userSession = await createUserSession(request, sessionId)
+      userSession = await createUserSession(request, sessionId)
 
       sessionCookie.set({ sessionId })
       const loginMsg = `User logged in UserId: ${userSession.id} displayName: ${userSession.displayName}`
@@ -31,7 +34,15 @@ const authCallbackController = {
       })
     }
 
-    const redirect = yar.flash(sessionNames.referrer)?.at(0) ?? '/'
+    let redirect = yar.flash(sessionNames.referrer)?.at(0) ?? '/'
+
+    if (userSession && redirect === '/services') {
+      const { scopeFlags } = await fetchScopes(userSession.token)
+      if (scopeFlags?.isAdmin) {
+        redirect = '/services/all'
+      }
+    }
+
     logger.info(`Login complete, redirecting user to ${redirect}`)
     return redirectWithRefresh(h, redirect)
   }

--- a/src/server/deployments/views/__file_snapshots__/Database-update-page---renders-for-logged-in-admin-user-2.html
+++ b/src/server/deployments/views/__file_snapshots__/Database-update-page---renders-for-logged-in-admin-user-2.html
@@ -109,7 +109,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/deployments/views/__file_snapshots__/Deployments-list-page---renders-for-logged-in-admin-user-2.html
+++ b/src/server/deployments/views/__file_snapshots__/Deployments-list-page---renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/deployments/views/__file_snapshots__/Microservice-deployment-page---renders-for-logged-in-admin-user-2.html
+++ b/src/server/deployments/views/__file_snapshots__/Microservice-deployment-page---renders-for-logged-in-admin-user-2.html
@@ -109,7 +109,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/home/__file_snapshots__/Blog-page---logged-in---admin-user-2.html
+++ b/src/server/home/__file_snapshots__/Blog-page---logged-in---admin-user-2.html
@@ -112,7 +112,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/home/__file_snapshots__/Home-page---logged-in---admin-user-2.html
+++ b/src/server/home/__file_snapshots__/Home-page---logged-in---admin-user-2.html
@@ -112,7 +112,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/repositories/__file_snapshots__/Repository-Status-page---Created-status---logged-in-admin-user-2.html
+++ b/src/server/repositories/__file_snapshots__/Repository-Status-page---Created-status---logged-in-admin-user-2.html
@@ -109,7 +109,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/repositories/__file_snapshots__/Repository-Status-page---Creating-status---logged-in-admin-user-2.html
+++ b/src/server/repositories/__file_snapshots__/Repository-Status-page---Creating-status---logged-in-admin-user-2.html
@@ -109,7 +109,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/routes/dependency-explorer/services/{entity}/{version~}/__file_snapshots__/Dependency-explorer,-service-dependencies-page---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/routes/dependency-explorer/services/{entity}/{version~}/__file_snapshots__/Dependency-explorer,-service-dependencies-page---page-renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                  <a class="govuk-service-navigation__link" href="/services" aria-current="page" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" aria-current="page" data-testid="nav-services">
                                     
                   <strong class="govuk-service-navigation__active-fallback">Services</strong>
 

--- a/src/server/routes/dependency-explorer/{dependency~}/__file_snapshots__/Dependency-explorer-page---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/routes/dependency-explorer/{dependency~}/__file_snapshots__/Dependency-explorer-page---page-renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/routes/services/{serviceId}/topology/{environment}/__file_snapshots__/Topology-page---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/routes/services/{serviceId}/topology/{environment}/__file_snapshots__/Topology-page---page-renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                  <a class="govuk-service-navigation__link" href="/services" aria-current="page" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" aria-current="page" data-testid="nav-services">
                                     
                   <strong class="govuk-service-navigation__active-fallback">Services</strong>
 

--- a/src/server/services/service/about/__file_snapshots__/About-postgres-service-page---logged-in-admin-user-restrictedTechPostgres-permission-2.html
+++ b/src/server/services/service/about/__file_snapshots__/About-postgres-service-page---logged-in-admin-user-restrictedTechPostgres-permission-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                  <a class="govuk-service-navigation__link" href="/services" aria-current="page" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" aria-current="page" data-testid="nav-services">
                                     
                   <strong class="govuk-service-navigation__active-fallback">Services</strong>
 

--- a/src/server/services/service/about/__file_snapshots__/About-prototype-service-page---logged-in-admin-user-restrictedTechPostgres-permission-2.html
+++ b/src/server/services/service/about/__file_snapshots__/About-prototype-service-page---logged-in-admin-user-restrictedTechPostgres-permission-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                  <a class="govuk-service-navigation__link" href="/services" aria-current="page" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" aria-current="page" data-testid="nav-services">
                                     
                   <strong class="govuk-service-navigation__active-fallback">Services</strong>
 

--- a/src/server/services/service/about/__file_snapshots__/Services---About-service-page---logged-in-admin-user-2.html
+++ b/src/server/services/service/about/__file_snapshots__/Services---About-service-page---logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                  <a class="govuk-service-navigation__link" href="/services" aria-current="page" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" aria-current="page" data-testid="nav-services">
                                     
                   <strong class="govuk-service-navigation__active-fallback">Services</strong>
 

--- a/src/server/services/service/automations/__file_snapshots__/Service-Automations-page---Frontend-service---deployments-view---page-renders-for-logged-in-admin-us-2.html
+++ b/src/server/services/service/automations/__file_snapshots__/Service-Automations-page---Frontend-service---deployments-view---page-renders-for-logged-in-admin-us-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                  <a class="govuk-service-navigation__link" href="/services" aria-current="page" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" aria-current="page" data-testid="nav-services">
                                     
                   <strong class="govuk-service-navigation__active-fallback">Services</strong>
 

--- a/src/server/services/service/automations/__file_snapshots__/Service-Automations-page---Frontend-service---test-runs-view---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/services/service/automations/__file_snapshots__/Service-Automations-page---Frontend-service---test-runs-view---page-renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                  <a class="govuk-service-navigation__link" href="/services" aria-current="page" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" aria-current="page" data-testid="nav-services">
                                     
                   <strong class="govuk-service-navigation__active-fallback">Services</strong>
 

--- a/src/server/services/service/automations/__file_snapshots__/Service-Automations-page---Prototype---deployments-view---page-renders-for-logged-in-admin-user-with-2.html
+++ b/src/server/services/service/automations/__file_snapshots__/Service-Automations-page---Prototype---deployments-view---page-renders-for-logged-in-admin-user-with-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                  <a class="govuk-service-navigation__link" href="/services" aria-current="page" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" aria-current="page" data-testid="nav-services">
                                     
                   <strong class="govuk-service-navigation__active-fallback">Services</strong>
 

--- a/src/server/services/service/maintenance/__file_snapshots__/Services---Maintenance-service-page---logged-in-admin-user-2.html
+++ b/src/server/services/service/maintenance/__file_snapshots__/Services---Maintenance-service-page---logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                  <a class="govuk-service-navigation__link" href="/services" aria-current="page" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" aria-current="page" data-testid="nav-services">
                                     
                   <strong class="govuk-service-navigation__active-fallback">Services</strong>
 

--- a/src/server/services/service/proxy/__file_snapshots__/Service-Proxy-page---all-envs-view---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/services/service/proxy/__file_snapshots__/Service-Proxy-page---all-envs-view---page-renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                  <a class="govuk-service-navigation__link" href="/services" aria-current="page" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" aria-current="page" data-testid="nav-services">
                                     
                   <strong class="govuk-service-navigation__active-fallback">Services</strong>
 

--- a/src/server/services/service/proxy/__file_snapshots__/Service-Proxy-page---single-envs-view---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/services/service/proxy/__file_snapshots__/Service-Proxy-page---single-envs-view---page-renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                  <a class="govuk-service-navigation__link" href="/services" aria-current="page" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" aria-current="page" data-testid="nav-services">
                                     
                   <strong class="govuk-service-navigation__active-fallback">Services</strong>
 

--- a/src/server/services/service/resources/__file_snapshots__/Service-resources-page---all-resources-view---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/services/service/resources/__file_snapshots__/Service-resources-page---all-resources-view---page-renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                  <a class="govuk-service-navigation__link" href="/services" aria-current="page" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" aria-current="page" data-testid="nav-services">
                                     
                   <strong class="govuk-service-navigation__active-fallback">Services</strong>
 

--- a/src/server/services/service/resources/__file_snapshots__/Service-resources-page---single-resources-env-view---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/services/service/resources/__file_snapshots__/Service-resources-page---single-resources-env-view---page-renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                  <a class="govuk-service-navigation__link" href="/services" aria-current="page" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" aria-current="page" data-testid="nav-services">
                                     
                   <strong class="govuk-service-navigation__active-fallback">Services</strong>
 

--- a/src/server/services/service/secrets/__file_snapshots__/Service-Secrets-page---all-envs-view---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/services/service/secrets/__file_snapshots__/Service-Secrets-page---all-envs-view---page-renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                  <a class="govuk-service-navigation__link" href="/services" aria-current="page" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" aria-current="page" data-testid="nav-services">
                                     
                   <strong class="govuk-service-navigation__active-fallback">Services</strong>
 

--- a/src/server/services/service/secrets/__file_snapshots__/Service-Secrets-page---single-envs-view---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/services/service/secrets/__file_snapshots__/Service-Secrets-page---single-envs-view---page-renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                  <a class="govuk-service-navigation__link" href="/services" aria-current="page" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" aria-current="page" data-testid="nav-services">
                                     
                   <strong class="govuk-service-navigation__active-fallback">Services</strong>
 

--- a/src/server/services/service/status/__file_snapshots__/Service-Status-page---Created-status---logged-in-admin-user-2.html
+++ b/src/server/services/service/status/__file_snapshots__/Service-Status-page---Created-status---logged-in-admin-user-2.html
@@ -109,7 +109,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                  <a class="govuk-service-navigation__link" href="/services" aria-current="page" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" aria-current="page" data-testid="nav-services">
                                     
                   <strong class="govuk-service-navigation__active-fallback">Services</strong>
 

--- a/src/server/services/service/status/__file_snapshots__/Service-Status-page---Creating-status---logged-in-admin-user-2.html
+++ b/src/server/services/service/status/__file_snapshots__/Service-Status-page---Creating-status---logged-in-admin-user-2.html
@@ -109,7 +109,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                  <a class="govuk-service-navigation__link" href="/services" aria-current="page" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" aria-current="page" data-testid="nav-services">
                                     
                   <strong class="govuk-service-navigation__active-fallback">Services</strong>
 

--- a/src/server/services/service/terminal/__file_snapshots__/Service-Terminal-page---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/services/service/terminal/__file_snapshots__/Service-Terminal-page---page-renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                  <a class="govuk-service-navigation__link" href="/services" aria-current="page" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" aria-current="page" data-testid="nav-services">
                                     
                   <strong class="govuk-service-navigation__active-fallback">Services</strong>
 

--- a/src/server/services/service/terminal/__file_snapshots__/Service-Terminal-page---page-renders-for-with-prod-terminal-button-for-admin-user-with-break-glass-2.html
+++ b/src/server/services/service/terminal/__file_snapshots__/Service-Terminal-page---page-renders-for-with-prod-terminal-button-for-admin-user-with-break-glass-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
-                  <a class="govuk-service-navigation__link" href="/services" aria-current="page" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" aria-current="page" data-testid="nav-services">
                                     
                   <strong class="govuk-service-navigation__active-fallback">Services</strong>
 

--- a/src/server/teams/__file_snapshots__/Teams-page---list-view---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/teams/__file_snapshots__/Teams-page---list-view---page-renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/teams/__file_snapshots__/Teams-page---team-view---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/teams/__file_snapshots__/Teams-page---team-view---page-renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/test-suites/test-suite/about/__file_snapshots__/About-Test-Suite-page---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/test-suites/test-suite/about/__file_snapshots__/About-Test-Suite-page---page-renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/test-suites/test-suite/automations/__file_snapshots__/Test-suite-automations-page---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/test-suites/test-suite/automations/__file_snapshots__/Test-suite-automations-page---page-renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/test-suites/test-suite/notifications/__file_snapshots__/Test-suite-notifications-page---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/test-suites/test-suite/notifications/__file_snapshots__/Test-suite-notifications-page---page-renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/test-suites/test-suite/proxy/__file_snapshots__/Proxy-Test-Suite-page---all-envs-view---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/test-suites/test-suite/proxy/__file_snapshots__/Proxy-Test-Suite-page---all-envs-view---page-renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/test-suites/test-suite/proxy/__file_snapshots__/Proxy-Test-Suite-page---single-envs-view---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/test-suites/test-suite/proxy/__file_snapshots__/Proxy-Test-Suite-page---single-envs-view---page-renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/test-suites/test-suite/secrets/__file_snapshots__/Secrets-Test-Suite-page---all-envs-view---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/test-suites/test-suite/secrets/__file_snapshots__/Secrets-Test-Suite-page---all-envs-view---page-renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/test-suites/test-suite/secrets/__file_snapshots__/Secrets-Test-Suite-page---single-envs-view---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/test-suites/test-suite/secrets/__file_snapshots__/Secrets-Test-Suite-page---single-envs-view---page-renders-for-logged-in-admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/test-suites/test-suite/status/__file_snapshots__/Test-Suite-Status-page---Created-status---logged-in-admin-user-2.html
+++ b/src/server/test-suites/test-suite/status/__file_snapshots__/Test-Suite-Status-page---Created-status---logged-in-admin-user-2.html
@@ -109,7 +109,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/test-suites/test-suite/status/__file_snapshots__/Test-Suite-Status-page---Creating-status---logged-in-admin-user-2.html
+++ b/src/server/test-suites/test-suite/status/__file_snapshots__/Test-Suite-Status-page---Creating-status---logged-in-admin-user-2.html
@@ -109,7 +109,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>

--- a/src/server/user-profile/__file_snapshots__/User-profile-page---logged-in---admin-user-2.html
+++ b/src/server/user-profile/__file_snapshots__/User-profile-page---logged-in---admin-user-2.html
@@ -111,7 +111,7 @@ Documentation
 
               
               <li class="govuk-service-navigation__item">
-                  <a class="govuk-service-navigation__link" href="/services" data-testid="nav-services">
+                  <a class="govuk-service-navigation__link" href="/services/all" data-testid="nav-services">
                                     
 Services
                   </a>


### PR DESCRIPTION
- Admin users were landing on My Services when navigating to /services. Updated buildNavigation to point the Services nav link to /services/all  for admin users
- Added redirect in auth callback for admins who log in while already  on /services