### PR TITLE
CORE-3150: Add last active col for users

### DIFF
--- a/src/__fixtures__/admin/cdp-user.js
+++ b/src/__fixtures__/admin/cdp-user.js
@@ -5,6 +5,7 @@ const cdpUserFixture = {
   github: 'BABaracus',
   createdAt: '2023-08-23T16:17:57.883Z',
   updatedAt: '2023-08-24T15:31:52.259Z',
+  lastActive: '2024-11-15T10:00:00.000Z',
   userId: '1398fa86-98a2-4ee8-84bb-2468cc71d0ec',
   teams: [
     {

--- a/src/server/admin/users/controllers/users-list.js
+++ b/src/server/admin/users/controllers/users-list.js
@@ -13,6 +13,7 @@ const usersListController = {
           { id: 'name', text: 'Name', width: '15' },
           { id: 'email', text: 'Email', width: '15' },
           { id: 'github-user', text: 'GitHub user', width: '15' },
+          { id: 'last-active', text: 'Last Active', width: '10' },
           { id: 'last-updated', text: 'Last Updated', width: '10' },
           { id: 'created', text: 'Created', width: '10' }
         ],

--- a/src/server/admin/users/transformers/transform-user-to-entity-row.js
+++ b/src/server/admin/users/transformers/transform-user-to-entity-row.js
@@ -1,4 +1,5 @@
 import { config } from '#config/config.js'
+import { dateFormatString } from '../../../common/constants/date.js'
 
 function transformUserToEntityRow(user) {
   const githubOrg = config.get('githubOrg')
@@ -31,12 +32,28 @@ function transformUserToEntityRow(user) {
         }
       },
       {
+        headers: 'last-active',
+        entity: {
+          kind: 'date',
+          value: user.lastActive,
+          formatString: dateFormatString
+        }
+      },
+      {
         headers: 'last-updated',
-        entity: { kind: 'date', value: user.updatedAt }
+        entity: {
+          kind: 'date',
+          value: user.updatedAt,
+          formatString: dateFormatString
+        }
       },
       {
         headers: 'created',
-        entity: { kind: 'date', value: user.createdAt }
+        entity: {
+          kind: 'date',
+          value: user.createdAt,
+          formatString: dateFormatString
+        }
       }
     ]
   }

--- a/src/server/admin/users/transformers/transform-user-to-entity-row.test.js
+++ b/src/server/admin/users/transformers/transform-user-to-entity-row.test.js
@@ -33,6 +33,15 @@ describe('#transformUserToEntityRow', () => {
         {
           entity: {
             kind: 'date',
+            formatString: 'EEEE do MMMM yyyy, HH:mm:ss',
+            value: '2024-11-15T10:00:00.000Z'
+          },
+          headers: 'last-active'
+        },
+        {
+          entity: {
+            kind: 'date',
+            formatString: 'EEEE do MMMM yyyy, HH:mm:ss',
             value: '2023-08-24T15:31:52.259Z'
           },
           headers: 'last-updated'
@@ -40,6 +49,7 @@ describe('#transformUserToEntityRow', () => {
         {
           entity: {
             kind: 'date',
+            formatString: 'EEEE do MMMM yyyy, HH:mm:ss',
             value: '2023-08-23T16:17:57.883Z'
           },
           headers: 'created'

--- a/src/server/admin/users/transformers/user-to-summary.js
+++ b/src/server/admin/users/transformers/user-to-summary.js
@@ -1,4 +1,5 @@
 import { renderComponent } from '../../../common/helpers/nunjucks/render-component.js'
+import { dateFormatString } from '../../../common/constants/date.js'
 import { noValue } from '../../../common/constants/no-value.js'
 import { buildLink } from '../../../common/helpers/view/build-link.js'
 
@@ -49,12 +50,29 @@ function transformUserToSummary(user, withActions = true) {
       },
       {
         key: { text: 'Last Updated' },
-        value: { html: renderComponent('time', { datetime: user.updatedAt }) }
+        value: {
+          html: renderComponent('time', {
+            datetime: user.updatedAt,
+            formatString: dateFormatString
+          })
+        }
+      },
+      {
+        key: { text: 'Last Active' },
+        value: {
+          html: renderComponent('time', {
+            datetime: user.lastActive,
+            formatString: dateFormatString
+          })
+        }
       },
       {
         key: { text: 'Created' },
         value: {
-          html: renderComponent('time', { datetime: user.createdAt })
+          html: renderComponent('time', {
+            datetime: user.createdAt,
+            formatString: dateFormatString
+          })
         }
       }
     ]

--- a/vite.config.js
+++ b/vite.config.js
@@ -36,5 +36,7 @@ export default defineConfig({
     lightningcss: { errorRecovery: true }
   },
   // Dev server
-  server: {}
+  server: {
+    allowedHosts: true
+  }
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -37,6 +37,6 @@ export default defineConfig({
   },
   // Dev server
   server: {
-    allowedHosts: true
+    allowedHosts: true // Allow local CDP proxy hostnames (e.g. cdp.127.0.0.1.sslip.io) through the Vite dev server
   }
 })


### PR DESCRIPTION
Adds new colun last active

Also, adds `allowedHosts: true` to the Vite dev server config to allow access via `cdp.127.0.0.1.sslip.io` during local development. Without this, Vite's DNS rebinding protection blocks requests for CSS/JS assets when using the journey tests compose stack hostname, resulting in the app loading with no styles.

<img width="1944" height="644" alt="image" src="https://github.com/user-attachments/assets/b2e4690b-d045-4f73-b791-3006591ff5c0" />
