### PR TITLE
CORE-2997: De-nesting macros in running services

### DIFF
--- a/src/server/common/components/running-service-entity/template.njk
+++ b/src/server/common/components/running-service-entity/template.njk
@@ -1,5 +1,3 @@
-{% from "time/macro.njk" import appTime %}
-{% from "tool-tip/macro.njk" import appToolTip %}
 {% from "icons/instance-success-icon/macro.njk" import appInstanceSuccessIcon %}
 {% from "icons/instance-pending-icon/macro.njk" import appInstancePendingIcon %}
 {% from "icons/instance-undeployed-icon/macro.njk" import appInstanceUndeployedIcon %}
@@ -9,7 +7,7 @@
     <span class="app-running-service-entity__label govuk-visually-hidden">Version:</span>
     {% set tooltipText = "failed" if params.unstable === true else params.status %}
 
-    {% call appToolTip({ text: tooltipText | title + " in " + params.environment | title }) %}
+    <span class="app-tool-tip" data-text="{{ tooltipText | title + " in " + params.environment | title }}">
       {% switch params.status %}
       {% case "running" %}
         {{ appInstanceSuccessIcon({ description: "Running", classes: "app-icon--tiny" }) }}
@@ -19,7 +17,7 @@
       {% case "undeployed" %}
         {{ appInstanceUndeployedIcon({ description: "Undeployed", classes: "app-icon--tiny" }) }}
       {% endswitch %}
-    {% endcall %}
+    </span>
 
     <a class="app-link govuk-!-margin-left-1"
        href="https://github.com/DEFRA/{{ params.service }}/releases/tag/{{ params.version }}"
@@ -35,10 +33,10 @@
       {{ "Undeployed" if params.status == "undeployed" else "Deployed" }}
     </a>
 
-    {{ appTime({
-      text: params.created | formatDistanceToNow,
-      datetime: params.created
-    }) }} ago
+    <span class="app-tool-tip" data-text="{{ params.created | formatDate }}">
+      <time datetime="{{ params.created }}" data-testid="app-time">
+        {{ params.created | formatDistanceToNow }}
+      </time>
+    </span> ago
   </div>
 </div>
-

--- a/src/server/running-services/common/components/running-service-row/template.njk
+++ b/src/server/running-services/common/components/running-service-row/template.njk
@@ -1,7 +1,4 @@
-{% from "time/macro.njk" import appTime %}
 {% from "icons/star-icon/macro.njk" import appStarIcon %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
-{% from "running-service-entity/macro.njk" import appRunningServiceEntity %}
 
 <tr class="{{ params.rowClasses }}" data-testid="app-entity-table-row-{{ params.loopIndex }}">
 
@@ -35,14 +32,13 @@
   {% for environment in params.allEnvironments %}
     <td headers="{{ environment }}" class="app-entity-table__cell app-entity-table__cell--slim"
         data-label="{{ environment | title }}">
-      {% set row = params.serviceEnvironments[environment] %}
+      {% set environmentRow = params.serviceEnvironments[environment] %}
 
-      {% if row %}
-        {{ appRunningServiceEntity(row) }}
+      {% if environmentRow %}
+        {{ environmentRow.html | safe }}
       {% else %}
         <div class="app-running-service-entity--empty"></div>
       {% endif %}
     </td>
   {% endfor %}
 </tr>
-

--- a/src/server/running-services/helpers/build-running-services-table-data.js
+++ b/src/server/running-services/helpers/build-running-services-table-data.js
@@ -8,6 +8,19 @@ import { runningServiceToEntityRow } from './transformers/running-service-to-ent
 import { sortByOwner } from '../../common/helpers/sort/sort-by-owner.js'
 import { fetchRunningServices } from './fetch/fetch-running-services.js'
 import { fetchServices } from '../../common/helpers/fetch/fetch-entities.js'
+import { renderRunningServiceEntity } from './render-running-service-entity.js'
+
+function addEnvironmentCellHtml(rows) {
+  return rows.map((row) => ({
+    ...row,
+    serviceEnvironments: Object.fromEntries(
+      Object.entries(row.serviceEnvironments).map(([environment, cell]) => [
+        environment,
+        { html: renderRunningServiceEntity(cell) }
+      ])
+    )
+  }))
+}
 
 function getFilters(runningServicesFilters) {
   const {
@@ -66,7 +79,9 @@ async function buildRunningServicesTableData(request) {
   })
 
   const ownerSorter = sortByOwner('serviceName')
-  const rows = services.toSorted(ownerSorter).map(runningServiceToEntityRow)
+  const rows = addEnvironmentCellHtml(
+    services.toSorted(ownerSorter).map(runningServiceToEntityRow)
+  )
 
   return {
     environments,

--- a/src/server/running-services/helpers/build-running-services-table-data.test.js
+++ b/src/server/running-services/helpers/build-running-services-table-data.test.js
@@ -10,6 +10,9 @@ import { scopes } from '@defra/cdp-validation-kit'
 vi.mock('./fetch/fetch-running-services-filters.js')
 vi.mock('./fetch/fetch-running-services.js')
 vi.mock('../../common/helpers/fetch/fetch-entities.js')
+vi.mock('./render-running-service-entity.js', () => ({
+  renderRunningServiceEntity: vi.fn(() => '<div>mock-cell-html</div>')
+}))
 
 describe('#buildRunningServicesTableData', () => {
   test('returns expected table data with valid inputs', async () => {
@@ -46,40 +49,7 @@ describe('#buildRunningServicesTableData', () => {
           isOwner: false,
           serviceEnvironments: {
             'infra-dev': {
-              cdpDeploymentId: '3c439dc3-014f-47ef-9433-57ef0a10d8aa',
-              configVersion: null,
-              cpu: '1024',
-              created: '2024-05-10T14:48:34.001Z',
-              deploymentTestRuns: [],
-              environment: 'infra-dev',
-              instanceCount: 1,
-              instances: {
-                'arn:aws:ecs:eu-west-2:506190012364:task/infra-dev-ecs-public/cb7de56df13e4c7fa3042b644a07b97e':
-                  {
-                    status: 'running',
-                    updated: '2024-05-10T14:49:42Z'
-                  }
-              },
-              lambdaId: 'ecs-svc/5038252746496072911',
-              lastDeploymentMessage: null,
-              lastDeploymentStatus: null,
-              memory: '2048',
-              secrets: {
-                createdDate: '',
-                keys: [],
-                lastChangedDate: ''
-              },
-              service: 'cdp-portal-frontend',
-              status: 'running',
-              statusClassname: 'item-detail--green',
-              taskDefinitionArn: null,
-              unstable: false,
-              updated: '2024-05-10T14:49:42Z',
-              user: {
-                displayName: 'RoboCop',
-                id: '01b99595-27b5-4ab0-9807-f104c09d2cd0'
-              },
-              version: '0.356.0'
+              html: '<div>mock-cell-html</div>'
             }
           },
           serviceName: 'cdp-portal-frontend',

--- a/src/server/running-services/helpers/render-running-service-entity.js
+++ b/src/server/running-services/helpers/render-running-service-entity.js
@@ -1,0 +1,12 @@
+import { nunjucksEnvironment } from '#config/nunjucks/index.js'
+
+const runningServiceEntityTemplate = nunjucksEnvironment.getTemplate(
+  'running-service-entity/template.njk',
+  true
+)
+
+function renderRunningServiceEntity(params) {
+  return runningServiceEntityTemplate.render({ params })
+}
+
+export { renderRunningServiceEntity }


### PR DESCRIPTION
**Problem**

/running-services had ~1.9s TTFB locally (600 services). ~98% of request time was Nunjucks rendering ~2000 env cells via macro inside the page template, with full page context in scope per cell.

**Fix**

Pre-render each env cell to HTML in JS with isolated context before h.view. Page template pastes strings instead of calling macros.
- render-running-service-entity.js - renders entity template from JS
- addEnvironmentCellHtml() - replaces raw cell data with { html: '...' } before page render
- Row template - {{ environmentRow.html | safe }} instead of appRunningServiceEntity macro
- Entity template - inlined appToolTip/appTime macros as plain HTML

Before fix:
<img width="2364" height="174" alt="image" src="https://github.com/user-attachments/assets/853d84a9-e5df-4779-80fa-ad0f3cbc56c0" />


After fix:
<img width="2364" height="174" alt="image" src="https://github.com/user-attachments/assets/733302df-3aaa-44a9-ae90-e42a199ca3f5" />
