### PR TITLE
handles missing entities

### DIFF
--- a/src/server/services/service/automations/__file_snapshots__/Service-Automations-page---Frontend-service---test-runs-view---page-renders-for-logged-in-admin-user-2.html
+++ b/src/server/services/service/automations/__file_snapshots__/Service-Automations-page---Frontend-service---test-runs-view---page-renders-for-logged-in-admin-user-2.html
@@ -667,17 +667,7 @@ width="12%"        >
 
 
 
-      
-
-
-
-
-
-<strong class="govuk-tag app-tag govuk-tag--blue" data-testid="govuk-tag">
-  Journey
-</strong>
-
-
+      <strong class="govuk-tag app-tag govuk-tag--blue" data-testid="govuk-tag">Journey</strong>
 
 
 
@@ -855,17 +845,7 @@ width="12%"        >
 
 
 
-      
-
-
-
-
-
-<strong class="govuk-tag app-tag govuk-tag--blue" data-testid="govuk-tag">
-  Journey
-</strong>
-
-
+      <strong class="govuk-tag app-tag govuk-tag--blue" data-testid="govuk-tag">Journey</strong>
 
 
 
@@ -1043,17 +1023,7 @@ width="12%"        >
 
 
 
-      
-
-
-
-
-
-<strong class="govuk-tag app-tag govuk-tag--blue" data-testid="govuk-tag">
-  Journey
-</strong>
-
-
+      <strong class="govuk-tag app-tag govuk-tag--blue" data-testid="govuk-tag">Journey</strong>
 
 
 
@@ -1231,17 +1201,7 @@ width="12%"        >
 
 
 
-      
-
-
-
-
-
-<strong class="govuk-tag app-tag govuk-tag--blue" data-testid="govuk-tag">
-  Journey
-</strong>
-
-
+      <strong class="govuk-tag app-tag govuk-tag--blue" data-testid="govuk-tag">Journey</strong>
 
 
 
@@ -1411,7 +1371,7 @@ width="12%"        >
 <script data-testid="app-autocomplete-suggestions">
   window.cdp = window.cdp || {};
   window.cdp.suggestions = window.cdp.suggestions || {};
-  window.cdp.suggestions["testSuite"] = [{"text":" - - select - - ","disabled":true,"attributes":{"selected":true}},{"value":"some-other-test-repo","text":"some-other-test-repo","hint":"\n\n\n\n\n\n<strong class=\"govuk-tag app-tag govuk-tag--blue\" data-testid=\"govuk-tag\">\n  Journey\n</strong>\n\n\n"},{"value":"some-test-repo","text":"some-test-repo","hint":"\n\n\n\n\n\n<strong class=\"govuk-tag app-tag govuk-tag--blue\" data-testid=\"govuk-tag\">\n  Journey\n</strong>\n\n\n"}]
+  window.cdp.suggestions["testSuite"] = [{"text":" - - select - - ","disabled":true,"attributes":{"selected":true}},{"value":"some-other-test-repo","text":"some-other-test-repo","hint":"<strong class=\"govuk-tag app-tag govuk-tag--blue\" data-testid=\"govuk-tag\">Journey</strong>\n"},{"value":"some-test-repo","text":"some-test-repo","hint":"<strong class=\"govuk-tag app-tag govuk-tag--blue\" data-testid=\"govuk-tag\">Journey</strong>\n"}]
 </script>
 
 
@@ -1457,32 +1417,12 @@ selected="selected">
           </option>
           <option value="some-other-test-repo"
 >
-            some-other-test-repo - 
-
-
-
-
-
-&lt;strong class=&quot;govuk-tag app-tag govuk-tag--blue&quot; data-testid=&quot;govuk-tag&quot;&gt;
-  Journey
-&lt;/strong&gt;
-
-
+            some-other-test-repo - &lt;strong class=&quot;govuk-tag app-tag govuk-tag--blue&quot; data-testid=&quot;govuk-tag&quot;&gt;Journey&lt;/strong&gt;
 
           </option>
           <option value="some-test-repo"
 >
-            some-test-repo - 
-
-
-
-
-
-&lt;strong class=&quot;govuk-tag app-tag govuk-tag--blue&quot; data-testid=&quot;govuk-tag&quot;&gt;
-  Journey
-&lt;/strong&gt;
-
-
+            some-test-repo - &lt;strong class=&quot;govuk-tag app-tag govuk-tag--blue&quot; data-testid=&quot;govuk-tag&quot;&gt;Journey&lt;/strong&gt;
 
           </option>
         </select>

--- a/src/server/services/service/automations/__file_snapshots__/Service-Automations-page---Frontend-service---test-runs-view---page-renders-for-logged-in-service-ow-2.html
+++ b/src/server/services/service/automations/__file_snapshots__/Service-Automations-page---Frontend-service---test-runs-view---page-renders-for-logged-in-service-ow-2.html
@@ -642,17 +642,7 @@ width="12%"        >
 
 
 
-      
-
-
-
-
-
-<strong class="govuk-tag app-tag govuk-tag--blue" data-testid="govuk-tag">
-  Journey
-</strong>
-
-
+      <strong class="govuk-tag app-tag govuk-tag--blue" data-testid="govuk-tag">Journey</strong>
 
 
 
@@ -796,17 +786,7 @@ width="12%"        >
 
 
 
-      
-
-
-
-
-
-<strong class="govuk-tag app-tag govuk-tag--blue" data-testid="govuk-tag">
-  Journey
-</strong>
-
-
+      <strong class="govuk-tag app-tag govuk-tag--blue" data-testid="govuk-tag">Journey</strong>
 
 
 
@@ -950,17 +930,7 @@ width="12%"        >
 
 
 
-      
-
-
-
-
-
-<strong class="govuk-tag app-tag govuk-tag--blue" data-testid="govuk-tag">
-  Journey
-</strong>
-
-
+      <strong class="govuk-tag app-tag govuk-tag--blue" data-testid="govuk-tag">Journey</strong>
 
 
 
@@ -1104,17 +1074,7 @@ width="12%"        >
 
 
 
-      
-
-
-
-
-
-<strong class="govuk-tag app-tag govuk-tag--blue" data-testid="govuk-tag">
-  Journey
-</strong>
-
-
+      <strong class="govuk-tag app-tag govuk-tag--blue" data-testid="govuk-tag">Journey</strong>
 
 
 
@@ -1250,7 +1210,7 @@ width="12%"        >
 <script data-testid="app-autocomplete-suggestions">
   window.cdp = window.cdp || {};
   window.cdp.suggestions = window.cdp.suggestions || {};
-  window.cdp.suggestions["testSuite"] = [{"text":" - - select - - ","disabled":true,"attributes":{"selected":true}},{"value":"some-other-test-repo","text":"some-other-test-repo","hint":"\n\n\n\n\n\n<strong class=\"govuk-tag app-tag govuk-tag--blue\" data-testid=\"govuk-tag\">\n  Journey\n</strong>\n\n\n"},{"value":"some-test-repo","text":"some-test-repo","hint":"\n\n\n\n\n\n<strong class=\"govuk-tag app-tag govuk-tag--blue\" data-testid=\"govuk-tag\">\n  Journey\n</strong>\n\n\n"}]
+  window.cdp.suggestions["testSuite"] = [{"text":" - - select - - ","disabled":true,"attributes":{"selected":true}},{"value":"some-other-test-repo","text":"some-other-test-repo","hint":"<strong class=\"govuk-tag app-tag govuk-tag--blue\" data-testid=\"govuk-tag\">Journey</strong>\n"},{"value":"some-test-repo","text":"some-test-repo","hint":"<strong class=\"govuk-tag app-tag govuk-tag--blue\" data-testid=\"govuk-tag\">Journey</strong>\n"}]
 </script>
 
 
@@ -1296,32 +1256,12 @@ selected="selected">
           </option>
           <option value="some-other-test-repo"
 >
-            some-other-test-repo - 
-
-
-
-
-
-&lt;strong class=&quot;govuk-tag app-tag govuk-tag--blue&quot; data-testid=&quot;govuk-tag&quot;&gt;
-  Journey
-&lt;/strong&gt;
-
-
+            some-other-test-repo - &lt;strong class=&quot;govuk-tag app-tag govuk-tag--blue&quot; data-testid=&quot;govuk-tag&quot;&gt;Journey&lt;/strong&gt;
 
           </option>
           <option value="some-test-repo"
 >
-            some-test-repo - 
-
-
-
-
-
-&lt;strong class=&quot;govuk-tag app-tag govuk-tag--blue&quot; data-testid=&quot;govuk-tag&quot;&gt;
-  Journey
-&lt;/strong&gt;
-
-
+            some-test-repo - &lt;strong class=&quot;govuk-tag app-tag govuk-tag--blue&quot; data-testid=&quot;govuk-tag&quot;&gt;Journey&lt;/strong&gt;
 
           </option>
         </select>

--- a/src/server/services/service/automations/helpers/render-test-suite-tag-html.js
+++ b/src/server/services/service/automations/helpers/render-test-suite-tag-html.js
@@ -1,10 +1,9 @@
-import { renderTag } from '#server/common/helpers/view/render-tag.js'
 import { entitySubTypes } from '@defra/cdp-validation-kit'
 
 function renderTestSuiteTagHtml(testSuite) {
   let classes
 
-  switch (testSuite.subType) {
+  switch (testSuite?.subType) {
     case entitySubTypes.performance:
       classes = ['govuk-tag--green']
       break
@@ -12,13 +11,12 @@ function renderTestSuiteTagHtml(testSuite) {
       classes = ['govuk-tag--blue']
       break
     default:
-      classes = ['app-tag--purple']
+      classes = ['govuk-tag--grey']
   }
 
-  return renderTag({
-    text: testSuite.subType,
-    classes
-  })
+  const text = testSuite?.subType ?? 'Unknown'
+
+  return `<strong class="govuk-tag app-tag ${classes.join(' ')}" data-testid="govuk-tag">${text}</strong>\n`
 }
 
 export { renderTestSuiteTagHtml }

--- a/src/server/services/service/automations/helpers/render-test-suite-tag-html.test.js
+++ b/src/server/services/service/automations/helpers/render-test-suite-tag-html.test.js
@@ -1,0 +1,28 @@
+import { renderTestSuiteTagHtml } from '#server/services/service/automations/helpers/render-test-suite-tag-html.js'
+import { entitySubTypes } from '@defra/cdp-validation-kit'
+
+describe('Render test suite tag', () => {
+  test('Should use the correct tag based on subtype', () => {
+    const tagJourney = renderTestSuiteTagHtml({
+      subType: entitySubTypes.journey
+    })
+    const tagPerf = renderTestSuiteTagHtml({
+      subType: entitySubTypes.performance
+    })
+
+    expect(tagJourney.trim()).toEqual(
+      '<strong class="govuk-tag app-tag govuk-tag--blue" data-testid="govuk-tag">Journey</strong>'
+    )
+
+    expect(tagPerf.trim()).toEqual(
+      '<strong class="govuk-tag app-tag govuk-tag--green" data-testid="govuk-tag">Performance</strong>'
+    )
+  })
+
+  test('Should handle unknown entities', () => {
+    const unknownTag = renderTestSuiteTagHtml(null)
+    expect(unknownTag.trim()).toEqual(
+      '<strong class="govuk-tag app-tag govuk-tag--grey" data-testid="govuk-tag">Unknown</strong>'
+    )
+  })
+})


### PR DESCRIPTION
This should guard against null entities (either from decommissioned suites or from changes in ownership) and at least show the data as it exists.

Will look at removing decommissioned suites on the backend to keep the data clean as part of this ticket.

Also replaces the call to renderTag with some in-line html.