### PR TITLE
CORE-3140: add missing px for maxWidth

### DIFF
--- a/src/client/javascripts/mermaid.js
+++ b/src/client/javascripts/mermaid.js
@@ -65,7 +65,7 @@ async function run() {
     })
 
     svg.setAttribute('viewBox', `0 0 ${width} ${height}`)
-    svg.style.maxWidth = width
+    svg.style.maxWidth = `${width}px`
   })
 
   document

--- a/src/server/routes/services/{serviceId}/topology/{environment}/page.njk
+++ b/src/server/routes/services/{serviceId}/topology/{environment}/page.njk
@@ -82,12 +82,6 @@
     </div>
   </section>
 
-
-  <script>
-    // TODO: Remove after testing
-    console.debug(JSON.stringify({{ topology | dump(2) | safe }}, null, 2));
-  </script>
-
 {% endblock %}
 
 {% block bodyEnd %}


### PR DESCRIPTION
The maxWidth property is a CSS length value and requires a unit string. getBoundingClientRect().width returns a plain number (e.g. 1200), so:

```
svg.style.maxWidth = width      // → invalid CSS, silently ignored
svg.style.maxWidth = `${width}px` // → valid: "1200px"
```